### PR TITLE
Remove template var

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -44,11 +44,6 @@ class Slim_Route {
     protected $pattern;
 
     /**
-     * @var string The route template (e.g. "/books/:id") used with the `urlFor()` helper method
-     */
-    protected $template;
-
-    /**
      * @var mixed The route callable
      */
     protected $callable;
@@ -90,7 +85,6 @@ class Slim_Route {
      */
     public function __construct( $pattern, $callable ) {
         $this->setPattern($pattern);
-        $this->setTemplate($pattern);
         $this->setCallable($callable);
         $this->setConditions(self::getDefaultConditions());
     }
@@ -126,7 +120,7 @@ class Slim_Route {
      * @return  void
      */
     public function setPattern( $pattern ) {
-        $this->pattern = str_replace(')', ')?', (string)$pattern);
+        $this->pattern = $pattern;
     }
 
     /**
@@ -134,7 +128,7 @@ class Slim_Route {
      * @return  string
      */
     public function getTemplate() {
-        return $this->template;
+        return $this->pattern;
     }
 
     /**
@@ -143,7 +137,7 @@ class Slim_Route {
      * @return  void
      */
     public function setTemplate( $template ) {
-        $this->template = $template;
+        $this->pattern = $template;
     }
 
     /**
@@ -330,22 +324,23 @@ class Slim_Route {
      * @return  bool
      */
     public function matches( $resourceUri ) {
+        $pattern = str_replace(')', ')?', (string)$this->pattern);
         //Extract URL params
-        preg_match_all('@:([\w]+)|\*@', $this->pattern, $paramNames, PREG_PATTERN_ORDER);
+        preg_match_all('@:([\w]+)|\*@', $pattern, $paramNames, PREG_PATTERN_ORDER);
         $paramNames = $paramNames[0];
 
         // Convert * wildcards into regex patterns
         $wildcards = array_keys($paramNames, '*');
         if( !empty($wildcards) ) {
             foreach ( $wildcards as $key) {
-                $this->pattern = preg_replace('@(?<!\\\\)\*@', '(?P<slim_route_wildcard' . $key . '>[a-zA-Z0-9_\-\.\!\~\*\\\'\(\)\:\@\&\=\$\+,%/]+)', $this->pattern, 1);
+                $pattern = preg_replace('@(?<!\\\\)\*@', '(?P<slim_route_wildcard' . $key . '>[a-zA-Z0-9_\-\.\!\~\*\\\'\(\)\:\@\&\=\$\+,%/]+)', $pattern, 1);
                 $paramNames[$key] = ':slim_route_wildcard' . $key;
             }
         }
 
         //Convert URL params into regex patterns, construct a regex for this route
-        $patternAsRegex = preg_replace_callback('@:[\w]+@', array($this, 'convertPatternToRegex'), $this->pattern);
-        if ( substr($this->pattern, -1) === '/' ) {
+        $patternAsRegex = preg_replace_callback('@:[\w]+@', array($this, 'convertPatternToRegex'), $pattern);
+        if ( substr($pattern, -1) === '/' ) {
             $patternAsRegex = $patternAsRegex . '?';
         }
         $patternAsRegex = '@^' . $patternAsRegex . '$@';

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -124,23 +124,6 @@ class Slim_Route {
     }
 
     /**
-     * Get route template
-     * @return  string
-     */
-    public function getTemplate() {
-        return $this->pattern;
-    }
-
-    /**
-     * Set route template
-     * @param   string $template
-     * @return  void
-     */
-    public function setTemplate( $template ) {
-        $this->pattern = $template;
-    }
-
-    /**
      * Get route callable
      * @return mixed
      */
@@ -388,12 +371,12 @@ class Slim_Route {
     }
 
     /**
-     * Set route template
-     * @param string $template The route template, overrides the default route pattern
+     * Set route pattern
+     * @param string $template The route pattern, overrides the default route pattern
      * @return  Slim_Route
      */
-    public function template( $template ) {
-        $this->setTemplate($template);
+    public function pattern( $pattern ) {
+        $this->setPattern($pattern);
         return $this;
     }
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -129,7 +129,7 @@ class Slim_Router implements Iterator {
         if ( !$this->hasNamedRoute($name) ) {
             throw new RuntimeException('Named route not found for name: ' . $name);
         }
-        $pattern = $this->getNamedRoute($name)->getTemplate();
+        $pattern = $this->getNamedRoute($name)->getPattern();
         $search = $replace = array();
         foreach ( $params as $key => $value ) {
             $search[] = ':' . $key;

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -54,28 +54,28 @@ class RouteTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Route sets default template equal to pattern
+     * Route sets pattern with params
      */
-    public function testRouteSetsDefaultTemplate() {
+    public function testRouteSetsPatternWithParams() {
         $route = new Slim_Route('/hello/:first/:last', 'hello');
-        $this->assertEquals('/hello/:first/:last', $route->getTemplate());
+        $this->assertEquals('/hello/:first/:last', $route->getPattern());
     }
 
     /**
-     * Route sets custom template that overrides pattern
+     * Route sets custom pattern that overrides pattern
      */
-    public function testRouteSetsCustomTemplate() {
+    public function testRouteSetsCustomPattern() {
         $route = new Slim_Route('/hello/*', 'hello');
-        $route->setTemplate('/hello/:name');
-        $this->assertEquals('/hello/:name', $route->getTemplate());
+        $route->setPattern('/hello/:name');
+        $this->assertEquals('/hello/:name', $route->getPattern());
     }
 
     /**
-     * Route sets custom template with chainable alias method
+     * Route sets custom pattern with chainable alias method
      */
     public function testRouteSetsCustomTemplateWithChainableAlias() {
         $route = new Slim_Route('/hello/*', 'hello');
-        $this->assertSame($route, $route->template('/hello/:name'));
+        $this->assertSame($route, $route->pattern('/hello/:name'));
     }
 
     /**


### PR DESCRIPTION
The template var in the Route class doesn't seem to be needed at all.

The first commit removes the var only, keeping the setter and getter to avoid breaking apps using this methods. The second commit removes them too, the pattern setter/getter can be used instead.
