### PR TITLE
Added support for Backbone.js's X-HTTP-Method-Override header

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -393,13 +393,18 @@ class Slim_Http_Request {
      * @return  void
      */
     protected function checkForHttpMethodOverride() {
-        if ( isset($this->post[self::METHOD_OVERRIDE]) ) {
-            $this->method = $this->post[self::METHOD_OVERRIDE];
+        $changed = false;
+    	if ( isset($this->post[self::METHOD_OVERRIDE]) ) {
+			$this->method = $this->post[self::METHOD_OVERRIDE];
             unset($this->post[self::METHOD_OVERRIDE]);
-            if ( $this->isPut() ) {
-                $this->put = $this->post;
-            }
-        }
+            $changed = true;
+		} else if(isset($this->headers['x-method-override'] )) {
+			$this->method = $this->headers['x-method-override'];
+			$changed = true;
+		}
+		if ( $changed && $this->isPut() ) {
+			$this->put = $this->post;
+		}
     }
 
 }


### PR DESCRIPTION
Would be a great addition to the frameowrk I think as it means SLIM will work with Backbone's emulateHTTP setting. At present it only works when you turn on both emulateHTTP and emulateJSON (unless you have successfully configured a RESTful server, which as I've found out lately, is less than easy, particularly for a front-end developer like myself)

...in emulateHTTP mode)
