### PR TITLE
Adding view classes for Dwoo, Rain, Savant, Sugar and HamlPHP

### DIFF
--- a/views/DwooView.php
+++ b/views/DwooView.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @copyright   2011 Josh Lockhart
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * DwooView
+ *
+ * The DwooView is a Custom View class that renders templates using the
+ * Dwoo template language (http://dwoo.org/).
+ *
+ * There are two fields that you, the developer, will need to change:
+ * - dwooDirectory
+ * - dwooTemplatesDirectory
+ *
+ * @package Slim
+ * @author  Matthew Callis <http://superfamicom.org/>
+ */
+class DwooView extends Slim_View {
+
+	/**
+	 * @var string The path to the directory containing the Dwoo folder without trailing slash.
+	 */
+	public static $dwooDirectory = null;
+
+	/**
+	 * @var persistent instance of the Smarty object
+	 */
+	private static $dwooInstance = null;
+
+	/**
+	 * @var string The path to the templates folder WITH the trailing slash
+	 */
+	public static $dwooTemplatesDirectory = 'templates';
+
+	/**
+	 * Renders a template using Dwoo.php.
+	 *
+	 * @see View::render()
+	 * @param string $template The template name specified in Slim::render()
+	 * @return string
+	 */
+	public function render( $template ) {
+		$dwoo = $this->getInstance();
+		return $dwoo->get(self::$dwooTemplatesDirectory.$template, $this->data);
+	}
+
+	/**
+	 * Creates new Dwoo instance if it doesn't already exist, and returns it.
+	 *
+     * @throws RuntimeException If Dwoo lib directory does not exist.
+	 * @return DwooInstance
+	 */
+	private function getInstance() {
+		if ( !self::$dwooInstance ) {
+            if ( !is_dir(self::$dwooDirectory) ) {
+                throw new RuntimeException('Cannot set the Dwoo lib directory : ' . self::$dwooDirectory . '. Directory does not exist.');
+            }
+			require_once self::$dwooDirectory . '/dwooAutoload.php';
+			self::$dwooInstance = new Dwoo();
+		}
+		return self::$dwooInstance;
+	}
+}
+
+?>

--- a/views/HamlView.php
+++ b/views/HamlView.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @copyright   2011 Josh Lockhart
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * HamlView
+ *
+ * The HamlView is a Custom View class that renders templates using the
+ * HAML template language (http://haml-lang.com/) through the use of
+ * HamlPHP (https://github.com/sniemela/HamlPHP).
+ *
+ * There are three field that you, the developer, will need to change:
+ * - hamlDirectory
+ * - hamlTemplatesDirectory
+ * - hamlCacheDirectory
+ *
+ * @package Slim
+ * @author  Matthew Callis <http://superfamicom.org/>
+ */
+
+class HamlView extends Slim_View {
+
+	/**
+	 * @var string The path to the directory containing the "HamlPHP" folder without trailing slash.
+	 */
+	public static $hamlDirectory = null;
+
+	/**
+	 * @var string The path to the templates folder WITH the trailing slash
+	 */
+	public static $hamlTemplatesDirectory = 'templates/';
+
+	/**
+	 * @var string The path to the templates folder WITH the trailing slash
+	 */
+	public static $hamlCacheDirectory = null;
+
+
+	/**
+	 * Renders a template using Haml.php.
+	 *
+	 * @see View::render()
+     * @throws RuntimeException If Haml lib directory does not exist.
+	 * @param string $template The template name specified in Slim::render()
+	 * @return string
+	 */	
+	public function render( $template ) {
+        if ( !is_dir(self::$hamlDirectory) ) {
+            throw new RuntimeException('Cannot set the HamlPHP lib directory : ' . self::$hamlDirectory . '. Directory does not exist.');
+        }
+
+		require_once self::$hamlDirectory . '/HamlPHP/HamlPHP.php';
+		require_once self::$hamlDirectory . '/HamlPHP/Storage/FileStorage.php';
+
+		$parser = new HamlPHP(new FileStorage(self::$hamlCacheDirectory));
+		return $parser->parseFile(self::$hamlTemplatesDirectory.$template, $this->data);
+	}
+}
+
+?>

--- a/views/RainView.php
+++ b/views/RainView.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @copyright   2011 Josh Lockhart
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * RainView
+ *
+ * The RainView is a Custom View class that renders templates using the
+ * Rain template language (http://www.raintpl.com/).
+ *
+ * There are three fields that you, the developer, will need to change:
+ * - rainDirectory
+ * - rainTemplatesDirectory
+ * - rainCacheDirectory
+ *
+ * @package Slim
+ * @author  Matthew Callis <http://superfamicom.org/>
+ */
+class RainView extends Slim_View {
+
+	/**
+	 * @var string The path to the directory containing "rain.tpl.class.php" without trailing slash.
+	 */
+	public static $rainDirectory = null;
+
+	/**
+	 * @var persistent instance of the Smarty object
+	 */
+	private static $rainInstance = null;
+
+	/**
+	 * @var string The path to the templates folder WITH the trailing slash
+	 */
+	public static $rainTemplatesDirectory = 'templates/';
+
+	/**
+	 * @var string The path to the cache folder WITH the trailing slash
+	 */
+	public static $rainCacheDirectory = null;
+
+	/**
+	 * Renders a template using Rain.php.
+	 *
+	 * @see View::render()
+	 * @param string $template The template name specified in Slim::render()
+	 * @return string
+	 */
+	public function render( $template ) {
+		$rain = $this->getInstance();
+		$rain->assign($this->data);
+		return $rain->draw($template, $return_string = true);
+	}
+
+	/**
+	 * Creates new Rain instance if it doesn't already exist, and returns it.
+	 *
+     * @throws RuntimeException If Rain lib directory does not exist.
+	 * @return RainInstance
+	 */
+	private function getInstance() {
+		if ( !self::$rainInstance ) {
+            if ( !is_dir(self::$rainDirectory) ) {
+                throw new RuntimeException('Cannot set the Rain lib directory : ' . self::$rainDirectory . '. Directory does not exist.');
+            }
+			require_once self::$rainDirectory . '/rain.tpl.class.php';
+			raintpl::$tpl_dir = self::$rainTemplatesDirectory;
+			raintpl::$cache_dir = self::$rainCacheDirectory;
+			self::$rainInstance = new raintpl();
+		}
+		return self::$rainInstance;
+	}
+}
+
+?>

--- a/views/RainView.php
+++ b/views/RainView.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @copyright   2011 Josh Lockhart
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * RainView
+ *
+ * The RainView is a Custom View class that renders templates using the
+ * Rain template language (http://rain.org/).
+ *
+ * There are three fields that you, the developer, will need to change:
+ * - rainDirectory
+ * - rainTemplatesDirectory
+ * - rainCacheDirectory
+ *
+ * @package Slim
+ * @author  Matthew Callis <http://superfamicom.org/>
+ */
+class RainView extends Slim_View {
+
+	/**
+	 * @var string The path to the directory containing "rain.tpl.class.php" without trailing slash.
+	 */
+	public static $rainDirectory = null;
+
+	/**
+	 * @var persistent instance of the Smarty object
+	 */
+	private static $rainInstance = null;
+
+	/**
+	 * @var string The path to the templates folder WITH the trailing slash
+	 */
+	public static $rainTemplatesDirectory = 'templates/';
+
+	/**
+	 * @var string The path to the cache folder WITH the trailing slash
+	 */
+	public static $rainCacheDirectory = null;
+
+	/**
+	 * Renders a template using Rain.php.
+	 *
+	 * @see View::render()
+	 * @param string $template The template name specified in Slim::render()
+	 * @return string
+	 */
+	public function render( $template ) {
+		$rain = $this->getInstance();
+		$rain->assign($this->data);
+		return $rain->draw($template, $return_string = true);
+	}
+
+	/**
+	 * Creates new Rain instance if it doesn't already exist, and returns it.
+	 *
+     * @throws RuntimeException If Rain lib directory does not exist.
+	 * @return RainInstance
+	 */
+	private function getInstance() {
+		if ( !self::$rainInstance ) {
+            if ( !is_dir(self::$rainDirectory) ) {
+                throw new RuntimeException('Cannot set the Rain lib directory : ' . self::$rainDirectory . '. Directory does not exist.');
+            }
+			require_once self::$rainDirectory . '/rain.tpl.class.php';
+			raintpl::$tpl_dir = self::$rainTemplatesDirectory;
+			raintpl::$cache_dir = self::$rainCacheDirectory;
+			self::$rainInstance = new raintpl();
+		}
+		return self::$rainInstance;
+	}
+}
+
+?>

--- a/views/SavantView.php
+++ b/views/SavantView.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @copyright   2011 Josh Lockhart
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * SavantView
+ *
+ * The SavantView is a Custom View class that renders templates using the
+ * Savant3 template language (http://phpsavant.com/).
+ *
+ * There are two fields that you, the developer, will need to change:
+ * - savantDirectory
+ * - savantOptions
+ *
+ * @package Slim
+ * @author  Matthew Callis <http://superfamicom.org/>
+ */
+class SavantView extends Slim_View {
+
+	/**
+	 * @var string The path to the directory containing Savant3.php and the Savant3 folder without trailing slash.
+	 */
+	public static $savantDirectory = null;
+
+	/**
+	 * @var array The options for the Savant3 environment, see http://phpsavant.com/api/Savant3/
+	 */
+	public static $savantOptions = array('template_path' => 'templates');
+
+	/**
+	 * @var persistent instance of the Savant object
+	 */
+	private static $savantInstance = null;
+
+	/**
+	 * Renders a template using Savant3.php.
+	 *
+	 * @see View::render()
+	 * @param string $template The template name specified in Slim::render()
+	 * @return string
+	 */
+	public function render( $template ) {
+		$savant = $this->getInstance();
+		$savant->assign($this->data);
+		return $savant->fetch($template);
+	}
+
+	/**
+	 * Creates new Savant instance if it doesn't already exist, and returns it.
+	 *
+     * @throws RuntimeException If Savant3 lib directory does not exist.
+	 * @return SavantInstance
+	 */
+	private function getInstance() {
+		if ( !self::$savantInstance ) {
+            if ( !is_dir(self::$savantDirectory) ) {
+                throw new RuntimeException('Cannot set the Savant lib directory : ' . self::$savantDirectory . '. Directory does not exist.');
+            }
+			require_once self::$savantDirectory . '/Savant3.php';
+			self::$savantInstance = new Savant3(self::$savantOptions);
+		}
+		return self::$savantInstance;
+	}
+}
+
+?>

--- a/views/SugarView.php
+++ b/views/SugarView.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @copyright   2011 Josh Lockhart
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * SugarView
+ *
+ * The SugarView is a Custom View class that renders templates using the
+ * Sugar template language (http://php-sugar.net/).
+ *
+ * There are three fields that you, the developer, will need to change:
+ * - sugarDirectory
+ * - sugarTemplatesDirectory
+ * - sugarCacheDirectory
+ *
+ * @package Slim
+ * @author  Matthew Callis <http://superfamicom.org/>
+ */
+class SugarView extends Slim_View {
+
+	/**
+	 * @var string The path to the directory containing the Sugar folder without trailing slash.
+	 */
+	public static $sugarDirectory = null;
+
+	/**
+	 * @var persistent instance of the Smarty object
+	 */
+	private static $sugarInstance = null;
+
+	/**
+	 * @var string The path to the templates folder WITH the trailing slash
+	 */
+	public static $sugarTemplatesDirectory = 'templates/';
+
+	/**
+	 * @var string The path to the cache folder WITH the trailing slash
+	 */
+	public static $sugarCacheDirectory = null;
+
+	/**
+	 * Renders a template using Sugar.php.
+	 *
+	 * @see View::render()
+	 * @param string $template The template name specified in Slim::render()
+	 * @return string
+	 */
+	public function render( $template ) {
+		$sugar = $this->getInstance();
+		$template = $sugar->getTemplate($template);
+		foreach($this->data as $key => $value){
+			$template->set($key, $value);
+		}
+		return $template->fetch();
+	}
+
+	/**
+	 * Creates new Sugar instance if it doesn't already exist, and returns it.
+	 *
+     * @throws RuntimeException If Sugar lib directory does not exist.
+	 * @return SugarInstance
+	 */
+	private function getInstance() {
+		if ( !self::$sugarInstance ) {
+            if ( !is_dir(self::$sugarDirectory) ) {
+                throw new RuntimeException('Cannot set the Sugar lib directory : ' . self::$sugarDirectory . '. Directory does not exist.');
+            }
+			require_once self::$sugarDirectory . '/Sugar.php';
+			self::$sugarInstance = new Sugar();
+			self::$sugarInstance->templateDir = self::$sugarTemplatesDirectory;
+			self::$sugarInstance->cacheDir = self::$sugarCacheDirectory;
+		}
+		return self::$sugarInstance;
+	}
+}
+
+?>


### PR DESCRIPTION
This simply adds support for the four following template engines, added to run some speed tests similar to those seen here: http://www.raintpl.com/PHP-Template-Engines-Speed-Test/
- [Dwoo](http://dwoo.org/)
- [Rain](http://www.raintpl.com/)
- [Savant](http://www.phpsavant.com/)
- [Sugar](http://php-sugar.net/)
- [HamlPHP](https://github.com/sniemela/HamlPHP)
