### PR TITLE
Made smartyInstance getter as public

### DIFF
--- a/views/README.markdown
+++ b/views/README.markdown
@@ -30,3 +30,17 @@ The `MustacheView` custom View class provides support for the [Mustache template
 	?>
 
 Before you can use the MustacheView class, you will need to set `MustacheView::$mustacheDirectory`. This property should be the relative or absolute path to the directory containing the `Mustache.php` library.
+
+## SmartyView
+
+The `SmartyView` custom View class provides support for the [Smarty](http://www.smarty.net/) template library. You can use the SmartyView custom View in your Slim application like this:
+
+	<?php
+	require 'slim/Slim.php';
+	require 'views/SmartyView.php';
+	Slim::init('SmartyView');
+	//Insert your application routes here
+	Slim::run();
+	?>
+
+You will need to configure the `SmartyView::$smartyDirectory`, `SmartyView::$smartyCompileDirectory` and `SmartyView::$smartyCacheDirectory` class variables before using the SmartyView class in your application. These variables can be found at the top of the `views/SmartyView.php` class definition.

--- a/views/README.markdown
+++ b/views/README.markdown
@@ -43,4 +43,4 @@ The `SmartyView` custom View class provides support for the [Smarty](http://www.
 	Slim::run();
 	?>
 
-You will need to configure the `SmartyView::$smartyDirectory`, `SmartyView::$smartyCompileDirectory` and `SmartyView::$smartyCacheDirectory` class variables before using the SmartyView class in your application. These variables can be found at the top of the `views/SmartyView.php` class definition.
+You will need to configure the `SmartyView::$smartyDirectory`,  `SmartyView::$smartyCompileDirectory` , `SmartyView::$smartyCacheDirectory` and optionally `SmartyView::$smartyTemplatesDirectory`, class variables before using the SmartyView class in your application. These variables can be found at the top of the `views/SmartyView.php` class definition.

--- a/views/SmartyView.php
+++ b/views/SmartyView.php
@@ -38,6 +38,7 @@
  *
  * Two fields that you, the developer, will need to change are:
  * - smartyDirectory
+ * - smartyTemplatesDirectory
  * - smartyCompileDirectory
  * - smartyCacheDirectory
  *
@@ -61,19 +62,25 @@ class SmartyView extends View {
      */
     public static $smartyCacheDirectory = null;
 
-	/**
-     * @var instance of the Smarty object
+    /**
+     * @var string The path to the templates folder WITHOUT the trailing slash
      */
-	private $smartyInstance =	null;
+    public static $smartyTemplatesDirectory = 'templates';
 
-	/**
-	 * Render Smarty Template
-	 *
-	 * This method will output the rendered template content
-	 *
-	 * @param 	string $template The path to the Smarty template, relative to the  templates directory.
-	 * @return 	void
-	 */
+    /**
+     * @var persistent instance of the Smarty object
+     */
+    public static $smartyInstance =	null;
+
+    /**
+    * Render Smarty Template
+    *
+    * This method will output the rendered template content
+    *
+    * @param 	string $template The path to the Smarty template, relative to the  templates directory.
+    * @return 	void
+    */
+
     public function render( $template ) {
         $instance = $this->getInstance();
         $instance->assign($this->data);
@@ -85,25 +92,31 @@ class SmartyView extends View {
      *
      * @return Smarty Instance
      */
-    private function getInstance() {
-        if ( !$this->smartyInstance ) {
+    public function getInstance() {
+
+        if ( !( self::$smartyInstance instanceof Smarty) ) {
+            
+            if ( !is_dir(self::$smartyDirectory) ) {
+		throw new RuntimeException('Cannot set the Smarty lib directory : ' . self::$smartyDirectory . '. Directory does not exist.');
+            }
+
             require_once self::$smartyDirectory . '/Smarty.class.php';
+            self::$smartyInstance = new Smarty();
 
-			$this->smartyInstance = new Smarty();
-
-			$this->smartyInstance->template_dir = $this->templatesDirectory();
+            self::$smartyInstance->template_dir = is_null(self::$smartyTemplatesDirectory) ?
+                                $this->templatesDirectory() : self::$smartyTemplatesDirectory;
 			
-			if ( self::$smartyCompileDirectory ) {
-				$this->smartyInstance->compile_dir  = self::$smartyCompileDirectory;
-			}
+            if ( self::$smartyCompileDirectory ) {
+		self::$smartyInstance->compile_dir  = self::$smartyCompileDirectory;
+            }
 			
-			if ( self::$smartyCompileDirectory ) {
-				$this->smartyInstance->cache_dir  = self::$smartyCacheDirectory;
-			}
+            if ( self::$smartyCompileDirectory ) {
+		self::$smartyInstance->cache_dir  = self::$smartyCacheDirectory;
+            }
 			
         }
 
-        return $this->smartyInstance;
+        return self::$smartyInstance;
     }
 }
 

--- a/views/SmartyView.php
+++ b/views/SmartyView.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Slim
+ *
+ * A simple PHP framework for PHP 5 or newer
+ *
+ * @author		Josh Lockhart <info@joshlockhart.com>
+ * @link		http://slim.joshlockhart.com
+ * @copyright	2010 Josh Lockhart
+ * 
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * SmartyView
+ *
+ * The SmartyView is a custom View class that renders templates using the Smarty 
+ * template language (http://www.smarty.net).
+ *
+ * Two fields that you, the developer, will need to change are:
+ * - smartyDirectory
+ * - smartyCompileDirectory
+ * - smartyCacheDirectory
+ *
+ * @package Slim
+ * @author  Jose da Silva <http://josedasilva.net>
+ */
+class SmartyView extends View {
+
+    /**
+     * @var string The path to the Smarty code directory WITHOUT the trailing slash
+     */
+    public static $smartyDirectory = null;
+
+    /**
+     * @var string The path to the Smarty compiled templates folder WITHOUT the trailing slash
+     */
+    public static $smartyCompileDirectory = null;
+
+    /**
+     * @var string The path to the Smarty cache folder WITHOUT the trailing slash
+     */
+    public static $smartyCacheDirectory = null;
+
+	/**
+     * @var instance of the Smarty object
+     */
+	private $smartyInstance =	null;
+
+	/**
+	 * Render Smarty Template
+	 *
+	 * This method will output the rendered template content
+	 *
+	 * @param 	string $template The path to the Smarty template, relative to the  templates directory.
+	 * @return 	void
+	 */
+    public function render( $template ) {
+        $instance = $this->getInstance();
+        $instance->assign($this->data);
+        echo $instance->fetch($template);
+    }
+
+    /**
+     * Creates new Smarty object instance if it doesn't already exist, and returns it.
+     *
+     * @return Smarty Instance
+     */
+    private function getInstance() {
+        if ( !$this->smartyInstance ) {
+            require_once self::$smartyDirectory . '/Smarty.class.php';
+
+			$this->smartyInstance = new Smarty();
+
+			$this->smartyInstance->template_dir = $this->templatesDirectory();
+			
+			if ( self::$smartyCompileDirectory ) {
+				$this->smartyInstance->compile_dir  = self::$smartyCompileDirectory;
+			}
+			
+			if ( self::$smartyCompileDirectory ) {
+				$this->smartyInstance->cache_dir  = self::$smartyCacheDirectory;
+			}
+			
+        }
+
+        return $this->smartyInstance;
+    }
+}
+
+?>


### PR DESCRIPTION
Made possible to use $smartyInstance object in order to access complete Smarty features when needed, making development more flexible
Added Smarty library directory validation, throwing an Exception if not found.
