### PR TITLE
Improve Encryption

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -182,7 +182,7 @@ class Slim_Http_Util {
      */
     public static function encodeSecureCookie( $value, $expires, $secret, $algorithm, $mode ) {
         $key = hash_hmac('sha1', $expires, $secret);
-        $iv = md5($expires);
+        $iv = self::get_iv($expires, $secret);
         $secureString = base64_encode(self::encrypt($value, $key, $iv, array(
             'algorithm' => $algorithm,
             'mode' => $mode
@@ -210,7 +210,7 @@ class Slim_Http_Util {
             $value = explode('|', $value);
             if ( count($value) === 3 && ( (int)$value[0] === 0 || (int)$value[0] > time() ) ) {
                 $key = hash_hmac('sha1', $value[0], $secret);
-                $iv = md5($value[0]);
+                $iv = self::get_iv($value[0], $secret);
                 $data = self::decrypt(base64_decode($value[1]), $key, $iv, array(
                     'algorithm' => $algorithm,
                     'mode' => $mode
@@ -360,4 +360,21 @@ class Slim_Http_Util {
         }
         return $cookies;
     }
+
+    /**
+     * Generate a random IV
+     *
+     * This method will generate a non-predictable IV for use with
+     * the cookie encryption
+     *
+     * @param   int     $expires    The UNIX timestamp at which this cookie will expire
+     * @param   string  $secret     The secret key used to hash the cookie value
+     * @return  binary string with length 40
+     */
+    private static function get_iv($expires, $secret) {
+        $data1 = hash_hmac('sha1', 'a'.$expires.'b', $secret);
+        $data2 = hash_hmac('sha1', 'z'.$expires.'y', $secret);
+        return pack("h*", $data1.$data2);
+    }
+
 }

--- a/tests/Middleware/SessionCookieTest.php
+++ b/tests/Middleware/SessionCookieTest.php
@@ -94,7 +94,7 @@ class SessionCookieTest extends PHPUnit_Framework_TestCase {
         $env = array(
             'SCRIPT_NAME' => '/foo/index.php', //<-- Physical
             'PATH_INFO' => '/bar', //<-- Virtual
-            'COOKIE' => 'slim_session=1639490378%7CqWbI5R%2Bf%2B%2F1KfHQQ9cANqEEdK5aNhf%2FQy2WX%2FCFOG5Y%3D%7Ce207c55544e1f7889a357ab39700f9cbb3836ea3',
+            'COOKIE' => 'slim_session=1644004961%7CLKkYPwqKIMvBK7MWl6D%2BxeuhLuMaW4quN%2F512ZAaVIY%3D%7Ce0f007fa852c7101e8224bb529e26be4d0dfbd63',
         );
         $app = new CustomAppGet();
         $mw = new Slim_Middleware_SessionCookie($app);


### PR DESCRIPTION
Previously were using md5($expiration) for the cookie encryption IV.
Downsides to this approach:
1) IV is predictable if attacker knows system time
2) Same for all systems with same system time
3) Only 128 bits of entropy (IV for default AES-256 is 256 bits)

The new approach solves these problems by combining the server secret
with the expiration to generate two HMACSHA1 messages, truncating the
result to 32 bytes, and using that for the IV.
