### PR TITLE
Fixed issue that saw any echo'd output before the $app->run() call get duplicated in the output stream.

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1128,6 +1128,11 @@ class Slim {
      * @return void
      */
     public function run() {
+        //Clear any existing output buffer
+        if (ob_get_length() > 0) {
+            $this->response->write(ob_get_clean());
+        }
+
         set_error_handler(array('Slim', 'handleErrors'));
 
         //Apply final outer middleware layers

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -959,6 +959,27 @@ class SlimTest extends PHPUnit_Framework_TestCase {
         $s->run();
     }
 
+    /**
+     * Test that runner clears an existing output buffer when starting to run the application.
+     *
+     * This is most likely to happen when the evironment has output_buffering "On" which seems
+     * to be the default as of at least PHP 5.4+ (maybe earlier)
+     */
+    public function testRunWithOutputBufferingOnAndPrePopulated() {
+
+        //As of PHP 4.3.5 output_buffering is off by default in CLI mode so we need to explicitly start it by
+        //calling ob_start() since the unit tests are run in CLI mode.
+        ob_start();
+
+        $this->expectOutputString('debug_statement--Foo');
+        $s = new Slim();
+        echo "debug_statement--";
+        $s->get('/bar', function () use ($s) {
+            echo "Foo";
+        });
+        $s->run();
+    }
+
     /************************************************
      * MIDDLEWARE
      ************************************************/

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -288,6 +288,34 @@ class SlimTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * Test GET route with output buffering on before object creation and pre / post content
+     */
+    public function testGetRouteWithOutputBufferingBeforeObjectCreationAndPreAndPostContent() {
+        ob_start();
+        $s = new Slim();
+        echo "1:";
+        $route = $s->get('/bar', function () { echo "foo"; });
+        $s->run();
+        echo ":2";
+        $this->assertEquals('foo', $s->response()->body());
+        $this->assertEquals('1:foo:2', ob_get_clean());
+    }
+
+    /**
+     * Test GET route with output buffering on after object creation and pre / post content
+     */
+    public function testGetRouteWithOutputBufferingAfterObjectCreationAndPreAndPostContent() {
+        $s = new Slim();
+        ob_start();
+        echo "1:";
+        $route = $s->get('/bar', function () { echo "foo"; });
+        $s->run();
+        echo ":2";
+        $this->assertEquals('foo', $s->response()->body());
+        $this->assertEquals('1:foo:2', ob_get_clean());
+    }
+
+    /**
      * Test POST route
      */
     public function testPostRoute() {
@@ -822,7 +850,7 @@ class SlimTest extends PHPUnit_Framework_TestCase {
             $s->stop();
             echo "Bar"; //<-- Should not be in response body!
         });
-        $s->call();
+        $s->run();
         $this->assertEquals('Foo', $s->response()->body());
     }
 


### PR DESCRIPTION
If you had any echo'd output before the $app->run() call it would get duplicated in the page output when output_buffering is turned on.  In PHP 5.4+ (maybe before?) output_buffering is set to 4096 by default.

Ex.

``` php
<?php
require 'vendor/autoload.php';
$app = new Slim();

printf("%s:%d<br/>\n", __FILE__, __LINE__);

$app->get('/hello/:name', function ($name) {
    echo "Hello, $name!<br/>\n";
});

$app->run();
printf("%s:%d<br/>\n", __FILE__, __LINE__);
?>
```

Output =>

``` html
B:\dev\slimapp\index.php:5
Hello, brian!
B:\dev\slimapp\index.php:5
B:\dev\slimapp\index.php:12
```
