### PR TITLE
Slim::flash casts to string

### DIFF
--- a/Slim/Session/Flash.php
+++ b/Slim/Session/Flash.php
@@ -109,7 +109,7 @@ class Slim_Session_Flash implements ArrayAccess {
      * @return Slim_Session_Flash
      */
     public function now( $key, $value ) {
-        $this->messages['now'][(string)$key] = (string)$value;
+        $this->messages['now'][(string)$key] = $value;
         return $this->save();
     }
 
@@ -121,7 +121,7 @@ class Slim_Session_Flash implements ArrayAccess {
      * @return Slim_Session_Flash
      */
     public function set( $key, $value ) {
-        $this->messages['next'][(string)$key] = (string)$value;
+        $this->messages['next'][(string)$key] = $value;
         return $this->save();
     }
 

--- a/tests/FlashTest.php
+++ b/tests/FlashTest.php
@@ -158,6 +158,21 @@ class FlashTest extends PHPUnit_Extensions_OutputTestCase {
         $this->assertArrayHasKey('error', $_SESSION['flash']);
         $this->assertEquals('New error message', $_SESSION['flash']['error']);
     }
+    
+    /**
+     * Tests flash can store array/object, not only strings.
+     */
+    public function testFlashKeepsObjects() {
+        $c = new StdClass;
+        $c->foo = 'bar';
+        
+        $f1 = new Slim_Session_Flash();
+        $f1->set('object', $c);
+        $f1->save();
+        $f1->load();
+        
+        $this->assertObjectHasAttribute( $f1['object'], 'foo' );
+    }
 
 }
 ?>


### PR DESCRIPTION
Removes Slim::flash casting to string. Now we can store any type of data in flash messages.
fixes #120
