### PR TITLE
Fix URI port parsing

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -392,6 +392,9 @@ class Slim_Http_Request {
      */
     public function getHost() {
         if ( isset($this->env['HOST']) ) {
+            if ( strpos($this->env['HOST'], ':') !== false ) {
+                return array_shift(explode(':', $this->env['HOST']));
+            }
             return $this->env['HOST'];
         } else {
             return $this->env['SERVER_NAME'];

--- a/Slim/Middleware/ContentTypes.php
+++ b/Slim/Middleware/ContentTypes.php
@@ -76,8 +76,14 @@ class Slim_Middleware_ContentTypes implements Slim_Middleware_Interface {
      */
     public function call( &$env ) {
         if ( isset($env['CONTENT_TYPE']) ) {
+            if ( strpos($env['CONTENT_TYPE'],';') !== false ) {
+                list($contentType, $charset) = explode(';', $env['CONTENT_TYPE']);
+            }
+            else {
+                $contentType = $env['CONTENT_TYPE'];
+            }
             $env['slim.input_original'] = $env['slim.input'];
-            $env['slim.input'] = $this->parse($env['slim.input'], $env['CONTENT_TYPE']);
+            $env['slim.input'] = $this->parse($env['slim.input'], $contentType);
         }
         return $this->app->call($env);
     }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -552,6 +552,18 @@ class RequestTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * Test get host when it has a port number
+     */
+    public function testGetHostAndStripPort() {
+        $env = Slim_Environment::mock(array(
+            'SERVER_NAME' => 'slim',
+            'HOST' => 'slimframework.com:80'
+        ));
+        $req = new Slim_Http_Request($env);
+        $this->assertEquals('slimframework.com', $req->getHost()); //Uses HTTP_HOST if available
+    }
+
+    /**
      * Test get host
      */
     public function testGetHostWhenNotExists() {
@@ -570,6 +582,20 @@ class RequestTest extends PHPUnit_Framework_TestCase {
     public function testGetHostWithPort() {
         $env = Slim_Environment::mock(array(
             'HOST' => 'slimframework.com',
+            'SERVER_NAME' => 'slim',
+            'SERVER_PORT' => 80,
+            'slim.url_scheme' => 'http'
+        ));
+        $req = new Slim_Http_Request($env);
+        $this->assertEquals('slimframework.com:80', $req->getHostWithPort());
+    }
+
+    /**
+     * Test get host with port doesn't dulplicate port numbers
+     */
+    public function testGetHostDoesntDulplicatePort() {
+        $env = Slim_Environment::mock(array(
+            'HOST' => 'slimframework.com:80',
             'SERVER_NAME' => 'slim',
             'SERVER_PORT' => 80,
             'slim.url_scheme' => 'http'


### PR DESCRIPTION
Hi,

I've been playing with the new PHP5.4 web server running on a non-standard port and noticed the getHostWithPort() method returning host:port:port so I had a dig around and found the current methods don't handle the case of Host including a port which seems to be part of the spec: 

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.23

I've knocked up a couple of tests to reproduce the issue along with a fix. I fixed this in Request rather than Environment as I imagined you would want Environment itself to reflect the actual server environment.

Best Regards,

Ben
