### PR TITLE
PHP5 < 5.3 incompatibility

### DIFF
--- a/slim/Slim.php
+++ b/slim/Slim.php
@@ -222,7 +222,7 @@ class Slim {
 	private static function runCallables($callables) {
 		foreach( $callables as $callable ) {
 			if( is_callable($callable) ) {
-				$callable();
+				call_user_func($callable);
 			}
 		}
 	}


### PR DESCRIPTION
Found another place where `$functionName()` is used. Replaced with `call_user_func($functionName)`.
