### PR TITLE
Fix redirect to set Location header only and leave body untouched.

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -923,8 +923,7 @@ class Slim {
      * this issues a 302 Found response; this is considered the default
      * generic redirect response. You may also specify another valid
      * 3xx status code if you want. This method will automatically set the
-     * HTTP Location header for you using the URL parameter and place the
-     * destination URL into the response body.
+     * HTTP Location header for you using the URL parameter.
      *
      * @param   string    $url        The destination URL
      * @param   int       $status     The HTTP redirect status code (Optional)
@@ -932,7 +931,7 @@ class Slim {
      */
     public function redirect( $url, $status = 302 ) {
         $this->response->redirect($url, $status);
-        $this->halt($status, $url); }
+        $this->halt($status); }
 
     /***** FLASH *****/
 

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -1006,7 +1006,7 @@ class SlimTest extends PHPUnit_Framework_TestCase {
         list($status, $header, $body) = $s->response()->finalize();
         $this->assertEquals(303, $status);
         $this->assertEquals('/somewhere/else', $header['Location']);
-        $this->assertEquals('/somewhere/else', $body);
+        $this->assertEquals('', $body);
     }
 
     /************************************************


### PR DESCRIPTION
Slim::redirect right now is kind of weird by returning the url in the body. That is like saying "i don't care of what is in the body, so let's put the url instead of nothing". But actually the Location header can be used in responses that need to have a body, especially when designing API.

e.g.
303 See others with representation of the resource in the body and Location pointing to other resources or
201 Created, with representation of the resource in the body and Location pointing to the canonical URL.

I changed it to leave the body alone. This may break compatibility but on a feature i don't think anyone is relying on. Maybe just in tests, but then again they should be checking the Location header directly, not the body.
