### PR TITLE
Array access

### DIFF
--- a/Slim/MiddlewareContainer.php
+++ b/Slim/MiddlewareContainer.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     1.6.7
+ * @package     Slim
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+namespace Slim;
+
+/**
+ * MiddlewareContainer
+ *
+ * @package Slim
+ * @author  Josh Lockhart
+ * @since   1.6.7
+ */
+class MiddlewareContainer implements \ArrayAccess, \IteratorAggregate
+{
+    /**
+     * @var array
+     */
+    protected $container;
+
+    /**
+     * @var app
+     */
+    protected $app;
+
+    /**
+     * Constructor
+     * @param  Slim application
+     * @return void
+     */
+    public function __construct($app)
+    {
+        $this->app = $app;
+        $this->container = array($this->app);
+    }
+
+    /**
+     * Add middleware
+     *
+     * This method prepends new middleware to the application middleware stack.
+     * The argument must be an instance that subclasses Slim_Middleware.
+     *
+     * @param   Slim_Middleware
+     * @return void
+     */
+    public function add(\Slim\Middleware $newMiddleware)
+    {
+        $newMiddleware->setApplication($this->app);
+        $newMiddleware->setNextMiddleware($this->container[0]);
+        array_unshift($this->container, $newMiddleware);
+    }
+
+    /***** ARRAY ACCESS *****/
+
+    /**
+     * Check if a parameter is set
+     *
+     * @param string $offset
+     * @return boolean
+     */
+    public function offsetExists( $offset )
+    {
+        return array_key_exists($offset, $this->container);
+    }
+
+    /**
+     * Set a parameter
+     *
+     * @param string $offset
+     * @param mixed $value
+     */
+    public function offsetSet( $offset, $value )
+    {
+        if(!($value instanceOf \Slim\Middleware)) {
+            throw new \InvalidArgumentException('Value must be instance of \Slim\Middleware');
+        }
+        $this->add($value);
+    }
+
+    /**
+     * Unset a parameter
+     *
+     * @param string $offset
+     */
+    public function offsetUnset( $offset )
+    {
+    }
+
+    /**
+     * Get a parameter
+     *
+     * @param string $offset
+     * @return mixed
+     */
+    public function offsetGet( $offset )
+    {
+        return isset($this->container[$offset]) ? $this->container[$offset] : null;
+    }
+
+    /***** ARRAY ITERATOR ****/
+
+   /**
+    * Return array iterator
+    *
+    * @return ArrayIterator
+    */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->container);
+    }
+}

