### PR TITLE
Revision to suggested .htaccess content

### DIFF
--- a/docs/routing-indepth-with-rewrite.markdown
+++ b/docs/routing-indepth-with-rewrite.markdown
@@ -16,8 +16,12 @@ Here is an example directory structure:
 The **.htaccess** file in the directory structure above contains:
 
     RewriteEngine On
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^(.*)$ index.php [QSA,L]
+    RewriteBase /
+    RewriteRule ^index\.php$ - [L]
+    RewriteCond %{REQUEST_FILENAME} -f [OR]
+    RewriteCond %{REQUEST_FILENAME} -d
+    RewriteRule ^ - [L]
+    RewriteRule . index.php [L]
 
 As a result, Apache will send all requests for non-existent files to my **index.php** script in which I instantiate and run my Slim application. With URL rewriting enabled and assuming the following Slim application is defined in **index.php**, you can access the application route below at "/foo" rather than "/index.php/foo".
 


### PR DESCRIPTION
On my local test system (MacBook Pro, OS 10.7.4, running built-in Apache 2.2.21 and built-in PHP 5.3.10), I use symlinks from a ~/www folder to my repository folders, and something about the symlink part of this (I think) breaks with the .htaccess as specified by your docs, but doesn't break using the .htaccess content above (which is from WordPress). This .htaccess snip also works in my production environment, which is (for now) a free slice on Pagoda.
