### PR TITLE
Simplify router and delay uri pass

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -155,7 +155,7 @@ class Slim_Router {
         //Invoke middleware
         foreach ( $route->getMiddleware() as $mw ) {
             if ( is_callable($mw) ) {
-                call_user_func($mw);
+                call_user_func($mw, $route);
             }
         }
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -41,12 +41,7 @@
  * @author  Josh Lockhart
  * @since   1.0.0
  */
-class Slim_Router implements Iterator {
-    /**
-     * @var string Request URI
-     */
-    protected $resourceUri;
-
+class Slim_Router {
     /**
      * @var array Lookup hash of all routes
      */
@@ -74,31 +69,21 @@ class Slim_Router implements Iterator {
 
     /**
      * Constructor
-     * @param   string   $resourceUri    The request URI
      */
-    public function __construct( $resourceUri ) {
-        $this->resourceUri = $resourceUri;
+    public function __construct() {
         $this->routes = array();
     }
 
     /**
-     * Get Current Route
-     * @return Slim_Route|false
-     */
-    public function getCurrentRoute() {
-        $this->getMatchedRoutes(); // <-- Parse if not already parsed
-        return $this->current();
-    }
-
-    /**
      * Return routes that match the current request
+     * @param   string   $resourceUri    The request URI to match against
      * @return array[Slim_Route]
      */
-    public function getMatchedRoutes( $reload = false ) {
+    public function getMatchedRoutes( $resourceUri, $reload = false ) {
         if ( $reload || is_null($this->matchedRoutes) ) {
             $this->matchedRoutes = array();
             foreach ( $this->routes as $route ) {
-                if ( $route->matches($this->resourceUri) ) {
+                if ( $route->matches($resourceUri) ) {
                     $this->matchedRoutes[] = $route;
                 }
             }
@@ -157,12 +142,13 @@ class Slim_Router implements Iterator {
      * slash, the route will not be matched and a 404 Not Found
      * response will be sent if no subsequent matching routes are found.
      *
-     * @param   Slim_Route          $route  The route object
+     * @param   Slim_Route          $route        The route object
+     * @param   string              $resourceUri  The request URI that was matched
      * @return  bool Was route callable invoked successfully?
      * @throws  Slim_Exception_RequestSlash
      */
-    public function dispatch( Slim_Route $route ) {
-        if ( substr($route->getPattern(), -1) === '/' && substr($this->resourceUri, -1) !== '/' ) {
+    public function dispatch( Slim_Route $route, $resourceUri ) {
+        if ( substr($route->getPattern(), -1) === '/' && substr($resourceUri, -1) !== '/' ) {
             throw new Slim_Exception_RequestSlash();
         }
 
@@ -257,45 +243,5 @@ class Slim_Router implements Iterator {
             $this->error = $callable;
         }
         return $this->error;
-    }
-
-    /**
-     * Iterator Interface: Rewind
-     * @return void
-     */
-    public function rewind() {
-        reset($this->matchedRoutes);
-    }
-
-    /**
-     * Iterator Interface: Current
-     * @return Slim_Route|false
-     */
-    public function current() {
-        return current($this->matchedRoutes);
-    }
-
-    /**
-     * Iterator Interface: Key
-     * @return int|null
-     */
-    public function key() {
-        return key($this->matchedRoutes);
-    }
-
-    /**
-     * Iterator Interface: Next
-     * @return void
-     */
-    public function next() {
-        next($this->matchedRoutes);
-    }
-
-    /**
-     * Iterator Interface: Valid
-     * @return boolean
-     */
-    public function valid() {
-        return $this->current();
     }
 }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -147,7 +147,7 @@ class Slim {
         $this->environment = Slim_Environment::getInstance();
         $this->request = new Slim_Http_Request($this->environment);
         $this->response = new Slim_Http_Response();
-        $this->router = new Slim_Router($this->request->getResourceUri());
+        $this->router = new Slim_Router();
         $this->settings = array_merge(self::getDefaultSettings(), $userSettings);
         $this->middleware = array($this);
         $this->add(new Slim_Middleware_Flash());
@@ -1133,12 +1133,11 @@ class Slim {
             $this->applyHook('slim.before.router');
             $dispatched = false;
             $httpMethodsAllowed = array();
-            $this->router->getMatchedRoutes();
-            foreach ( $this->router as $route ) {
+            foreach ( $this->router->getMatchedRoutes($this->request->getResourceUri()) as $route ) {
                 if ( $route->supportsHttpMethod($this->environment['REQUEST_METHOD']) ) {
                     try {
                         $this->applyHook('slim.before.dispatch');
-                        $dispatched = $this->router->dispatch($route);
+                        $dispatched = $this->router->dispatch($route, $this->request->getResourceUri());
                         $this->applyHook('slim.after.dispatch');
                         if ( $dispatched ) {
                             break;

--- a/docs/routing-middleware.markdown
+++ b/docs/routing-middleware.markdown
@@ -50,13 +50,12 @@ If you are running PHP >= 5.3, you can get a bit more creative. Suppose you want
 
 ## Are there any parameters passed to the Route Middleware callable?
 
-Yes.  The middleware callable is called with three parameters, `Slim_Http_Request`, `Slim_Http_Response` and the currently matched `Slim_Route`.
+Yes.  The middleware callable is called with one parameter, the currently matched `Slim_Route`.
 
-    $aBitOfInfo = function ($request, $response, $route) {
-        $response->write(sprintf("We got %d GET/POST parameter(s)", count($request->params())));
+    $aBitOfInfo = function ($route) {
         echo "Current route is " . $route->getName();
     };
 
     $app->get('/foo', $aBitOfInfo, function () {
         echo "foo";
-    });
+    })->name('fooRoute');

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -64,7 +64,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      * even if no params data is provided.
      */
     public function testUrlForNamedRouteWithoutParams() {
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $route = $router->map('/foo/bar', function () {})->via('GET');
         $router->addNamedRoute('foo', $route);
         $this->assertEquals('/foo/bar', $router->urlFor('foo'));
@@ -75,7 +75,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      * param data is provided.
      */
     public function testUrlForNamedRouteWithParams() {
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $route = $router->map('/foo/:one/and/:two', function ($one, $two) {})->via('GET');
         $router->addNamedRoute('foo', $route);
         $this->assertEquals('/foo/Josh/and/John', $router->urlFor('foo', array('one' => 'Josh', 'two' => 'John')));
@@ -87,7 +87,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      */
     public function testUrlForNamedRouteThatDoesNotExist() {
         $this->setExpectedException('RuntimeException');
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $route = $router->map('/foo/bar', function () {})->via('GET');
         $router->addNamedRoute('bar', $route);
         $router->urlFor('foo');
@@ -99,7 +99,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      */
     public function testNamedRouteWithExistingName() {
         $this->setExpectedException('RuntimeException');
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $route1 = $router->map('/foo/bar', function () {})->via('GET');
         $route2 = $router->map('/foo/bar/2', function () {})->via('GET');
         $router->addNamedRoute('bar', $route1);
@@ -118,7 +118,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      * Non-existant route found not to exist;
      */
     public function testHasNamedRoute() {
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $route = $router->map('/foo', function () {})->via('GET');
         $router->addNamedRoute('foo', $route);
         $this->assertTrue($router->hasNamedRoute('foo'));
@@ -137,7 +137,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      * NULL is returned if named route does not exist;
      */
     public function testGetNamedRoute() {
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $route1 = $router->map('/foo', function () {})->via('GET');
         $router->addNamedRoute('foo', $route1);
         $this->assertSame($route1, $router->getNamedRoute('foo'));
@@ -155,7 +155,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      * Array iterator returned for named routes;
      */
     public function testGetNamedRoutes() {
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $route1 = $router->map('/foo', function () {})->via('GET');
         $route2 = $router->map('/bar', function () {})->via('POST');
         $router->addNamedRoute('foo', $route1);
@@ -169,7 +169,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      * Router should keep reference to a callable NotFound callback
      */
     public function testNotFoundHandler() {
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $notFoundCallback = function () { echo "404"; };
         $callback = $router->notFound($notFoundCallback);
         $this->assertSame($notFoundCallback, $callback);
@@ -179,7 +179,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      * Router should NOT keep reference to a callback that is not callable
      */
     public function testNotFoundHandlerIfNotCallable() {
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $notFoundCallback = 'foo';
         $callback = $router->notFound($notFoundCallback);
         $this->assertNull($callback);
@@ -189,7 +189,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      * Router should keep reference to a callable NotFound callback
      */
     public function testErrorHandler() {
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $errCallback = function () { echo "404"; };
         $callback = $router->error($errCallback);
         $this->assertSame($errCallback, $callback);
@@ -199,7 +199,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      * Router should NOT keep reference to a callback that is not callable
      */
     public function testErrorHandlerIfNotCallable() {
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $errCallback = 'foo';
         $callback = $router->error($errCallback);
         $this->assertNull($callback);
@@ -225,9 +225,9 @@ class RouterTest extends PHPUnit_Framework_TestCase {
         $this->env = Slim_Environment::getInstance();
         $this->req = new Slim_Http_Request($this->env);
         $this->res = new Slim_Http_Response();
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $route = $router->map('/bar', function () {})->via('GET', 'HEAD');
-        $numberOfMatchingRoutes = count($router->getMatchedRoutes());
+        $numberOfMatchingRoutes = count($router->getMatchedRoutes($this->req->getResourceUri()));
         $this->assertEquals(1, $numberOfMatchingRoutes);
     }
 
@@ -235,7 +235,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
      * Router::urlFor
      */
     public function testRouterUrlFor() {
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $route1 = $router->map('/foo/bar', function () {})->via('GET');
         $route2 = $router->map('/foo/:one/:two', function () {})->via('GET');
         $route3 = $router->map('/foo/:one(/:two)', function () {})->via('GET');
@@ -306,32 +306,12 @@ class RouterTest extends PHPUnit_Framework_TestCase {
         $this->env = Slim_Environment::getInstance();
         $this->req = new Slim_Http_Request($this->env);
         $this->res = new Slim_Http_Response();
-        $router = new Slim_Router($this->req->getResourceUri());
+        $router = new Slim_Router();
         $router->map('/foo', function () {})->via('GET');
         $router->map('/foo', function () {})->via('POST');
         $router->map('/foo', function () {})->via('PUT');
         $router->map('/foo/bar/xyz', function () {})->via('DELETE');
-        $this->assertEquals(3, count($router->getMatchedRoutes()));
-    }
-
-    /**
-     * Test get current route
-     */
-    public function testGetCurrentRoute() {
-        Slim_Environment::mock(array(
-            'REQUEST_METHOD' => 'GET',
-            'SCRIPT_NAME' => '', //<-- Physical
-            'PATH_INFO' => '/foo' //<-- Virtual
-        ));
-        $app = new Slim();
-        $route1 = $app->get('/bar', function () {
-            echo "Bar";
-        });
-        $route2 = $app->get('/foo', function () {
-            echo "Foo";
-        });
-        $app->call();
-        $this->assertSame($route2, $app->router()->getCurrentRoute());
+        $this->assertEquals(3, count($router->getMatchedRoutes($this->req->getResourceUri())));
     }
 
     public function testDispatch() {
@@ -351,13 +331,13 @@ class RouterTest extends PHPUnit_Framework_TestCase {
         ));
         $env = Slim_Environment::getInstance();
         $req = new Slim_Http_Request($env);
-        $router = new Slim_Router($req->getResourceUri());
+        $router = new Slim_Router();
         $route = new Slim_Route('/hello/:name', function ($name) { echo "Hello $name"; });
         $route->matches($req->getResourceUri()); //<-- Extracts params from resource URI
-        $router->dispatch($route);
+        $router->dispatch($route, $req->getResourceUri());
     }
 
-    public function testDispatchWithMiddlware() {
+    public function testDispatchWithMiddleware() {
         $this->expectOutputString('First! Second! Hello josh');
         Slim_Environment::mock(array(
             'REQUEST_METHOD' => 'GET',
@@ -374,7 +354,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
         ));
         $env = Slim_Environment::getInstance();
         $req = new Slim_Http_Request($env);
-        $router = new Slim_Router($req->getResourceUri());
+        $router = new Slim_Router();
         $route = new Slim_Route('/hello/:name', function ($name) { echo "Hello $name"; });
         $route->setMiddleware(function () {
             echo "First! ";
@@ -383,7 +363,7 @@ class RouterTest extends PHPUnit_Framework_TestCase {
             echo "Second! ";
         });
         $route->matches($req->getResourceUri()); //<-- Extracts params from resource URI
-        $router->dispatch($route);
+        $router->dispatch($route, $req->getResourceUri());
     }
 
     public function testDispatchWithRequestSlash() {
@@ -403,10 +383,10 @@ class RouterTest extends PHPUnit_Framework_TestCase {
         ));
         $env = Slim_Environment::getInstance();
         $req = new Slim_Http_Request($env);
-        $router = new Slim_Router($req->getResourceUri());
+        $router = new Slim_Router();
         $route = new Slim_Route('/hello/:name/', function ($name) { echo "Hello $name"; });
         $route->matches($req->getResourceUri()); //<-- Extracts params from resource URI
-        $router->dispatch($route);
+        $router->dispatch($route, $req->getResourceUri());
     }
 
     public function testDispatchWithoutCallable() {
@@ -425,9 +405,9 @@ class RouterTest extends PHPUnit_Framework_TestCase {
         ));
         $env = Slim_Environment::getInstance();
         $req = new Slim_Http_Request($env);
-        $router = new Slim_Router($req);
+        $router = new Slim_Router();
         $route = new Slim_Route('/hello/:name', 'foo');
         $route->matches($req->getResourceUri()); //<-- Extracts params from resource URI
-        $this->assertFalse($router->dispatch($route));
+        $this->assertFalse($router->dispatch($route, $req->getResourceUri()));
     }
 }


### PR DESCRIPTION
- Simplified the router and its interface.
- Delayed the passing of the URI until matching is required which allows hooks to modify the requested URI.
- Added route as parameter for route middleware.  Added test.  I think not sending request and response is ok as well since nothing else (routes, hooks etc) do that.  The user can always use ($app) and get it themselves.

Note the request URI is passed into the `router::dispatch()` method.  I am not a fan of this but I left it as is and will chat with you tomorrow with 2 changes that will easily remedy this.
