### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,5 @@
     },
     "autoload": {
         "psr-0": { "Slim": "." }
-    },
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
Removed minimum stability setting... there are no requirements on other packages.

This setting dictates the stability level of packages you require.  Read it as "are you ok with composer installing dev level packages".  Users of slim would put this in their composer.json file if they wanted to access dev packages of slim, like "dev-master".
