### PR TITLE
New option 'routing.basepath'

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -378,7 +378,7 @@ class Slim {
      * @return  Slim_Route
      */
     protected function mapRoute($args) {
-        $pattern = $this->settings['routing.base_path'].array_shift($args);
+        $pattern = $this->settings['routing.basepath'].array_shift($args);
         $callable = array_pop($args);
         $route = $this->router->map($pattern, $callable);
         if ( count($args) > 0 ) {

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -158,6 +158,8 @@ class Slim {
         $this->settings = array_merge(array(
             //Mode
             'mode' => 'development',
+            //Routing
+            'routing.basepath' => '',
             //Logging
             'log.enable' => false,
             'log.logger' => null,
@@ -376,7 +378,7 @@ class Slim {
      * @return  Slim_Route
      */
     protected function mapRoute($args) {
-        $pattern = array_shift($args);
+        $pattern = $this->settings['routing.base_path'].array_shift($args);
         $callable = array_pop($args);
         $route = $this->router->map($pattern, $callable);
         if ( count($args) > 0 ) {


### PR DESCRIPTION
New option 'routing.basepath'. With this option you can add a prefix to all routes. This can be useful when you do the administrator part of the site so that every time do not write route '/admin/[more]'.
