### PR TITLE
Autoload classes in include path

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -134,7 +134,7 @@ class Slim
         }
         $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
 
-        if (file_exists($fileName)) {
+        if (false !== stream_resolve_include_path($fileName)) {
             require $fileName;
         }
     }


### PR DESCRIPTION
Replace the file_exists() with stream_resolve_include_path() such that classes in include path can be loaded. 

Project Setting:
+-- lib/Slim/Slim.php
 |-- index.php

In the top of index.php, add this line:
set_include_path('lib');

The original file_exists() doesn't handle this situation properly.