--- a/Slim/Settings.php
+++ b/Slim/Settings.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     1.6.7
+ * @package     Slim
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+namespace Slim;
+
+/**
+ * Settings
+ *
+ * @package Slim
+ * @author  Josh Lockhart
+ * @since   1.6.7
+ */
+class Settings implements \ArrayAccess, \IteratorAggregate
+{
+    /**
+     * @var array
+     */
+    protected $container = array();
+
+    /**
+     * Constructor merges users settings with the default settings
+     *
+     * @param array $userSettings Key-Value array of application settings
+     * @return void
+     */
+    public function __construct($userSettings = array())
+    {
+        $this->container = array_merge($this->getDefaultSettings(), $userSettings);
+    }
+
+    /**
+     * Get default application settings
+     * @return array
+     */
+    public function getDefaultSettings()
+    {
+        return array(
+            //Application
+            'mode' => 'development',
+            //Debugging
+            'debug' => true,
+            //Logging
+            'log.writer' => null,
+            'log.level' => \Slim\Log::DEBUG,
+            'log.enabled' => true,
+            //View
+            'templates.path' => './templates',
+            'view' => '\Slim\View',
+            //Cookies
+            'cookies.lifetime' => '20 minutes',
+            'cookies.path' => '/',
+            'cookies.domain' => null,
+            'cookies.secure' => false,
+            'cookies.httponly' => false,
+            //Encryption
+            'cookies.secret_key' => 'CHANGE_ME',
+            'cookies.cipher' => MCRYPT_RIJNDAEL_256,
+            'cookies.cipher_mode' => MCRYPT_MODE_CBC,
+            //HTTP
+            'http.version' => '1.1'
+        );
+    }
+
+    /**
+     * Set a settings attribute
+     *
+     * @param string $name the name of the setting to set or retrieve.
+     * @param mixed $value If name is a string, the value of the setting identified by $name
+     * @return mixed
+     */
+    public function set($name, $value = null) {
+        if (func_num_args() === 1) {
+            if (is_array($name)) {
+                $this->container = array_merge($this->container, $name);
+            }
+        } else {
+            if(is_array($value)) {
+                throw new \InvalidArgumentException('Arrays are not allowed here.');
+            }
+            $this->container[$name] = $value;
+        }
+    }
+
+    /**
+     * Get a settings attribute value
+     *
+     * @param string $name
+     * @return mixed
+     */
+    public function get($name) {
+        return isset($this->container[$name]) ? $this->container[$name] : null;
+    }
+
+    /***** ARRAY ACCESS *****/
+
+    /**
+     * Check if a parameter is set
+     *
+     * @param string $offset
+     * @return boolean
+     */
+    public function offsetExists( $offset )
+    {
+        return array_key_exists($offset, $this->container);
+    }
+
+    /**
+     * Set a parameter
+     *
+     * @param string $offset
+     * @param mixed $value
+     */
+    public function offsetSet( $offset, $value )
+    {
+        $this->set($offset, $value);
+    }
+
+    /**
+     * Unset a parameter
+     *
+     * @param string $offset
+     */
+    public function offsetUnset( $offset )
+    {
+        unset($this->container[$offset]);
+    }
+
+    /**
+     * Get a parameter
+     *
+     * @param string $offset
+     * @return mixed
+     */
+    public function offsetGet( $offset )
+    {
+        return $this->get($offset);
+    }
+
+    /***** ARRAY ITERATOR ****/
+
+   /**
+    * Return array iterator
+    *
+    * @return ArrayIterator
+    */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->container);
+    }
+}

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -172,15 +172,15 @@ class Slim implements \ArrayAccess
         $this->add(new \Slim\Middleware\Flash());
         $this->add(new \Slim\Middleware\MethodOverride());
 
-        // initialize container array
+        // Initialize DI container array
         $this->container = array();
-
-        //Determine application mode
-        $this->getMode();
         $this['environment'] = $this->environment;
         $this['request'] = $this->request;
         $this['response'] = $this->response;
         $this['router'] = $this->router;
+
+        //Determine application mode
+        $this->getMode();
 
         //Setup view
         $this->view($this->config('view'));

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -177,6 +177,10 @@ class Slim implements \ArrayAccess
 
         //Determine application mode
         $this->getMode();
