### PR TITLE
fix self:: scope errors

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1159,7 +1159,7 @@ class Slim
      */
     public function run()
     {
-        set_error_handler(array('self', 'handleErrors'));
+        set_error_handler(array('\Slim\Slim', 'handleErrors'));
 
         //Apply final outer middleware layers
         $this->add(new \Slim\Middleware\PrettyExceptions());


### PR DESCRIPTION
This fixes some errors that where being displayed when running the tests.

```
PHP Warning:  Invalid callback self::handleErrors, cannot access self:: when no class scope is active.
```
