### PR TITLE
updated session docs

### DIFF
--- a/docs/sessions.markdown
+++ b/docs/sessions.markdown
@@ -15,7 +15,7 @@ You may also use the `Slim_Middleware_SessionCookie` middleware to persist sessi
 
     $app = new Slim();
     
-    $app->add('Slim_Middleware_SessionCookie', array(
+    $app->add(new Slim_Middleware_SessionCookie, array(
         'expires' => '20 minutes',
         'path' => '/',
         'domain' => null,


### PR DESCRIPTION
$app->add() code mentioned passing the Middleware name as a string--which didn't work for me. I got an error stating that an instance was needed, so I updated the docs accordingly. No the errors and docs match. :)
