### PR TITLE
Slim_View::appendData: Remove array type hint for greater flexibility when subclassing

### DIFF
--- a/Slim/View.php
+++ b/Slim/View.php
@@ -110,7 +110,8 @@ class Slim_View {
      * @param   array $data
      * @return  void
      */
-    public function appendData( array $data ) {
+    public function appendData( $data ) {
+        if ( !is_array($data) ) throw new InvalidArgumentException('Cannot append View data, array required');
         $this->data = array_merge($this->data, $data);
     }
 

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -91,15 +91,25 @@ class ViewTest extends PHPUnit_Framework_TestCase {
      * Test View appends data
      *
      * Pre-conditions:
-     * Append data to View several times
+     * Case A: Append data to View several times
+     * Case B: Append view data which is not an array
      *
      * Post-conditions:
-     * The View data contains all appended data
+     * Case A: The View data contains all appended data
+     * Case B: An InvalidArgumentException is thrown
      */
     public function testViewAppendsData(){
+        //Case A
         $this->view->appendData(array('a' => 'A'));
         $this->view->appendData(array('b' => 'B'));
         $this->assertEquals(array('a' => 'A', 'b' => 'B'), $this->view->getData());
+        
+        //Case B
+        try {
+            $this->view->appendData('not an array');
+            $this->fail('Appending View data with non-array argument did not throw exception');
+        } catch ( InvalidArgumentException $e ) {}
+        
     }
 
     /**


### PR DESCRIPTION
This is a very small change. `Slim_View::appendData` just accepts arrays. In certain circumstances, it would be desirable to allow objects as input.

(I've run into this when I tried to make Mustache lambdas work in PHP 5.2. It is easy, but you need to pass in an object rather than an array because in PHP 5.2, arrays can't yet contain functions.)

Removing the type hint would provide just that flexibility when subclassing `Slim_View`.

Code is attached. For a bit of pseudo type safety, I've added a run-time check to the `Slim_View` base class, throwing an exception if the parameter is not an array. There's also a test for that case.

Now that's a lot of words for a two-line change ;)
