### PR TITLE
handle return values from handlers and improve exceptions handling

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -200,7 +200,7 @@ class Slim_Http_Response implements ArrayAccess, Countable, IteratorAggregate {
      */
     public function write( $body, $replace = false ) {
         if ( $replace ) {
-            $this->body = $body;
+            $this->body = (string)$body;
         } else {
             $this->body .= (string)$body;
         }

--- a/Slim/Middleware/PrettyExceptions.php
+++ b/Slim/Middleware/PrettyExceptions.php
@@ -87,6 +87,7 @@ class Slim_Middleware_PrettyExceptions extends Slim_Middleware {
         $html = sprintf('<h1>%s</h1>', $title);
         $html .= '<p>The application could not run because of the following error:</p>';
         $html .= '<h2>Details</h2>';
+        $html .= sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
         if ( $code ) {
             $html .= sprintf('<div><strong>Code:</strong> %s</div>', $code);
         }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -38,6 +38,8 @@ if ( !defined('MCRYPT_MODE_CBC') ) {
     define('MCRYPT_MODE_CBC', 0);
 }
 
+require('exceptions.php');
+
 // Comment out this line if you are using an alternative autoloader (e.g. Composer)
 Slim::registerAutoloader();
 

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -458,15 +458,30 @@ class Slim {
         if ( !is_null($callable) ) {
             $this->router->notFound($callable);
         } else {
-            ob_start();
-            $customNotFoundHandler = $this->router->notFound();
-            if ( is_callable($customNotFoundHandler) ) {
-                call_user_func($customNotFoundHandler);
-            } else {
-                call_user_func(array($this, 'defaultNotFound'));
-            }
-            $this->halt(404, ob_get_clean());
+            $this->response->status(404);
+            $this->response->write($this->callNotFoundHandler(), true);
+            $this->stop();
         }
+    }
+
+    /**
+     * Call NotFound handler
+     *
+     * This will invoke the custom or default Not Found handler
+     * and RETURN its output.
+     *
+     * @return  string
+     */
+    protected function callNotFoundHandler() {
+        ob_start();
+        $customNotFoundHandler = $this->router->notFound();
+        if ( is_callable($customNotFoundHandler) ) {
+            $result = (string)call_user_func($customNotFoundHandler);
+        } else {
+            $result = (string)call_user_func(array($this, 'defaultNotFound'));
+        }
+        // return stuff that get echoed and then the result.
+        return ob_get_clean() . $result;
     }
 
     /**

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1171,11 +1171,12 @@ class Slim {
             $dispatched = false;
             $httpMethodsAllowed = array();
             $this->router->getMatchedRoutes();
+            $result = '';
             foreach ( $this->router as $route ) {
                 if ( $route->supportsHttpMethod($this->environment['REQUEST_METHOD']) ) {
                     try {
                         if ( substr($route->getPattern(), -1) === '/' &&
-                             substr($this->resourceUri, -1) !== '/' ) {
+                             substr($this->request->getResourceUri(), -1) !== '/' ) {
                             throw new Slim_Exception_RequestSlash();
                         }
                         //Invoke middleware

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -31,6 +31,13 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+if ( !defined('MCRYPT_RIJNDAEL_256') ) {
+    define('MCRYPT_RIJNDAEL_256', 0);
+}
+if ( !defined('MCRYPT_MODE_CBC') ) {
+    define('MCRYPT_MODE_CBC', 0);
+}
+
 // Comment out this line if you are using an alternative autoloader (e.g. Composer)
 Slim::registerAutoloader();
 

--- a/Slim/exceptions.php
+++ b/Slim/exceptions.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     1.6.5
+ * @package     Slim
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * prettyException
+ *
+ * This function displays Exception in a developer-friendly way
+ *
+ * @package Slim
+ * @author  Josh Lockhart
+ * @param Exception
+ * @since TODO
+ */
+
+function prettyException( $exception ) {
+    $title = 'Slim Application Error';
+    $code = $exception->getCode();
+    $message = $exception->getMessage();
+    $file = $exception->getFile();
+    $line = $exception->getLine();
+    $trace = $exception->getTraceAsString();
+    $html = sprintf('<h1>%s</h1>', $title);
+    $html .= '<p>The application could not run because of the following error:</p>';
+    $html .= '<h2>Details</h2>';
+    $html .= sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
+    if ( $code ) {
+        $html .= sprintf('<div><strong>Code:</strong> %s</div>', $code);
+    }
+    if ( $message ) {
+        $html .= sprintf('<div><strong>Message:</strong> %s</div>', $message);
+    }
+    if ( $file ) {
+        $html .= sprintf('<div><strong>File:</strong> %s</div>', $file);
+    }
+    if ( $line ) {
+        $html .= sprintf('<div><strong>Line:</strong> %s</div>', $line);
+    }
+    if ( $trace ) {
+        $html .= '<h2>Trace</h2>';
+        $html .= sprintf('<pre>%s</pre>', $trace);
+    }
+    return sprintf("<html><head><title>%s</title><style>body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana,sans-serif;}h1{margin:0;font-size:48px;font-weight:normal;line-height:48px;}strong{display:inline-block;width:65px;}</style></head><body>%s</body></html>", $title, $html);
+}


### PR DESCRIPTION
Data returned by handlers added by Slim::error Slim::notFound and routes are processed as strings and append at the end for the body (because return is always after someone put echo in route handler).

Slim::error is now exception handler and accept Exception as argument (Forget to put that information into comements)

I removed Slim_Middleware_PrettyExceptions middleware put that code into a function (in exception.php maybe it need to be put elsewhere or change to a method in Slim class). 

Exceptions are handled in this way
- if user don't define error handler via Slim::exception it will exceute defaultError or prettyException depending on config('debug')
- if user define handler it will overwrite this check.
  Also exceptions from user exception handler are cached and the default handler is exectued (defaulError or prettyException).

Also in order to intercept data returned from handlers I needed to put the code that was in Router::dispatch (it's now dead code, I didn't remove it) into Slim::call where it was executed, this probably fix also the issue with `slim.before.dispatch` and  `slim.after.dispatch` which was executed even if handler was not exected (dispatched).
