### PR TITLE
ClassName::methodName" Routes support for PHP 5.3

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -389,7 +389,14 @@ class Slim_Route {
         }
         //Invoke callable
         if ( is_callable($this->getCallable()) ) {
-            call_user_func_array($this->callable, array_values($this->params));
+            
+            if( is_string($this->callable) && strpos($this->callable, '::' )!==false ) {
+                list($className, $methodName) = explode('::', $this->callable);
+                call_user_func_array( array(new $className(), $methodName), array_values($this->params));
+            } else {
+                call_user_func_array($this->callable, array_values($this->params));
+            }
+            
             return true;
         }
         return false;


### PR DESCRIPTION
Hello !

In order to be able to map Controllers instances to Slim Routes, I added "ClassName::methodName" Routes support for PHP 5.3 (an instance of $className is automatically created instead of calling the method statically).
It shouldn't change anything on PHP < 5.3, because `is_callable()` will then return `false`.

As you can see, it's a very minor addition... but it can be a very handy one :-)
