### PR TITLE
VirtualDocumentRoot support and optional create instance when there isn't (fixed LF)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,6 +5,10 @@ RewriteEngine On
 # absolute physical path to the directory that contains this htaccess file.
 #
 # RewriteBase /
-
+# The first rewritecond will catch the relative path while the %1 added to the rewrite rule will apply it.
+# It assumes you're using only letters and numbers as your route
+#RewriteCond %{REQUEST_URI} (.+)/(\w+)$
+#RewriteCond %{REQUEST_FILENAME} !-f
+#RewriteRule ^   %1/index.php [QSA,L]
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^ index.php [QSA,L]

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -189,10 +189,11 @@ class Slim {
     /**
      * Get Slim application instance by name
      * @param   string      $name The name of the Slim application to fetch
+     * @param   boolean $create determines wether it should create a new slim instance when there is no current one
      * @return  Slim|null
      */
-    public static function getInstance( $name = 'default' ) {
-        return isset(self::$apps[$name]) ? self::$apps[$name] : null;
+    public static function getInstance( $name = 'default', $create=false ) {
+                return isset(self::$apps[$name]) ? self::$apps[$name] : ($create ? new Slim($name) :null);
     }
 
     /**


### PR DESCRIPTION
**.htaccess** for [VirtualDocumentRoot](http://httpd.apache.org/docs/2.2/mod/mod_vhost_alias.html#virtualdocumentroot) and or [mod_alias](http://httpd.apache.org/docs/2.2/mod/mod_alias.html)  (in case you don't know which path you'll run on)

**Slim.php** adds optional _$create_ parameter, default false. If true, it will create a new Slim instance if there isn't one.
