### PR TITLE
Templates path assignement to view refactoring.

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -574,9 +574,22 @@ class Slim {
             } else {
                 $this->view = new $viewClass();
             }
+            $this->assignPathsToView();
             $this->view->appendData($existingData);
         }
         return $this->view;
+    }
+
+    /**
+     * Feed to current view with the templates path from the configuration.
+     */
+    public function assignPathsToView(){
+        $templatesPath = $this->config('templates.path');
+        //Legacy support
+        if ( is_null($templatesPath) ) {
+            $templatesPath = $this->config('templates_dir');
+        }
+        $this->view->setTemplatesDirectory($templatesPath);
     }
 
     /***** RENDERING *****/
@@ -595,12 +608,7 @@ class Slim {
      * @return  void
      */
     public function render( $template, $data = array(), $status = null ) {
-        $templatesPath = $this->config('templates.path');
-        //Legacy support
-        if ( is_null($templatesPath) ) {
-            $templatesPath = $this->config('templates_dir');
-        }
-        $this->view->setTemplatesDirectory($templatesPath);
+        $this->assignPathsToView();
         if ( !is_null($status) ) {
             $this->response->status($status);
         }


### PR DESCRIPTION
Was required for TwigView(slim-extra) to add filters on Twig.

Explanation:
I needed to add a filter to Twig before render().
But SlimView->getEnvironment() needed its templates path to initialize Twig.
Problem is that the path are given to the view on render...
Extracting some code was necessary; and now, the paths are passed to the view upon assignement.
