### PR TITLE
Treat objects returned from handlers as strings

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -200,7 +200,7 @@ class Slim_Http_Response implements ArrayAccess, Countable, IteratorAggregate {
      */
     public function write( $body, $replace = false ) {
         if ( $replace ) {
-            $this->body = $body;
+            $this->body = (string)$body;
         } else {
             $this->body .= (string)$body;
         }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1154,6 +1154,7 @@ class Slim {
             foreach ( $this->router as $route ) {
                 if ( $route->supportsHttpMethod($this->environment['REQUEST_METHOD']) ) {
                     try {
+                        $this->applyHook('slim.before.dispatch');
                         if ( substr($route->getPattern(), -1) === '/' &&
                              substr($this->request->getResourceUri(), -1) !== '/' ) {
                             throw new Slim_Exception_RequestSlash();
@@ -1164,7 +1165,6 @@ class Slim {
                                 call_user_func($mw);
                             }
                         }
-                        $this->applyHook('slim.before.dispatch');
                         // Invoke route handler
                         if ( is_callable($route->getCallable()) ) {
                             $args = array_values($route->getParams());

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -527,11 +527,11 @@ class Slim {
         ob_start();
         $customErrorHandler = $this->router->error();
         if ( is_callable($customErrorHandler) ) {
-            call_user_func_array($customErrorHandler, array($argument));
+            $result = (string)call_user_func_array($customErrorHandler, array($argument));
         } else {
-            call_user_func_array(array($this, 'defaultError'), array($argument));
+            $result = (string)call_user_func_array(array($this, 'defaultError'), array($argument));
         }
-        return ob_get_clean();
+        return ob_get_clean() . $result;
     }
 
     /***** ACCESSORS *****/

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -451,15 +451,30 @@ class Slim {
         if ( !is_null($callable) ) {
             $this->router->notFound($callable);
         } else {
-            ob_start();
-            $customNotFoundHandler = $this->router->notFound();
-            if ( is_callable($customNotFoundHandler) ) {
-                call_user_func($customNotFoundHandler);
-            } else {
-                call_user_func(array($this, 'defaultNotFound'));
-            }
-            $this->halt(404, ob_get_clean());
+            $this->response->status(404);
+            $this->response->write($this->callNotFoundHandler(), true);
+            $this->stop();
         }
+    }
+
+    /**
+     * Call NotFound handler
+     *
+     * This will invoke the custom or default Not Found handler
+     * and RETURN its output.
+     *
+     * @return  string
+     */
+    protected function callNotFoundHandler() {
+        ob_start();
+        $customNotFoundHandler = $this->router->notFound();
+        if ( is_callable($customNotFoundHandler) ) {
+            $result = (string)call_user_func($customNotFoundHandler);
+        } else {
+            $result = (string)call_user_func(array($this, 'defaultNotFound'));
+        }
+        // return stuff that get echoed and then the result.
+        return ob_get_clean() . $result;
     }
 
     /**
@@ -1134,13 +1149,29 @@ class Slim {
             $dispatched = false;
             $httpMethodsAllowed = array();
             $this->router->getMatchedRoutes();
+            $result = '';
+            $dispatched = false;
             foreach ( $this->router as $route ) {
                 if ( $route->supportsHttpMethod($this->environment['REQUEST_METHOD']) ) {
                     try {
-                        $this->applyHook('slim.before.dispatch');
-                        $dispatched = $this->router->dispatch($route);
-                        $this->applyHook('slim.after.dispatch');
-                        if ( $dispatched ) {
+                        if ( substr($route->getPattern(), -1) === '/' &&
+                             substr($this->request->getResourceUri(), -1) !== '/' ) {
+                            throw new Slim_Exception_RequestSlash();
+                        }
+                        //Invoke middleware
+                        foreach ( $route->getMiddleware() as $mw ) {
+                            if ( is_callable($mw) ) {
+                                call_user_func($mw);
+                            }
+                        }
+                        // Invoke route handler
+                        if ( is_callable($route->getCallable()) ) {
+                            $this->applyHook('slim.before.dispatch');
+                            $args = array_values($route->getParams());
+                            $result = (string)call_user_func_array($route->getCallable(),
+                                                                   $args);
+                            $this->applyHook('slim.after.dispatch');
+                            $dispatched = true;
                             break;
                         }
                     } catch ( Slim_Exception_Pass $e ) {
@@ -1155,7 +1186,7 @@ class Slim {
             $this->applyHook('slim.after.router');
             $this->stop();
         } catch ( Slim_Exception_Stop $e ) {
-            $this->response()->write(ob_get_clean());
+            $this->response()->write(ob_get_clean() . $result);
             $this->applyHook('slim.after');
         } catch ( Slim_Exception_RequestSlash $e ) {
             $this->response->redirect($this->request->getPath() . '/', 301);

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1164,14 +1164,16 @@ class Slim {
                                 call_user_func($mw);
                             }
                         }
+                        $this->applyHook('slim.before.dispatch');
                         // Invoke route handler
                         if ( is_callable($route->getCallable()) ) {
-                            $this->applyHook('slim.before.dispatch');
                             $args = array_values($route->getParams());
                             $result = (string)call_user_func_array($route->getCallable(),
                                                                    $args);
-                            $this->applyHook('slim.after.dispatch');
                             $dispatched = true;
+                        }
+                        $this->applyHook('slim.after.dispatch');
+                        if ($dispatched) {
                             break;
                         }
                     } catch ( Slim_Exception_Pass $e ) {


### PR DESCRIPTION
Separed PR for using values returned by routes, notFound and Error as String like object for body of the response. the result is appended after the php ob buffer

``` php
$app->get('/', function() {
     echo '{{ debug }}';
     return new Template('page.template', array('title' => 'hello'));
});
```

will add to body

```
{{ debug }}
<html>
  <title>hello</title>
...
```

Bigger change is moving code from Router::dispatch to Slim::call where it was called. So now Router::dispatch is dead code. This change was nessesary to get value from invoation of route callback. IMHO it was weird that router return routes and then those routes was passed back to router, if router know which routes to dispach why he don't just dispach them without returing them, or if routes are returned from router then those routes should be handled in that place.

PS: 1 commit for this change and 2 commits because I put dispach hooks in wrong place.
