### PR TITLE
request: Send back exceptions in JSON if negotiated

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -322,6 +322,18 @@ class Slim_Http_Request {
     }
 
     /**
+     * Get Accept header
+     * @return string
+     */
+    public function getAccept() {
+        if ( isset($this->env['ACCEPT']) ) {
+            return $this->env['ACCEPT'];
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Get Body
      * @return string
      */

--- a/Slim/Middleware/PrettyJsonExceptions.php
+++ b/Slim/Middleware/PrettyJsonExceptions.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     1.6.5
+ * @package     Slim
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * Pretty JSON Exceptions
+ *
+ * This middleware catches any Exception thrown by the surrounded
+ * application and sets appropriate headers and filters content in
+ * order to get a JSON parsable stack trace.
+ *
+ * @package Slim
+ * @author  Carl Helmertz
+ * @since   1.0.0
+ */
+class Slim_Middleware_PrettyJsonExceptions extends Slim_Middleware_PrettyExceptions {
+
+    public function call() {
+        try {
+            $this->next->call();
+        } catch ( Exception $e ) {
+            $env = $this->app->environment();
+            $env['slim.log']->error($e);
+            $this->app->contentType('application/json');
+            $this->app->response()->status(500);
+            $this->app->response()->body($this->renderBody($env, $e));
+        }
+    }
+
+    /**
+     * Render response body
+     * @param array $env
+     * @param Exception $exception
+     * @return string
+     */
+    protected function renderBody( &$env, $exception ) {
+        return json_encode(array(
+            'title' => 'Slim Application Error',
+            'code' => $exception->getCode(),
+            'message' => $exception->getMessage(),
+            'file' => $exception->getFile(),
+            'line' => $exception->getLine(),
+            'trace' => $exception->getTrace()
+        ));
+    }
+}

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim - a micro PHP 5 framework
  *
@@ -1083,7 +1084,11 @@ class Slim {
         set_error_handler(array('Slim', 'handleErrors'));
 
         //Apply final outer middleware layers
-        $this->add(new Slim_Middleware_PrettyExceptions());
+        if( strpos($this->request->getAccept(), 'application/json') !== false ) {
+            $this->add(new Slim_Middleware_PrettyJsonExceptions());
+        } else {
+            $this->add(new Slim_Middleware_PrettyExceptions());
+        }
 
         //Invoke middleware and application stack
         $this->middleware[0]->call();

--- a/tests/Middleware/PrettyJsonExceptionsTest.php
+++ b/tests/Middleware/PrettyJsonExceptionsTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2012 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     1.6.4
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * @author      Carl Helmertz <helmertz@gmail.com>
+ */
+class PrettyJsonExceptionsTest extends PHPUnit_Framework_TestCase {
+    /**
+     * Test middleware returns successful response unchanged
+     */
+    public function testReturnsUnchangedSuccessResponse() {
+        Slim_Environment::mock(array(
+            'SCRIPT_NAME' => '/index.php',
+            'PATH_INFO' => '/foo'
+        ));
+        $app = new Slim();
+        $app->get('/foo', function () {
+            echo "Success";
+        });
+        $mw = new Slim_Middleware_PrettyExceptions();
+        $mw->setApplication($app);
+        $mw->setNextMiddleware($app);
+        $mw->call();
+        $this->assertEquals(200, $app->response()->status());
+        $this->assertEquals('Success', $app->response()->body());
+    }
+
+    /**
+     * Test middleware returns diagnostic screen for error response
+     */
+    public function testErrorReturnsJson() {
+        Slim_Environment::mock(array(
+            'SCRIPT_NAME' => '/index.php',
+            'PATH_INFO' => '/foo',
+            'ACCEPT' => 'application/json'
+        ));
+        $app = new Slim(array(
+            'log.enabled' => false
+        ));
+        $app->get('/foo', function () {
+            throw new Exception('Test Message', 100);
+        });
+        $mw = new Slim_Middleware_PrettyJsonExceptions();
+        $mw->setApplication($app);
+        $mw->setNextMiddleware($app);
+        $mw->call();
+        $json_as_string = $app->response()->body();
+        $this->assertNotNull(json_decode($json_as_string), $json_as_string);
+        $this->assertEquals(500, $app->response()->status());
+    }
+}


### PR DESCRIPTION
This patch exposes the accept-header, of the environment, to the
request. If I ask for json (like popular js-frameworks do), let them
not have to get a styled and very hard to parse HTML exception in the
response, but rather a well formed json-string.

With sensible messages in uncaught exceptions (if that ever can be
considered sensible..), this method let's all calling javascript reach
the error message in response.message on their end.

Signed-off-by: Carl Helmertz helmertz@gmail.com
