### PR TITLE
Allow flash object to be iterated over

### DIFF
--- a/Slim/Middleware/Flash.php
+++ b/Slim/Middleware/Flash.php
@@ -44,7 +44,7 @@
   * @author     Josh Lockhart
   * @since      1.6.0
   */
-class Slim_Middleware_Flash extends Slim_Middleware implements ArrayAccess {
+class Slim_Middleware_Flash extends Slim_Middleware implements ArrayAccess, IteratorAggregate {
     /**
      * @var array
      */
@@ -181,5 +181,13 @@ class Slim_Middleware_Flash extends Slim_Middleware implements ArrayAccess {
      */
     public function offsetUnset( $offset ) {
         unset($this->messages['prev'][$offset], $this->messages['now'][$offset]);
+    }
+
+    /**
+     * Iterator Aggregate: Get Iterator
+     */
+    public function getIterator() {
+        $messages = $this->getMessages();
+        return new ArrayIterator($messages);
     }
 }

--- a/tests/Middleware/FlashTest.php
+++ b/tests/Middleware/FlashTest.php
@@ -107,4 +107,19 @@ class SlimFlashTest extends PHPUnit_Framework_TestCase {
         unset($f['info']);
         $this->assertFalse(isset($f['info']));
     }
+
+    /**
+     * Test iteration
+     */
+    public function testIteration() {
+        $_SESSION['slim.flash'] = array('info' => 'foo', 'error' => 'bar');
+        $f = new Slim_Middleware_Flash();
+        $f->loadMessages();
+        $output = '';
+        foreach ( $f as $key => $value ) {
+            $output .= $key . $value;
+        }
+        $this->assertEquals('infofooerrorbar', $output);
+    }
+
 }


### PR DESCRIPTION
Typically when I display flash messages I like to do something like:

``` php
<?php
foreach ( $flash as $key => $message) {
    echo "<div class='{$key}'>{$message}</div>";
}
```

This patch adds IteratorAggregate to Slim_Middleware_Flash to allow iterating on the messages. I also added a test for it.
