### PR TITLE
Multiple Router pattern support

### DIFF
--- a/slim/Slim.php
+++ b/slim/Slim.php
@@ -91,31 +91,25 @@ class Slim {
 		$this->settings = array();
 	}
 	
-	/***** INITIALIZERS (Choose One) *****/
+	/***** INITIALIZER *****/
 	
 	/**
 	 * Initialize Slim
 	 *
 	 * This instantiates the actual Slim app and sets a default
 	 * 404 Not Found handler.
+	 *
+	 * Optionally can set a view class on initialisation
 	 */
-	public static function init() {
+	public static function init($viewClass = NULL) {
 		self::$app = new Slim();
 		self::notFound(array('Slim', 'defaultNotFound'));
+		
+		if ( !is_null($viewClass) ) {
+			self::view($viewClass);
+		}
 	}
-	
-	/**
-	 * Initialize Slim with View
-	 *
-	 * Along with initializing Slim (see above), this also sets the View
-	 * class used to render templates.
-	 *
-	 * @param string $viewClass The name of the view class Slim will use
-	 */
-	public static function initWithView($viewClass) {
-		self::init();
-		self::view($viewClass);
-	}
+
 	
 	/***** ROUTING *****/
 	


### PR DESCRIPTION
I was playing with slim and straight away wanted the same callable in use for two patterns. First I solved this with:
    function get_page($page = 'index')
    {
    }

```
Slim::get('/', 'get_page');
Slim::get('/:page', 'get_page');
```

Then I realised an array of patterns would be much more DRY:

```
Slim::get(array('/', '/:page'), function() {
});
```

But sometimes the arguments may be swapped about or completely different, so I added two methods to Router, Router::params() and Router::param(). This allows you to get hold of the params from within the callable, Router::param even lets you define a default.

Also I could not see the purpose in have two init functions, why not just have the view class definition as optional within the one init? So I have made that change also.

Great work so far though, seriously useful!!
Luke
