### PR TITLE
Added test mediatype no param

### DIFF
--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -660,6 +660,30 @@ class RequestTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * Test get media type
+     */
+    public function testGetMediaTypeWhenNoParamsExist() {
+        $env = Slim_Environment::getInstance();
+        $req = new Slim_Http_Request($env);
+        Slim_Environment::mock(array(
+            'REQUEST_METHOD' => 'PUT',
+            'REMOTE_ADDR' => '127.0.0.1',
+            'SCRIPT_NAME' => '/foo/index.php', //<-- Physical
+            'PATH_INFO' => '/bar/xyz', //<-- Virtual
+            'QUERY_STRING' => 'one=1&two=2&three=3',
+            'SERVER_NAME' => 'slim',
+            'SERVER_PORT' => 80,
+            'slim.url_scheme' => 'http',
+            'slim.input' => '',
+            'slim.errors' => fopen('php://stderr', 'w'),
+            'CONTENT_TYPE' => 'application/json'
+        ));
+        $env = Slim_Environment::getInstance();
+        $req = new Slim_Http_Request($env);
+        $this->assertEquals('application/json', $req->getMediaType());
+    }
+
+    /**
      * Test get media type params
      */
     public function testGetMediaTypeParams() {


### PR DESCRIPTION
I added a test to cover content-type extraction when no parameters are present. It's a possibility in RFC and the code wasnt clear to me (preg_split returns the whole thing as an array when pattern doesnt match)
