### PR TITLE
Fix same name cookies

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -348,13 +348,7 @@ class Slim_Http_Util {
             if ( count($cParts) === 2 ) {
                 $key = urldecode($cParts[0]);
                 $value = urldecode($cParts[1]);
-                if ( isset($cookies[$key]) ) {
-                    if ( is_array($cookies[$key]) ) {
-                        $cookies[$key][] = $value;
-                    } else {
-                        $cookies[$key] = array($cookies[$key], $value);
-                    }
-                } else {
+                if ( !isset($cookies[$key]) ) {
                     $cookies[$key] = $value;
                 }
             }

--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -342,7 +342,7 @@ class Slim_Http_Util {
     public static function parseCookieHeader( $header ) {
         $cookies = array();
         $header = rtrim($header, "\r\n");
-        $headerPieces = preg_split('@\s*;\s*@', $header);
+        $headerPieces = preg_split('@\s*[;,]\s*@', $header);
         foreach ( $headerPieces as $c ) {
             $cParts = explode('=', $c);
             if ( count($cParts) === 2 ) {

--- a/docs/request-cookies.markdown
+++ b/docs/request-cookies.markdown
@@ -11,6 +11,8 @@ Only Cookies **sent** with the current HTTP request are accessible with this met
     //Get all cookies as associative array
     $cookies = $app->request()->cookies();
 
+When multiple cookies with the same name are available (e.g. because they have different paths) only the most specific one (longest matching path) is returned. See RFC 2109.
+
 ## Get Encrypted Cookies [request-cookies-encrypted] ##
 
 If you previously set an encrypted cookie, you can fetch its decrypted value with the Slim application's `getEncryptedCookie()` instance method like this:

--- a/tests/Http/UtilTest.php
+++ b/tests/Http/UtilTest.php
@@ -339,14 +339,17 @@ class SlimHttpUtilTest extends PHPUnit_Framework_TestCase {
      * Test parses Cookie: HTTP header
      */
     public function testParsesCookieHeader() {
-        $header = 'foo=bar; one=two; colors=blue; colors=red; colors=green';
+        $header = 'foo=bar; one=two; colors=blue';
         $result = Slim_Http_Util::parseCookieHeader($header);
         $this->assertEquals(3, count($result));
         $this->assertEquals('bar', $result['foo']);
         $this->assertEquals('two', $result['one']);
-        $this->assertEquals(3, count($result['colors']));
-        $this->assertEquals('blue', $result['colors'][0]);
-        $this->assertEquals('red', $result['colors'][1]);
-        $this->assertEquals('green', $result['colors'][2]);
+        $this->assertEquals('blue', $result['colors']);
+    }
+
+    public function testPrefersLeftmostCookieWhenManyCookiesWithSameName() {
+        $header = 'foo=bar; foo=beer';
+        $result = Slim_Http_Util::parseCookieHeader($header);
+        $this->assertEquals('bar', $result['foo']);
     }
 }

--- a/tests/Http/UtilTest.php
+++ b/tests/Http/UtilTest.php
@@ -347,6 +347,15 @@ class SlimHttpUtilTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('blue', $result['colors']);
     }
 
+    public function testParsesCookieHeaderWithCommaSeparator() {
+        $header = 'foo=bar, one=two, colors=blue';
+        $result = Slim_Http_Util::parseCookieHeader($header);
+        $this->assertEquals(3, count($result));
+        $this->assertEquals('bar', $result['foo']);
+        $this->assertEquals('two', $result['one']);
+        $this->assertEquals('blue', $result['colors']);
+    }
+
     public function testPrefersLeftmostCookieWhenManyCookiesWithSameName() {
         $header = 'foo=bar; foo=beer';
         $result = Slim_Http_Util::parseCookieHeader($header);


### PR DESCRIPTION
Fixed as i said in issue #299. While i was there i noticed comma is a valid cookie delimiter and fixed that as well.
