### PR TITLE
Added "ClassName#instanceMethodName" Routes callable support.

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -392,6 +392,12 @@ class Slim_Route {
             call_user_func_array($this->callable, array_values($this->params));
             return true;
         }
+        // Do we have "className#instanceMethodName" pattern ?
+        if (is_string($this->callable) && strpos($this->callable, '#')!==false) {
+            list($className, $instanceMethodName) = explode('#', $this->callable);
+            call_user_func_array(array(new $className(), $instanceMethodName), array_values($this->params));
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
Because it is sometimes very useful to be able to create a Class instance rather than calling a static method of this Class (it allows custom common initialization in the Class constructor, for example), this simple and intuitive notation allows this process, without breaking anything.