+        $this['environment'] = $this->environment;
+        $this['request'] = $this->request;
+        $this['response'] = $this->response;
+        $this['router'] = $this->router;
 
         //Setup view
         $this->view($this->config('view'));

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -157,12 +157,11 @@ class Slim implements \ArrayAccess
     public function __construct($userSettings = array())
     {
         //Setup Slim application
-        $this->settings = array_merge(self::getDefaultSettings(), $userSettings);
+        //$this->settings = new \Slim\Settings($userSettings);
         $this->environment = \Slim\Environment::getInstance();
         $this->request = new \Slim\Http\Request($this->environment);
         $this->response = new \Slim\Http\Response();
         $this->router = new \Slim\Router($this->request->getResourceUri());
-        $this->settings = array_merge(self::getDefaultSettings(), $userSettings);
 
         // Initialize DI container array
         $this->container = array();
@@ -170,6 +169,7 @@ class Slim implements \ArrayAccess
         $this['request'] = $this->request;
         $this['response'] = $this->response;
         $this['router'] = $this->router;
+        $this['config'] = new \Slim\Settings($userSettings);
         $this['middleware'] = new \Slim\MiddlewareContainer($this);
 
         // Add middleware to the middleware container
@@ -278,7 +278,7 @@ class Slim implements \ArrayAccess
      * If two arguments are provided, the first argument is the name of the setting
      * to be created or updated, and the second argument is the setting value.
      *
-     * @param  string|array $name  If a string, the name of the setting to set or retrieve. Else an associated array of setting names and values
+     * @param  string $name  The name of the setting to set or retrieve.
      * @param  mixed        $value If name is a string, the value of the setting identified by $name
      * @return mixed        The value of a setting if only one argument is a string
      */
@@ -286,12 +286,12 @@ class Slim implements \ArrayAccess
     {
         if (func_num_args() === 1) {
             if (is_array($name)) {
-                $this->settings = array_merge($this->settings, $name);
+                $this['config']->set($name);
             } else {
-                return isset($this->settings[$name]) ? $this->settings[$name] : null;
+                return $this['config']->get($name);
             }
         } else {
-            $this->settings[$name] = $value;
+            $this['config']->set($name, $value);
         }
     }
 

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -32,9 +32,6 @@
  */
 namespace Slim;
 
-// Comment out this line if you are using an alternative autoloader (e.g. Composer)
-Slim::registerAutoloader();
-
 // Ensure mcrypt constants are defined even if mcrypt extension is not loaded
 if (!extension_loaded('mcrypt')) {
     define('MCRYPT_MODE_CBC', 0);
@@ -47,7 +44,7 @@ if (!extension_loaded('mcrypt')) {
  * @author  Josh Lockhart
  * @since   1.0.0
  */
-class Slim
+class Slim implements \ArrayAccess
 {
     /**
      * @const string
@@ -103,6 +100,11 @@ class Slim
      * @var array
      */
     protected $middleware;
+
+    /**
+     * @var array
+     */
+    protected $container;
 
     /**
      * @var array
@@ -169,6 +171,9 @@ class Slim
         $this->middleware = array($this);
         $this->add(new \Slim\Middleware\Flash());
         $this->add(new \Slim\Middleware\MethodOverride());
+
+        // initialize container array
+        $this->container = array();
 
         //Determine application mode
         $this->getMode();
@@ -1256,6 +1261,51 @@ class Slim
                 }
             }
         }
+    }
+
+    /***** ARRAY ACCESS *****/
+
+    /**
+     * Check if a parameter is set
+     *
+     * @param string $offset
+     * @return boolean
+     */
+    public function offsetExists( $offset )
+    {
+        return array_key_exists($offset, $this->container);
+    }
+
+    /**
+     * Set a parameter
+     *
+     * @param string $offset
+     * @param mixed $value
+     */
+    public function offsetSet( $offset, $value )
+    {
+        $this->container[$offset] = $value;
+    }
+
+    /**
+     * Unset a parameter
+     *
+     * @param string $offset
+     */
+    public function offsetUnset( $offset )
+    {
+        unset($this->container[$offset]);
+    }
+
+    /**
+     * Get a parameter
+     *
+     * @param string $offset
+     * @return mixed
+     */
+    public function offsetGet( $offset )
+    {
+        return isset($this->container[$offset]) ? $this->container[$offset] : null;
     }
 
     /***** EXCEPTION AND ERROR HANDLING *****/

--- a/index.php
+++ b/index.php
@@ -9,6 +9,9 @@
  */
 require 'Slim/Slim.php';
 
+// Comment out this line if you are using an alternative autoloader (e.g. Composer)
+Slim\Slim::registerAutoloader();
+
 /**
  * Step 2: Instantiate the Slim application
  *

--- a/tests/MiddlewareContainerTest.php
+++ b/tests/MiddlewareContainerTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     1.6.7
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+class Foo_Middleware extends \Slim\Middleware
+{
+    public function call()
+    {
+        echo "Before";
+        $this->next->call();
+        echo "After";
+    }
+}
+
+class MiddlewareContainerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Set Middleware using the add method
+     */
+    public function testSetMiddlewareUsingAddMethod()
+    {
+        $app = new \Slim\Slim();
+        $mw = new Foo_Middleware();
+        $app['middleware']->add($mw);
+        $this->assertSame($app, $mw->getApplication());
+    }
+
+    /**
+     * Set Middleware using the array access method
+     */
+    public function testSetMiddlewareUsingArrayMethod()
+    {
+        $app = new \Slim\Slim();
+        $mw = new Foo_Middleware();
+        $app['middleware'][] = $mw;
+        $this->assertSame($app, $mw->getApplication());
+    }
+
+    /**
+     * Set not valid Middleware
+     */
+    public function testSetNotValidMiddleware()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $app = new \Slim\Slim();
+        $mw = 'foo';
+        $app['middleware'][] = $mw;
+        $this->assertSame($app, $mw->getApplication());
+    }
+}

--- a/tests/SettingsTest.php
+++ b/tests/SettingsTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     1.6.7
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+class SettingsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test default settings
+     */
+    public function testDefaultSettings()
+    {
+        $s = new \Slim\Settings(array());
+        $this->assertSame('development', $s['mode']);
+    }
+
+    /**
+     * Test set settings
+     */
+    public function testSetSettings()
+    {
+        $s = new \Slim\Settings(array());
+        $s->set('mode', 'production');
+        $this->assertSame('production', $s['mode']);
+        $s['view'] = 'foo';
+        $this->assertSame('foo', $s->get('view'));
+    }
+
+    /**
+     * Set settings using an array
+     */
+    public function testSetSettingsArray()
+    {
+        $s = new \Slim\Settings(array('mode' => 'production', 'view' => 'foo'));
+        $this->assertSame('production', $s['mode']);
+        $this->assertSame('foo', $s['view']);
+        $s->set(array('mode' => 'development', 'view' => 'bar'));
+        $this->assertSame('development', $s['mode']);
+        $this->assertSame('bar', $s['view']);
+    }
+
+    /**
+     * Set an invalid argument
+     */
+    public function testSettingsWithInvalidArgument()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $s = new \Slim\Settings(array());
+        $s['foo'] = array('bar');
+    }
+}

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -1410,4 +1410,34 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $app->clearHooks();
         $this->assertEquals(array(array()), $app->getHooks('test.hook.one'));
     }
