### PR TITLE
Remove error handlers from Router

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -64,16 +64,6 @@ class Router implements \Iterator
     protected $matchedRoutes;
 
     /**
-     * @var mixed Callable to be invoked if no matching route objects are found
-     */
-    protected $notFound;
-
-    /**
-     * @var mixed Callable to be invoked if application error
-     */
-    protected $error;
-
-    /**
      * Constructor
      */
     public function __construct()
@@ -262,34 +252,6 @@ class Router implements \Iterator
         }
 
         return new \ArrayIterator($this->namedRoutes);
-    }
-
-    /**
-     * Register a 404 Not Found callback
-     * @param  mixed    $callable   Anything that returns TRUE for is_callable()
-     * @return mixed
-     */
-    public function notFound($callable = null)
-    {
-        if (is_callable($callable)) {
-            $this->notFound = $callable;
-        }
-
-        return $this->notFound;
-    }
-
-    /**
-     * Register a 500 Error callback
-     * @param  mixed    $callable   Anything that returns TRUE for is_callable()
-     * @return mixed
-     */
-    public function error($callable = null)
-    {
-        if (is_callable($callable)) {
-            $this->error = $callable;
-        }
-
-        return $this->error;
     }
 
     /**

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -102,6 +102,16 @@ class Slim
     protected $middleware;
 
     /**
+     * @var mixed Callable to be invoked if application error
+     */
+    protected $error;
+
+    /**
+     * @var mixed Callable to be invoked if no matching routes are found
+     */
+    protected $notFound;
+
+    /**
      * @var array
      */
     protected $hooks = array(
@@ -485,15 +495,13 @@ class Slim
      *
      * @param  mixed $callable Anything that returns true for is_callable()
      */
-    public function notFound($callable = null)
-    {
-        if (!is_null($callable)) {
-            $this->router->notFound($callable);
+    public function notFound( $callable = null ) {
+        if ( is_callable($callable) ) {
+            $this->notFound = $callable;
         } else {
             ob_start();
-            $customNotFoundHandler = $this->router->notFound();
-            if (is_callable($customNotFoundHandler)) {
-                call_user_func($customNotFoundHandler);
+            if ( is_callable($this->notFound) ) {
+                call_user_func($this->notFound);
             } else {
                 call_user_func(array($this, 'defaultNotFound'));
             }
@@ -528,7 +536,7 @@ class Slim
     {
         if (is_callable($argument)) {
             //Register error handler
-            $this->router->error($argument);
+            $this->error = $argument;
         } else {
             //Invoke error handler
             $this->response->status(500);
@@ -550,9 +558,8 @@ class Slim
     protected function callErrorHandler($argument = null)
     {
         ob_start();
-        $customErrorHandler = $this->router->error();
-        if (is_callable($customErrorHandler)) {
-            call_user_func_array($customErrorHandler, array($argument));
+        if ( is_callable($this->error) ) {
+            call_user_func_array($this->error, array($argument));
         } else {
             call_user_func_array(array($this, 'defaultError'), array($argument));
         }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -177,54 +177,6 @@ class RouterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Router should keep reference to a callable NotFound callback
-     */
-    public function testNotFoundHandler()
-    {
-        $router = new \Slim\Router();
-        $router->setResourceUri($this->req->getResourceUri());
-        $notFoundCallback = function () { echo "404"; };
-        $callback = $router->notFound($notFoundCallback);
-        $this->assertSame($notFoundCallback, $callback);
-    }
-
-    /**
-     * Router should NOT keep reference to a callback that is not callable
-     */
-    public function testNotFoundHandlerIfNotCallable()
-    {
-        $router = new \Slim\Router();
-        $router->setResourceUri($this->req->getResourceUri());
-        $notFoundCallback = 'foo';
-        $callback = $router->notFound($notFoundCallback);
-        $this->assertNull($callback);
-    }
-
-    /**
-     * Router should keep reference to a callable NotFound callback
-     */
-    public function testErrorHandler()
-    {
-        $router = new \Slim\Router();
-        $router->setResourceUri($this->req->getResourceUri());
-        $errCallback = function () { echo "404"; };
-        $callback = $router->error($errCallback);
-        $this->assertSame($errCallback, $callback);
-    }
-
-    /**
-     * Router should NOT keep reference to a callback that is not callable
-     */
-    public function testErrorHandlerIfNotCallable()
-    {
-        $router = new \Slim\Router();
-        $router->setResourceUri($this->req->getResourceUri());
-        $errCallback = 'foo';
-        $callback = $router->error($errCallback);
-        $this->assertNull($callback);
-    }
-
-    /**
      * Router considers HEAD requests as GET requests
      */
     public function testRouterConsidersHeadAsGet()

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -1321,6 +1321,46 @@ class SlimTest extends PHPUnit_Framework_TestCase
         error_reporting($defaultErrorReporting);
     }
 
+    /**
+     * Slim should keep reference to a callable error callback
+     */
+    public function testErrorHandler() {
+        $s = new \Slim\Slim();
+        $errCallback = function () { echo "404"; };
+        $s->error($errCallback);
+        $this->assertSame($errCallback, PHPUnit_Framework_Assert::readAttribute($s, 'error'));
+    }
+
+    /**
+     * Slim should throw a Slim_Exception_Stop if error callback is not callable
+     */
+    public function testErrorHandlerIfNotCallable() {
+       $this->setExpectedException('\Slim\Exception\Stop');
+        $s = new \Slim\Slim();
+        $errCallback = 'foo';
+        $s->error($errCallback);
+    }
+
+    /**
+     * Slim should keep reference to a callable NotFound callback
+     */
+    public function testNotFoundHandler() {
+        $s = new \Slim\Slim();
+        $notFoundCallback = function () { echo "404"; };
+        $s->notFound($notFoundCallback);
+        $this->assertSame($notFoundCallback, PHPUnit_Framework_Assert::readAttribute($s, 'notFound'));
+    }
+
+    /**
+     * Slim should throw a Slim_Exception_Stop if NotFound callback is not callable
+     */
+    public function testNotFoundHandlerIfNotCallable() {
+       $this->setExpectedException('\Slim\Exception\Stop');
+        $s = new \Slim\Slim();
+        $notFoundCallback = 'foo';
+        $s->notFound($notFoundCallback);
+    }
+
     /************************************************
      * HOOKS
      ************************************************/


### PR DESCRIPTION
Remove error handlers form the Router class and let the Slim class to handle it.

Error callbacks were stored in the Router class but it seems more appropriate to have them in the Slim class instead. This simplifies the Router code.
