### PR TITLE
Autoload breaks when Slim.php isn't placed in default directory.

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -152,7 +152,7 @@ class Slim {
         if ( strpos($class, 'Slim') !== 0 ) {
             return;
         }
-        $file = dirname(__FILE__) . '/../' . str_replace('_', DIRECTORY_SEPARATOR, $class) . '.php';
+        $file = dirname(__FILE__) . '/' . str_replace('_', DIRECTORY_SEPARATOR, substr($class,4)) . '.php';
         if ( file_exists($file) ) {
             require $file;
         }


### PR DESCRIPTION
Let's try to change default "Slim" directory name to ex. "slim", then autoload fails, because "Slim_" in classes names points to exacly "Slim" directory.

I've fixed it by simple substr.
