### PR TITLE
Update README: Do not use `if` in a `location` block for nginx

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -76,9 +76,7 @@ Ensure the `.htaccess` and `index.php` files are in the same public-accessible d
 
 Your nginx configuration file should contain this code (along with other settings you may need) in your `location` block:
 
-    if (!-f $request_filename) {
-        rewrite ^ /index.php last;
-    }
+    try_files $uri $uri/ /index.php;
 
 This assumes that Slim's `index.php` is in the root folder of your project (www root).
 


### PR DESCRIPTION
As `IfIsEvil` (http://wiki.nginx.org/IfIsEvil#What_to_do_instead) it should be avoided in this case. `try_files` basically does the same (tries to request the file, then a directory and falls back to a rewrite to /index.php in case nothing of the previous does match). This should be a lot smarter.
