### PR TITLE
urlFor update

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -44,11 +44,6 @@ class Slim_Route {
     protected $pattern;
 
     /**
-     * @var string The route template (e.g. "/books/:id") used with the `urlFor()` helper method
-     */
-    protected $template;
-
-    /**
      * @var mixed The route callable
      */
     protected $callable;
@@ -90,7 +85,6 @@ class Slim_Route {
      */
     public function __construct( $pattern, $callable ) {
         $this->setPattern($pattern);
-        $this->setTemplate($pattern);
         $this->setCallable($callable);
         $this->setConditions(self::getDefaultConditions());
     }
@@ -127,23 +121,6 @@ class Slim_Route {
      */
     public function setPattern( $pattern ) {
         $this->pattern = $pattern;
-    }
-
-    /**
-     * Get route template
-     * @return  string
-     */
-    public function getTemplate() {
-        return $this->template;
-    }
-
-    /**
-     * Set route template
-     * @param   string $template
-     * @return  void
-     */
-    public function setTemplate( $template ) {
-        $this->template = $template;
     }
 
     /**
@@ -390,16 +367,6 @@ class Slim_Route {
      */
     public function name( $name ) {
         $this->setName($name);
-        return $this;
-    }
-
-    /**
-     * Set route template
-     * @param string $template The route template, overrides the default route pattern
-     * @return  Slim_Route
-     */
-    public function template( $template ) {
-        $this->setTemplate($template);
         return $this;
     }
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -126,7 +126,7 @@ class Slim_Route {
      * @return  void
      */
     public function setPattern( $pattern ) {
-        $this->pattern = str_replace(')', ')?', (string)$pattern);
+        $this->pattern = $pattern;
     }
 
     /**
@@ -330,22 +330,23 @@ class Slim_Route {
      * @return  bool
      */
     public function matches( $resourceUri ) {
+        $pattern = str_replace(')', ')?', (string)$this->pattern);
         //Extract URL params
-        preg_match_all('@:([\w]+)|\*@', $this->pattern, $paramNames, PREG_PATTERN_ORDER);
+        preg_match_all('@:([\w]+)|\*@', $pattern, $paramNames, PREG_PATTERN_ORDER);
         $paramNames = $paramNames[0];
 
         // Convert * wildcards into regex patterns
         $wildcards = array_keys($paramNames, '*');
         if( !empty($wildcards) ) {
             foreach ( $wildcards as $key) {
-                $this->pattern = preg_replace('@(?<!\\\\)\*@', '(?P<slim_route_wildcard' . $key . '>[a-zA-Z0-9_\-\.\!\~\*\\\'\(\)\:\@\&\=\$\+,%/]+)', $this->pattern, 1);
+                $pattern = preg_replace('@(?<!\\\\)\*@', '(?P<slim_route_wildcard' . $key . '>[a-zA-Z0-9_\-\.\!\~\*\\\'\(\)\:\@\&\=\$\+,%/]+)', $pattern, 1);
                 $paramNames[$key] = ':slim_route_wildcard' . $key;
             }
         }
 
         //Convert URL params into regex patterns, construct a regex for this route
-        $patternAsRegex = preg_replace_callback('@:[\w]+@', array($this, 'convertPatternToRegex'), $this->pattern);
-        if ( substr($this->pattern, -1) === '/' ) {
+        $patternAsRegex = preg_replace_callback('@:[\w]+@', array($this, 'convertPatternToRegex'), $pattern);
+        if ( substr($pattern, -1) === '/' ) {
             $patternAsRegex = $patternAsRegex . '?';
         }
         $patternAsRegex = '@^' . $patternAsRegex . '$@';

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -129,7 +129,20 @@ class Slim_Router implements Iterator {
         if ( !$this->hasNamedRoute($name) ) {
             throw new RuntimeException('Named route not found for name: ' . $name);
         }
-        $pattern = $this->getNamedRoute($name)->getTemplate();
+        $pattern = $this->getNamedRoute($name)->getPattern();
+
+        //Extract URL wildcards
+        preg_match_all('@(?<!\\\\)\*@', $pattern, $paramNames, PREG_PATTERN_ORDER);
+        $paramNames = $paramNames[0];
+
+        // Convert * wildcards into param patterns
+        $wildcards = array_keys($paramNames, '*');
+        if( !empty($wildcards) ) {
+            foreach ( $wildcards as $key) {
+                $pattern = preg_replace('@(?<!\\\\)\*@', ':splat' . $key, $pattern, 1);
+            }
+        }
+
         $search = $replace = array();
         foreach ( $params as $key => $value ) {
             $search[] = ':' . $key;

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -54,28 +54,20 @@ class RouteTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
-     * Route sets default template equal to pattern
+     * Route sets pattern with params
      */
-    public function testRouteSetsDefaultTemplate() {
+    public function testRouteSetsPatternWithParams() {
         $route = new Slim_Route('/hello/:first/:last', 'hello');
-        $this->assertEquals('/hello/:first/:last', $route->getTemplate());
+        $this->assertEquals('/hello/:first/:last', $route->getPattern());
     }
 
     /**
-     * Route sets custom template that overrides pattern
+     * Route sets custom pattern that overrides pattern
      */
     public function testRouteSetsCustomTemplate() {
         $route = new Slim_Route('/hello/*', 'hello');
-        $route->setTemplate('/hello/:name');
-        $this->assertEquals('/hello/:name', $route->getTemplate());
-    }
-
-    /**
-     * Route sets custom template with chainable alias method
-     */
-    public function testRouteSetsCustomTemplateWithChainableAlias() {
-        $route = new Slim_Route('/hello/*', 'hello');
-        $this->assertSame($route, $route->template('/hello/:name'));
+        $route->setPattern('/hello/:name');
+        $this->assertEquals('/hello/:name', $route->getPattern());
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -241,11 +241,14 @@ class RouterTest extends PHPUnit_Framework_TestCase {
         $route3 = $router->map('/foo/:one(/:two)', function () {})->via('GET');
         $route4 = $router->map('/foo/:one/(:two/)', function () {})->via('GET');
         $route5 = $router->map('/foo/:one/(:two/(:three/))', function () {})->via('GET');
+        $route6 = $router->map('/foo/*/bar', function (){})->via('GET');
         $route1->setName('route1');
         $route2->setName('route2');
         $route3->setName('route3');
         $route4->setName('route4');
         $route5->setName('route5');
+        $route6->setName('route6');
+        $route6->setTemplate('/foo/:foo/bar');
         //Route
         $this->assertEquals('/foo/bar', $router->urlFor('route1'));
         //Route with params
@@ -268,6 +271,8 @@ class RouterTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('/foo/:one/bar/', $router->urlFor('route5', array('two' => 'bar')));
         $this->assertEquals('/foo/:one/bar/what/', $router->urlFor('route5', array('two' => 'bar', 'three' => 'what')));
         $this->assertEquals('/foo/:one/', $router->urlFor('route5'));
+        //Route with wildcard params
+        $this->assertEquals('/foo/bar/bar', $router->urlFor('route6', array('foo'=>'bar')));
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -242,13 +242,16 @@ class RouterTest extends PHPUnit_Framework_TestCase {
         $route4 = $router->map('/foo/:one/(:two/)', function () {})->via('GET');
         $route5 = $router->map('/foo/:one/(:two/(:three/))', function () {})->via('GET');
         $route6 = $router->map('/foo/*/bar', function (){})->via('GET');
+        $route7 = $router->map('/foo/*/*/bar', function (){})->via('GET');
+        $route8 = $router->map('/foo/*', function (){})->via('GET');
         $route1->setName('route1');
         $route2->setName('route2');
         $route3->setName('route3');
         $route4->setName('route4');
         $route5->setName('route5');
         $route6->setName('route6');
-        $route6->setTemplate('/foo/:foo/bar');
+        $route7->setName('route7');
+        $route8->setName('route8');
         //Route
         $this->assertEquals('/foo/bar', $router->urlFor('route1'));
         //Route with params
@@ -272,7 +275,9 @@ class RouterTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('/foo/:one/bar/what/', $router->urlFor('route5', array('two' => 'bar', 'three' => 'what')));
         $this->assertEquals('/foo/:one/', $router->urlFor('route5'));
         //Route with wildcard params
-        $this->assertEquals('/foo/bar/bar', $router->urlFor('route6', array('foo'=>'bar')));
+        $this->assertEquals('/foo/bar/bar', $router->urlFor('route6', array('splat0'=>'bar')));
+        $this->assertEquals('/foo/foo/bar/bar', $router->urlFor('route7', array('splat0'=>'foo', 'splat1'=>'bar')));
+        $this->assertEquals('/foo/bar', $router->urlFor('route8', array('splat0'=>'bar')));
     }
 
     /**


### PR DESCRIPTION
This branch uses hardcoded values for the wildcard params in the urlFor method instead of the template var, it also removes the template var and its setter/getter methods from Route.

Please review the code and see if this is more convenient than what's in place.
