### PR TITLE
Feature route middleware docs

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1128,6 +1128,11 @@ class Slim {
      * @return void
      */
     public function run() {
+        //Clear any existing output buffer
+        if (ob_get_length() > 0) {
+            $this->response->write(ob_get_clean());
+        }
+
         set_error_handler(array('Slim', 'handleErrors'));
 
         //Apply final outer middleware layers

--- a/docs/routing-middleware.markdown
+++ b/docs/routing-middleware.markdown
@@ -41,9 +41,22 @@ If you are running PHP >= 5.3, you can get a bit more creative. Suppose you want
                 Slim::flash('error', 'Login required');
                 Slim::redirect('/login');
             }
-        }
-    }
+        };
+    };
     $app = new Slim();
     $app->get('/foo', $authenticateForRole('admin'), function () {
         //Display admin control panel
+    });
+
+## Are there any parameters passed to the Route Middleware callable?
+
+Yes.  The middleware callable is called with three parameters, `Slim_Http_Request`, `Slim_Http_Response` and the currently matched `Slim_Route`.
+
+    $aBitOfInfo = function ($request, $response, $route) {
+        $response->write(sprintf("We got %d GET/POST parameter(s)", count($request->params())));
+        echo "Current route is " . $route->getName();
+    };
+
+    $app->get('/foo', $aBitOfInfo, function () {
+        echo "foo";
     });

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -959,6 +959,27 @@ class SlimTest extends PHPUnit_Framework_TestCase {
         $s->run();
     }
 
+    /**
+     * Test that runner clears an existing output buffer when starting to run the application.
+     *
+     * This is most likely to happen when the evironment has output_buffering "On" which seems
+     * to be the default as of at least PHP 5.4+ (maybe earlier)
+     */
+    public function testRunWithOutputBufferingOnAndPrePopulated() {
+
+        //As of PHP 4.3.5 output_buffering is off by default in CLI mode so we need to explicitly start it by
+        //calling ob_start() since the unit tests are run in CLI mode.
+        ob_start();
+
+        $this->expectOutputString('debug_statement--Foo');
+        $s = new Slim();
+        echo "debug_statement--";
+        $s->get('/bar', function () use ($s) {
+            echo "Foo";
+        });
+        $s->run();
+    }
+
     /************************************************
      * MIDDLEWARE
      ************************************************/


### PR DESCRIPTION
Added comments for route middleware function parameters and fixed missing ";" for the examples above.
