### PR TITLE
1.6 regression: SCRIPT_NAME broken in Windows environments

### DIFF
--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -137,7 +137,7 @@ class Slim_Environment implements ArrayAccess, IteratorAggregate {
             if ( strpos($_SERVER['REQUEST_URI'], $_SERVER['SCRIPT_NAME']) === 0 ) {
                 $env['SCRIPT_NAME'] = $_SERVER['SCRIPT_NAME']; //Without URL rewrite
             } else {
-                $env['SCRIPT_NAME'] = pathinfo($_SERVER['SCRIPT_NAME'], PATHINFO_DIRNAME); //With URL rewrite
+                $env['SCRIPT_NAME'] = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME']) ); //With URL rewrite
             }
             $env['PATH_INFO'] = substr_replace($_SERVER['REQUEST_URI'], '', 0, strlen($env['SCRIPT_NAME']));
             if ( strpos($env['PATH_INFO'], '?') !== false ) {


### PR DESCRIPTION
On Windows, `$env['SCRIPT_NAME']` contains an unwanted backslash, breaking `Slim_Http_Request::getScriptName` and `Slim_Http_Request::getRootUri`.

The tests for this exist already, and they fail as expected on Windows.

This can easily be fixed by changing a single line, setting `SCRIPT_NAME` the way it was done in Slim 1.5.
