### PR TITLE
Add fetch method to return rendered template without echoing it

### DIFF
--- a/Slim/View.php
+++ b/Slim/View.php
@@ -145,6 +145,18 @@ class Slim_View {
     }
 
     /**
+     * Fetch rendered template
+     *
+     * This method returns the rendered template as a string
+     *
+     * @param   string $template Path to template file relative to templates directoy
+     * @return  void
+     */
+    public function fetch( $template ) {
+        return $this->render($template);
+    }
+
+    /**
      * Render template
      * @param   string $template    Path to template file relative to templates directory
      * @return  string              Rendered template


### PR DESCRIPTION
Allow a rendered template to be returned as follows:

```
$rendered_template = $app->view()->fetch('template.tpl');
```
## Reasoning

This is useful for rendering a template to a string. That string can then be passed on to a function that sends email, for example.