+
+    /************************************************
+     * ARRAY ACCESS
+     ************************************************/
+
+    /**
+     * Test array access offset set
+     */
+    public function testArrayAccessOffsetSet()
+    {
+        $app = new \Slim\Slim();
+        $this->assertFalse($app->offsetExists('foo'));
+        $app['foo'] = 'bar';
+        $this->assertEquals('bar', $app['foo']);
+        $this->assertEquals('bar', $app->offSetGet('foo'));
+    }
+
+    /**
+     * Test array access offset unset
+     */
+    public function testArrayAccessOffsetUnset()
+    {
+        $app = new \Slim\Slim();
+        $this->assertFalse($app->offsetExists('foo'));
+        $app['foo'] = 'bar';
+        $this->assertEquals('bar', $app['foo']);
+        $this->assertEquals('bar', $app->offSetGet('foo'));
+        unset($app['foo']);
+        $this->assertFalse($app->offsetExists('foo'));
+    }
 }

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -1440,4 +1440,43 @@ class SlimTest extends PHPUnit_Framework_TestCase
         unset($app['foo']);
         $this->assertFalse($app->offsetExists('foo'));
     }
+
+    /**
+     * Test array access Response
+     */
+    public function testArrayAccessResponse()
+    {
+        $app = new \Slim\Slim();
+        $response = $app->response();
+        $this->assertEquals($app['response'], $response);
+        $response['status'] = '500';
+        $this->assertEquals($app['response']['status'], $response['status']);
+    }
+
+    /**
+     * Test array access Response
+     */
+    public function testArrayAccessRequest()
+    {
+        $app = new \Slim\Slim();
+        $this->assertEquals($app['request'], $app->request());
+    }
+
+    /**
+     * Test array access Environment
+     */
+    public function testArrayAccessEnvironment()
+    {
+        $app = new \Slim\Slim();
+        $this->assertEquals($app['environment'], $app->environment());
+    }
+
+    /**
+     * Test array access Router
+     */
+    public function testArrayAccessRouter()
+    {
+        $app = new \Slim\Slim();
+        $this->assertEquals($app['router'], $app->router());
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,9 @@ set_include_path(dirname(__FILE__) . '/../' . PATH_SEPARATOR . get_include_path(
 
 require_once 'Slim/Slim.php';
 
+// Comment out this line if you are using an alternative autoloader (e.g. Composer)
+\Slim\Slim::registerAutoloader();
+
 //Register non-Slim autoloader
 function customAutoLoader( $class )
 {


### PR DESCRIPTION
This is an initial implementation for #398.

So far what it does is implement ArrayAccess in the Slim class and make the Request, Response, Environment and Router array accessible.

```
$app = new \Slim\Slim();
$app['response']['status'] = '500';
```

Maybe adding the Slim settings and the application middleware to the array access would be cool too, something like the Pimple's share method might be also useful.

I kind of like this DI container idea and I think it would allow Slim to evolve in a much more modular framework, what do you guys think?
