### PR TITLE
Add support for earlier version of PHP5

### DIFF
--- a/bootstrap-php5.php
+++ b/bootstrap-php5.php
@@ -1,0 +1,45 @@
+<?php
+
+require('slim/Slim.php');
+
+/* INIT SLIM */
+
+Slim::init();
+
+/* CALLBACKS */
+
+Slim::before('example_before');
+function example_before() {
+	Slim::response()->write('Before!');
+}
+
+Slim::after('example_after');
+function example_after() {
+	Slim::response()->write('After!');
+}
+
+/* ROUTES */
+
+Slim::get('/', 'get_example');
+function get_example() {
+	Slim::render('index.php');
+}
+
+Slim::post('/post', 'post_example');
+function post_example() {
+	echo '<br/><br/>Here are the details about your POST request:<br/><br/>';
+	print_r(Slim::request());
+}
+
+Slim::put('/put', 'put_example');
+function put_example() {
+	echo '<br/><br/>Here are the details about your PUT request:<br/><br/>';
+	print_r(Slim::request());
+}
+
+Slim::delete('/delete', 'delete_example');
+function delete_example() {
+	echo '<br/><br/>Here are the details about your DELETE request:<br/><br/>';
+	print_r(Slim::request());
+}
+?>

--- a/slim/Slim.php
+++ b/slim/Slim.php
@@ -101,7 +101,7 @@ class Slim {
 	 */
 	public static function init() {
 		self::$app = new Slim();
-		self::notFound(function(){ echo "We couldn't find what you are looking for. There's a slim chance you typed in the wrong URL."; });
+		self::notFound(array('Slim', 'defaultNotFound'));
 	}
 	
 	/**
@@ -343,6 +343,16 @@ class Slim {
 		self::response()->status($code);
 	}
 	
+	/**
+	 * Default NOT FOUND handler
+	 *
+	 * Default callback that will be called when a route cannot be
+	 * matched to the current HTTP request.
+	 */
+	public static function defaultNotFound() {
+		echo "We couldn't find what you are looking for. There's a slim chance you typed in the wrong URL.";
+	}
+	
 	/***** RUN SLIM *****/
 	
 	/**
@@ -368,7 +378,7 @@ class Slim {
 			//stop the application and send a 404 response.
 			ob_start();
 			$notFoundCallable = self::router()->notFound();
-			$notFoundCallable();
+			call_user_func($notFoundCallable);
 			$notFound = ob_get_clean();
 			self::error(404, $notFound);
 			


### PR DESCRIPTION
This just removes the one place where a closure is used in the main Slim class, and provides an example bootstrap-php5.php file. For those of us not yet using PHP5.3.
