### PR TITLE
Support for locals

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# Slim Framework for PHP 5
+# Slim Framework for PHP 5 [![Build Status](https://secure.travis-ci.org/peters/Slim.png?branch=master)](http://travis-ci.org/peters/Slim)
 
 Slim is a micro framework for PHP 5 that helps you quickly write simple yet powerful RESTful web applications and APIs. Slim is easy to use for both beginners and professionals. Slim favors cleanliness over terseness and common cases over edge cases. Its interface is simple, intuitive, and extensively documented — both online and in the code itself. Thank you for choosing Slim for your next project. I think you're going to love it.
 

--- a/Slim/Locals.php
+++ b/Slim/Locals.php
@@ -1,0 +1,146 @@
+<?php
+
+class Slim_Locals {
+
+	/**
+	 * @var array
+	 */
+	private $properties;
+
+ 	/**
+     * Constructor
+     *
+     * 
+     */
+    public function __construct() {
+    	$this->properties = array();
+    }
+	
+	/**
+	 * Get value of a local property
+	 * 
+	 * @param string $name Name of property
+	 * @return mixed|null Value of property, otherwise null.
+	 */
+	protected function get($name) {
+		return isset($this->properties[$name]) ? $this->properties[$name] : null;
+	}
+		
+	/**
+	 * Set value of a local property
+	 * 
+	 * @param string $name Name of property
+	 * @param mixed $value Value of property
+	 * @return mixed Actual value of assigned property
+	 */
+	protected function set($name, $value) {
+		$this->properties[$name] = $value;
+		return $value;
+	}
+	
+	/**
+	 * Prevent properties being added to class object
+	 * 
+	 * @param string $name 
+	 * @param mixed $value
+	 */
+	public function __set($name, $value) {}
+	
+	/**
+	 * Determines if the value of a local property is a callable
+	 * method
+	 * 
+	 * @param string $name Name of property
+	 * @return bool True if callable method, otherwise false.
+	 */
+	protected function isCallable($name) {
+	 	$fn = $this->get($name);
+		return $fn !== null && is_callable($fn);
+	}
+	
+	/**
+	 * Tries to locate a given property. Contents of the given property value
+	 * can either by any value type or a closure/lambda method.
+	 * 
+	 * If value is a method the remaining arguments will be passed to that method,
+	 * otherwise the actual value will be returned.
+	 * 
+	 * Please note that existing properties will be overwritten.
+	 * 
+	 * @param array $args Array of arguments
+	 * @return mixed|null
+	 */			
+	protected function parse($args) {
+			
+		// number of arguments available
+		$numArgs = count($args);
+	
+		// return all properties available
+		if( $numArgs === 0 ) {
+			return (object) $this->properties;
+		}
+	
+		// name of property
+		$name = $args[0];
+		
+		// does the property exist?
+		$exists = isset($this->properties[$name]);
+		
+		// return the value of existing property
+		if ( $numArgs === 1 ) {
+			return $this->get($name);
+		}
+	
+		// is property callable?
+		$existingIsCallable = $this->isCallable($name);
+		$currentIsCallable = is_callable($args[1]);
+					
+		// set new property if it does not exist
+		if (!$exists && $numArgs === 2) {
+			return $this->set($name, $args[1]);
+		}
+		
+		// overwrite existing property
+		if( $exists && !$existingIsCallable) {
+			return $this->set($name, $args[1]);
+		}
+		
+		// overwrite existing method
+		if( $exists && $currentIsCallable) {
+			return $this->set($name, $args[1]);
+		}	
+				
+		// call existing method with x number of arguments
+		if ( $exists && $existingIsCallable ) {
+			$fn = $this->get($name);
+		 	return call_user_func_array( $fn, array_slice( $args, 1 ));
+		} 
+				
+		return null;
+ 
+	}
+	
+	/**
+	 * Number of properties available.
+	 * 
+	 * @return integer Number of properties available. 
+	 */
+	public function count() {
+		return count ( $this->properties ); 
+	}
+	
+	/**
+	 * Allows access of properties to retrieved by local array index
+	 * and by calling `locals` as a derrived method.
+	 * 
+	 * @param string $name Name of method
+	 * @param array $args Array of arguments to pass to calling method
+	 * @return Exception|mixed
+	 */
+	public function __call($name, $args) {
+		if(is_callable(array($this, $name))) {
+            return call_user_func_array(array($this, $name), $args);
+        }
+	}
+	
+}

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -83,6 +83,11 @@ class Slim_Route {
      */
     protected $middleware = array();
 
+	/**
+	 * @var array List of permissions required to access a given route
+	 */
+	protected $permissions = array();
+
     /**
      * Constructor
      * @param   string  $pattern    The URL pattern (e.g. "/books/:id")
@@ -292,6 +297,14 @@ class Slim_Route {
         return $this->middleware;
     }
 
+	/**
+	 * Get route permissions
+	 * @return array List of required permissions
+	 */
+	public function getPermissions() {
+		return $this->permissions;
+	}
+
     /**
      * Set middleware
      *
@@ -388,6 +401,17 @@ class Slim_Route {
         $this->conditions = array_merge($this->conditions, $conditions);
         return $this;
     }
+	
+	/**
+	 * Permissions required to access given route
+	 * 
+	 * @param array $flags A list of flags required to access given route
+	 * @return Slim_Route
+	 */
+	public function permissions ( array $flags ) {
+		$this->permissions = $flags;
+		return $this;
+	}
 
     /**
      * Dispatch route

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -112,6 +112,16 @@ class Slim {
      */
     protected $middleware;
 
+	/**
+	 * @var mixed A callable object
+	 */
+	protected $authorizationFn;
+
+	/**
+	 * @var mixed A callable object
+	 */
+	protected $permissionFn;
+	
     /**
      * @var array
      */
@@ -159,6 +169,7 @@ class Slim {
         $this->settings = array_merge(self::getDefaultSettings(), $userSettings);
         $this->middleware = array($this);
 	    $this->locals = new Slim_Locals();
+		
         $this->add(new Slim_Middleware_Flash());
         $this->add(new Slim_Middleware_MethodOverride());
         //Determine application mode
@@ -569,6 +580,40 @@ class Slim {
 	 */
 	public function locals() {
 		return $this->locals->parse(func_get_args());	
+	}
+	
+	/**
+	 * Handles user level authorization
+	 * 
+	 * This method installs a hook before a request is dispatched so
+	 * that you can handle authorization from a single point of entry.
+	 * 
+	 * @param mixed $fn A callable object
+	 * @return void
+	 */
+	public function authorization( $fn ) {
+		if( is_callable( $fn )) {
+			$this->authorizationFn = $fn;
+			return;
+		}
+		throw new InvalidArgumentException("Slim::authorization first parameter must be a callable object");
+	}
+	
+	/**
+	 * Handles permissions for accessing a given route
+	 * 
+	 * This method installs a hook before a request is dispatched but
+	 * after authorization is handled.
+	 * 
+	 * @return mixed $fn A callable object
+	 * @return void
+	 */
+	public function permission ( $fn ) {
+		if( is_callable( $fn )) {
+			$this->permissionFn = $fn;
+			return;
+		}
+		throw new InvalidArgumentException("Slim::permission first parameter must be a callable object");		
 	}
 
     /** 
@@ -1151,6 +1196,12 @@ class Slim {
             foreach ( $this->router as $route ) {
                 if ( $route->supportsHttpMethod($this->environment['REQUEST_METHOD']) ) {
                     try {
+                    	if ( is_callable ( $this->authorizationFn )) {
+                    		call_user_func($this->authorizationFn, null);
+                    	}
+						if ( is_callable ( $this->permissionFn ) ) {
+                    		call_user_func($this->permissionFn, $route->getPermissions());
+						}
                         $this->applyHook('slim.before.dispatch');
                         $dispatched = $route->dispatch();
                         $this->applyHook('slim.after.dispatch');

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -158,9 +158,9 @@ class Slim {
         $this->router = new Slim_Router($this->request, $this->response);
         $this->settings = array_merge(self::getDefaultSettings(), $userSettings);
         $this->middleware = array($this);
+	    $this->locals = new Slim_Locals();
         $this->add(new Slim_Middleware_Flash());
         $this->add(new Slim_Middleware_MethodOverride());
-
         //Determine application mode
         $this->getMode();
 
@@ -453,7 +453,7 @@ class Slim {
      * to invoke an already-registered handler. If the handler has been
      * registered and is callable, it is invoked and sends a 404 HTTP Response
      * whose body is the output of the Not Found handler.
-     *
+     * 
      * @param   mixed $callable Anything that returns true for is_callable()
      * @return  void
      */
@@ -562,8 +562,16 @@ class Slim {
     public function router() {
         return $this->router;
     }
+			
+	/**
+	 * Get the Locals object
+	 * @return string|null 
+	 */
+	public function locals() {
+		return $this->locals->parse(func_get_args());	
+	}
 
-    /**
+    /** 
      * Get and/or set the View
      *
      * This method declares the View to be used by the Slim application.
@@ -979,7 +987,7 @@ class Slim {
             $this->environment['slim.flash']->keep();
         }
     }
-
+	
     /***** HOOKS *****/
 
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true">
+    <testsuites>
+        <testsuite name="Slim Framework Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/LocalsTest.php
+++ b/tests/LocalsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+set_include_path(dirname(__FILE__) . '/../' . PATH_SEPARATOR . get_include_path());
+
+require_once 'Slim/Locals.php';
+
+class LocalsTest extends PHPUnit_Framework_TestCase {
+		
+	public function setUp() {
+		$this->locals = new Slim_Locals();
+	}
+
+	public function locals() {
+		return $this->locals->parse(func_get_args());	
+	}
+	
+	public function testLocalsPropertiesCannotBeAssignedLocally() {
+		$this->locals->test = 123;
+		$this->assertTrue( !isset($this->locals->test) );
+	}
+	
+	public function testLocalsSetSimpleValue() {
+		$this->locals('test', 123);
+		$this->assertTrue( $this->locals('test') === 123 );
+	}
+	
+	public function testLocalsSetSimpleGetReturnValue() {
+		$rtn = $this->locals('test', 123);
+		$this->assertTrue($rtn === 123);
+	}
+	
+	public function testLocalsSetSimpleValueOverwrite() {
+		$this->locals('test', 123);
+		$this->locals('test', 124);
+		$this->assertTrue( $this->locals('test') === 124 );
+	}
+	
+	public function testLocalsSetSimpleValueMethod() {
+		$this->locals('eq', function($a, $b) {
+			return $a === $b;
+		});
+		$this->assertTrue( is_callable( $this->locals('eq' ) ) );		
+	}
+	
+	public function testLocalsReturnMethodBodyByKey() {
+		$this->locals('eq', function($a, $b) {
+			return $a === $b;
+		});
+		$this->assertTrue( is_callable( $this->locals('eq') ) );
+	}
+	
+	public function testLocalsSimpleValueMethod() {
+		$this->locals('eq', function($a, $b) {
+			return $a === $b;
+		});
+		$this->assertTrue( $this->locals('eq', 1, 1) );
+		$this->assertFalse( $this->locals('eq', 1, 2));	
+	}
+	
+	public function testLocalsOverwriteSimpleValueMethod() {
+		$this->locals('eq', function($a, $b) {
+			return $a === $b;
+		});	
+		$this->locals('eq', function($a, $b) {
+			return $a !== $b;
+		});
+		$this->assertFalse( $this->locals('eq', 1, 1) );
+		$this->assertTrue( $this->locals('eq', 1, 2));	
+	}
+	
+	public function testLocalsEmptyArgumentsShouldReturnAllValues() {
+		$this->locals('eq', function($a, $b) {
+			return $a === $b;
+		});
+		$this->locals('test', 123);
+		$this->locals('trolol', 12341);
+		$this->assertTrue( $this->locals->count() === 3);
+	}
+	
+	public function testOverwriteExistingValueWithMethod() {
+		$this->locals('test', 123);
+		$this->locals('test', function($a, $b) {
+			return $a === $b;
+		});
+		$this->assertTrue( is_callable($this->locals('test')) );
+	}
+	
+}

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -381,6 +381,24 @@ class RouteTest extends PHPUnit_Framework_TestCase {
         $this->assertArrayHasKey('id', $c);
         $this->assertArrayHasKey('name', $c);
     }
+	
+	/**
+	 * Test route permissions
+	 * 
+	 * Pre-conditions:
+	 * Route instantiated
+	 * 
+	 * Post-conditions:
+	 * Case A: Route instance has default permissions
+	 * 
+	 */
+	public function testRoutePermissions() {
+        $route = new Slim_Route('/hello/:first/and/:second', function () {});
+		$permissions = array( 1, 2, 3 );
+		$route->permissions( array( 1, 2, 3 ) );
+		//Case A
+		$this->assertEquals($permissions, $route->getPermissions());
+	}
 
     /**
      * Test route sets and gets middleware

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,24 @@
+# see http://about.travis-ci.org/docs/user/languages/php/ for more hints
+language: php
+
+php:
+
+  # aliased to 5.2.17
+  - 5.2
+
+  # aliased to a recent 5.3.x version
+  - 5.3
+
+# optionally specify a list of environments, for example to test different RDBMS
+env:
+
+# execute any number of scripts before the test run, custom env's are available as variables
+before_script:
+
+# omitting "script:" will default to phpunit
+# use the $DB env variable to determine the phpunit.xml to use
+script: phpunit tests/
+
+# configure notifications (email, IRC, campfire etc)
+notifications:
+  email: peter.sunde@gmail.com

--- a/travis.yml
+++ b/travis.yml
@@ -1,24 +1,8 @@
-# see http://about.travis-ci.org/docs/user/languages/php/ for more hints
 language: php
 
 php:
-
-  # aliased to 5.2.17
   - 5.2
-
-  # aliased to a recent 5.3.x version
   - 5.3
+  - 5.4
 
-# optionally specify a list of environments, for example to test different RDBMS
-env:
-
-# execute any number of scripts before the test run, custom env's are available as variables
-before_script:
-
-# omitting "script:" will default to phpunit
-# use the $DB env variable to determine the phpunit.xml to use
-script: phpunit tests/
-
-# configure notifications (email, IRC, campfire etc)
-notifications:
-  email: peter.sunde@gmail.com
+script: phpunit --coverage-text --verbose


### PR DESCRIPTION
A nice feature inspired by the express framework on how local variables should be exposed to views and other internal components. This component provides a simple way of doing so.

```

<?php
require 'Slim/Slim.php';
$app = new Slim();
$app->locals('name', function($lastname) {
   return "Peter $lastname";
});

$app->get('/hello/:name', function ($name) use($app) {
    echo "Hello, " . $app->locals('name', "Sunde"));
});
$app->run();
```
