### PR TITLE
If gzip is enabled the Content-length header will be incorrect

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -303,7 +303,7 @@ class Slim_Http_Response {
         }
 
         //Flush all output to client
-        flush();
+        //flush();
     }
 
     /**


### PR DESCRIPTION
The flush(); call will force the headers to be sent so the webserver can't change it. This causes a connection closed error in chrome and other browsers. Experienced on windows with Apache 2.2.19 and PHP 5.3.6
