### PR TITLE
Add support for 422 HTTP status code

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -121,6 +121,7 @@ class Slim_Http_Response {
         415 => '415 Unsupported Media Type',
         416 => '416 Requested Range Not Satisfiable',
         417 => '417 Expectation Failed',
+        422 => '422 Unprocessable Entity',
         //Server Error 5xx
         500 => '500 Internal Server Error',
         501 => '501 Not Implemented',

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -122,6 +122,7 @@ class Slim_Http_Response {
         416 => '416 Requested Range Not Satisfiable',
         417 => '417 Expectation Failed',
         422 => '422 Unprocessable Entity',
+        423 => '423 Locked',
         //Server Error 5xx
         500 => '500 Internal Server Error',
         501 => '501 Not Implemented',


### PR DESCRIPTION
Rails uses 422 (Unprocessable Entity) to communicate errors in the semantics of the posted entity (f.e. when validations fail).

From RFC 4918:

> 11.2.  422 Unprocessable Entity
> 
>   The 422 (Unprocessable Entity) status code means the server
>    understands the content type of the request entity (hence a
>    415(Unsupported Media Type) status code is inappropriate), and the
>    syntax of the request entity is correct (thus a 400 (Bad Request)
>    status code is inappropriate) but was unable to process the contained
>    instructions.  For example, this error condition may occur if an XML
>    request body contains well-formed (i.e., syntactically correct), but
>    semantically erroneous, XML instructions.

Slim currently throws an exception when trying to set the status code to 422, and as far as I can see there is no workaround as the Status header is overwritten right before sending the headers.
