### PR TITLE
uninitialized app->flash makes stop() fail

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -881,7 +881,7 @@ class Slim {
      * @return  void
      */
     public static function stop() {
-        self::$app->flash->save();
+        if (self::$app->flash) self::$app->flash->save();
         session_write_close();
         self::response()->send();
         throw new Slim_Exception_Stop();


### PR DESCRIPTION
Basically, i tried to log to an unwritable path. Setup of logging is before setup of session/flash. The exception got caught and ended up calling stop() which failed() trying to app->flash->save(). This is a quick fix. Maybe you should strive to make stop() bulletproof (try/catch ?). Wherever an exception happens, stop() should not fail.
