### PR TITLE
Added TwigView class.

### DIFF
--- a/slim/Request.php
+++ b/slim/Request.php
@@ -112,7 +112,7 @@ class Request {
 		}
 		$this->headers = $this->getHttpHeaders();
 		$this->cookies = $_COOKIE;
-		$this->isAjax = isset($request->headers['X_REQUESTED_WITH']) && $request->headers['X_REQUESTED_WITH'] == 'XMLHttpRequest';
+		$this->isAjax = isset($this->headers['X_REQUESTED_WITH']) && $this->headers['X_REQUESTED_WITH'] == 'XMLHttpRequest';
 		$this->checkForHttpMethodOverride();
 	}
 

--- a/slim/TwigView.php
+++ b/slim/TwigView.php
@@ -35,13 +35,17 @@
  *
  * The TwigView is a Custom View class that renders templates using the Twig 
  * template language (http://www.twig-project.org/).
+ *
+ * Two fields that you, the developer, will need to change are:
+ * - twigDirectory
+ * - twigOptions
  */
 class TwigView extends View {
 
     /**
-     * @var TwigEnvironment The Twig environment for rendering templates.
+     * @var array The path to the Twig code directory.
      */
-    private $twigEnvironment = null;
+    public  $twigDirectory = null;
 
     /**
      * @var array The options for the Twig environment, see 
@@ -50,10 +54,9 @@ class TwigView extends View {
     public  $twigOptions = array();
 
     /**
-     * @var array The location of the Twig code directory.
-     * Defaults to __DIR__/../lib/Twig/lib/Twig in TwigView::getTwigDirectory().
+     * @var TwigEnvironment The Twig environment for rendering templates.
      */
-    public  $twigDirectory = null;
+    private $twigEnvironment = null;
 
     public function render( $template ) {
         $env = $this->getEnvironment();
@@ -68,9 +71,7 @@ class TwigView extends View {
      */
     private function getEnvironment() {
         if( !$this->twigEnvironment ) {
-            $twigDirectory = $this->getTwigDirectory();
-
-            require_once $twigDirectory . '/Autoloader.php';
+            require_once $this->twigDirectory . '/Autoloader.php';
             Twig_Autoloader::register();
             $loader = new Twig_Loader_Filesystem($this->templatesDirectory());
 
@@ -80,18 +81,5 @@ class TwigView extends View {
             );
         }
         return $this->twigEnvironment;
-    }
-
-    /**
-     * Get the Twig directory, and set it to a reasonable default if it isn't 
-     * already set.
-     *
-     * @return string path to the Twig directory.
-     */
-    private function getTwigDirectory() {
-        if( !$this->twigDirectory ) {
-            $this->twigDirectory = dirname(__FILE__).'/../lib/Twig/lib/Twig';
-        }
-        return $this->twigDirectory;
     }
 }

--- a/slim/TwigView.php
+++ b/slim/TwigView.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Slim
+ *
+ * A simple PHP framework for PHP 5 or newer
+ *
+ * @author		Josh Lockhart <info@joshlockhart.com>
+ * @link		http://slim.joshlockhart.com
+ * @copyright	2010 Josh Lockhart
+ * 
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * TwigView
+ *
+ * The TwigView is a Custom View class that renders templates using the Twig 
+ * template language (http://www.twig-project.org/).
+ */
+class TwigView extends View {
+
+    /**
+     * @var TwigEnvironment The Twig environment for rendering templates.
+     */
+    private $twigEnvironment = null;
+
+    /**
+     * @var array The options for the Twig environment, see 
+     * http://www.twig-project.org/book/03-Twig-for-Developers
+     */
+    public  $twigOptions = array();
+
+    /**
+     * @var array The location of the Twig code directory.
+     * Defaults to __DIR__/../lib/Twig/lib/Twig in TwigView::getTwigDirectory().
+     */
+    public  $twigDirectory = null;
+
+    public function render( $template ) {
+        $env = $this->getEnvironment();
+        $template = $env->loadTemplate($template); 
+        echo $template->render($this->data);
+    }
+
+    /**
+     * Creates new TwigEnvironment if it doesn't already exist, and returns it.
+     *
+     * @return TwigEnvironment
+     */
+    private function getEnvironment() {
+        if( !$this->twigEnvironment ) {
+            $twigDirectory = $this->getTwigDirectory();
+
+            require_once $twigDirectory . '/Autoloader.php';
+            Twig_Autoloader::register();
+            $loader = new Twig_Loader_Filesystem($this->templatesDirectory());
+
+            $this->twigEnvironment = new Twig_Environment(
+                $loader, 
+                $this->twigOptions
+            );
+        }
+        return $this->twigEnvironment;
+    }
+
+    /**
+     * Get the Twig directory, and set it to a reasonable default if it isn't 
+     * already set.
+     *
+     * @return string path to the Twig directory.
+     */
+    private function getTwigDirectory() {
+        if( !$this->twigDirectory ) {
+            $this->twigDirectory = dirname(__FILE__).'/../lib/Twig/lib/Twig';
+        }
+        return $this->twigDirectory;
+    }
+}

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -99,6 +99,34 @@ class RequestTest extends PHPUnit_Framework_TestCase {
 		$this->assertEquals($r->root, '/');
 	}
 
+    /**
+     * Test isAjax is set to true, when HTTP_X_REQUESTED_WITH is set to
+     * 'XMLHttpRequest'.
+     *
+     * Pre-conditions:
+     * Case A: HTTP_X_REQUESTED_WITH is set to XMLHttpRequest.
+     * Case B: HTTP_X_REQUESTED_WITH is not set to XMLHttpRequest.
+     * Case C: HTTP_X_REQUESTED_WITH is not set.
+     * 
+     * Post-conditions:
+     * Case A: Request::isAjax should be true.
+     * Case B: Request::isAjax should be false.
+     * Case C: Request::isAjax should be false.
+     */
+    public function testIsAjaxSet(){
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest';
+        $r = new Request();
+        $this->assertTrue($r->isAjax);
+
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'foo';
+        $r = new Request();
+        $this->assertFalse($r->isAjax);
+
+        unset($_SERVER['HTTP_X_REQUESTED_WITH']);
+        $r = new Request();
+        $this->assertFalse($r->isAjax);
+    }
+
 }
 
 ?>

--- a/tests/TwigViewTest.php
+++ b/tests/TwigViewTest.php
@@ -30,27 +30,39 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+require_once '../slim/View.php';
+require_once '../slim/TwigView.php';
 require_once 'PHPUnit/Framework.php';
-require_once 'ViewTest.php';
-require_once 'TwigViewTest.php';
-require_once 'RouteTest.php';
-require_once 'RouterTest.php';
-require_once 'RequestTest.php';
-require_once 'SlimTest.php';
+ 
+class TwigViewTest extends PHPUnit_Framework_TestCase {
 
-class AllTests {
+	/***** SETUP *****/
 
-	public static function suite() {
-		$suite = new PHPUnit_Framework_TestSuite('SlimTestSuite');
-		$suite->addTestSuite('ViewTest');
-		$suite->addTestSuite('TwigViewTest');
-		$suite->addTestSuite('RouteTest');
-		$suite->addTestSuite('RouterTest');
-		$suite->addTestSuite('SlimTest');
-		$suite->addTestSuite('RequestTest');
-		return $suite;
+	public function setUp() {
+		$this->view = new TwigView();
 	}
 
+	/***** TESTS *****/
+
+    /**
+	 * Test Twig View class renders template using Twig
+	 *
+	 * Pre-conditions:
+	 * You instantiate a View object, sets its templates directory to
+	 * an existing directory. You pass data into the View, and render
+	 * an existing Twig template. No errors or exceptions are thrown.
+	 *
+	 * Post-conditions:
+	 * The contents of the output buffer match the rendered Twig template.
+	 */
+	public function testRendersTemplateWithData() {
+		$this->view->templatesDirectory(realpath('./templates'));
+		ob_start();
+		$this->view->data(array('foo' => 'bar'));
+		$this->view->render('test.twig');
+		$output = ob_get_clean();
+		$this->assertEquals($output, 'test twig output bar');
+	}
 }
 
 ?>

--- a/tests/TwigViewTest.php
+++ b/tests/TwigViewTest.php
@@ -58,6 +58,7 @@ class TwigViewTest extends PHPUnit_Framework_TestCase {
 	public function testRendersTemplateWithData() {
 		$this->view->templatesDirectory(realpath('./templates'));
 		ob_start();
+        $this->view->twigDirectory = dirname(__FILE__)."/../lib/Twig/lib/Twig/";
 		$this->view->data(array('foo' => 'bar'));
 		$this->view->render('test.twig');
 		$output = ob_get_clean();

--- a/tests/templates/test.twig
+++ b/tests/templates/test.twig
@@ -1,0 +1,1 @@
+test twig output {{ foo }}


### PR DESCRIPTION
Points for discussion:
1. Should `TwigView` live within the `slim` directory, or within a
   `slim/views` (or something) directory?
2. How should `CustomView`s handle options? Currently, two options
   (`twigDirectory` and `twigOptions`) simply exist as public vars
   that can be overridden. Was originally using `Slim::config` but
   dropped it, as it doesn't fit with the rest of the framework.
3. Should `TwigView::getTwigEnvironment()` be a singleton function, as
   it currently is? This means if someone renders a template, then
   wants to change the `twigOptions` and re-render, it won't take
   effect. I assume that's a fairly rare use-case, so haven't worried
   about it.
4. Should the Slim repository include the templating libraries it includes
   `CustomView`s for? I'm guessing not, so I haven't included it here.

Any feedback?
