### PR TITLE
Make flash message types be arrays

### DIFF
--- a/Slim/Middleware/Flash.php
+++ b/Slim/Middleware/Flash.php
@@ -108,7 +108,7 @@ class Slim_Middleware_Flash extends Slim_Middleware implements ArrayAccess {
      * @return  void
      */
     public function set( $key, $value ) {
-        $this->messages['next'][(string)$key] = $value;
+        $this->messages['next'][(string)$key][] = $value;
     }
 
     /**


### PR DESCRIPTION
In a new Slim project, I found need to send several 'info' level messages to the user, but found that `$app->flash('info', 'blah');` only stores the most recent value.  I find it more useful if `$flash['info']` is an array.

My specific use-case is sending the messages "Thank you for registering" and "You have successfully Logged in" as "info" level flash messages. I know this breaks the current API/behavior, so you may have objections to the addition.

If you are fine with the change, I'll throw in a test or two, along with documentation changes, and you can merge the request at your leisure.  Otherwise, I guess I'll extend `Slim_Middleware_Flash` within my application and change just the one method ;).

Let me know what you think.
