### PR TITLE
Changes in Slim::getInstance and (optional) htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,5 +6,13 @@ RewriteEngine On
 #
 # RewriteBase /
 
+# This one was tested in Apache with VirtualDocumentRoot + ModAlias environment
+# The first rewritecond will catch the relative path while the %1 added to the rewrite rule will apply it.
+# It assumes you're using only letters and numbers as your route
+#RewriteBase /
+#RewriteCond %{REQUEST_URI} (.+)/(\w+)$
+#RewriteCond %{REQUEST_FILENAME} !-f
+#RewriteRule ^   %1/index.php [QSA,L]
+
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^ index.php [QSA,L]

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -189,10 +189,11 @@ class Slim {
     /**
      * Get Slim application instance by name
      * @param   string      $name The name of the Slim application to fetch
+     * @param   boolean $create determines wether it should create a new slim instance when there is no current one
      * @return  Slim|null
      */
-    public static function getInstance( $name = 'default' ) {
-        return isset(self::$apps[$name]) ? self::$apps[$name] : null;
+    public static function getInstance( $name = 'default', $create=false ) {
+        return isset(self::$apps[$name]) ? self::$apps[$name] : ($create ? new Slim($name) :null);
     }
 
     /**


### PR DESCRIPTION
.htaccess tested in Apache with VirtualDocumentRoot and Mod Alias
Slim::getInstance offers the option to create the instance if there isn't one
