### PR TITLE
Defines the application name through the configuration array

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -165,8 +165,13 @@ class Slim {
         //Setup view
         $this->view($this->config('view'));
 
-        //Make default if first instance
-        if ( is_null(self::getInstance()) ) {
+        //Use app name passed through configuration
+        $applicationName = $this->config('application-name');
+        if ( $applicationName ) {
+            $this->setName($applicationName);
+        }
+        //or make default if first instance
+        else if ( is_null(self::getInstance()) ) {
             $this->setName('default');
         }
 

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -112,6 +112,16 @@ class SlimTest extends PHPUnit_Framework_TestCase {
     }
 
     /**
+     * Test set name using configuration
+     */
+     public function testSetNameUsingConfiguration() {
+        $appName = 'Foo';
+        $config = array('application-name' => $appName);
+        $s = new Slim($config);
+        $this->assertEquals($s->getName(), 'Foo');
+     }
+
+    /**
      * Test Slim autoloader ignores non-Slim classes
      *
      * Pre-conditions:


### PR DESCRIPTION
Defines the application name through the configuration array (just in __construct). For example:

``` php
$app = new Slim(array('application-name' => 'Foo'));
$app->getName(); // outputs "Foo"
```

This would avoid a setName call after instantiation. Maybe a __construct parameter would suit better, I'm not sure.

Thank you.
