### PR TITLE
Router constructor doesn't take arguments

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -170,7 +170,7 @@ class Slim
         $this->environment = \Slim\Environment::getInstance();
         $this->request = new \Slim\Http\Request($this->environment);
         $this->response = new \Slim\Http\Response();
-        $this->router = new \Slim\Router($this->request->getResourceUri());
+        $this->router = new \Slim\Router();
         $this->middleware = array($this);
         $this->add(new \Slim\Middleware\Flash());
         $this->add(new \Slim\Middleware\MethodOverride());


### PR DESCRIPTION
Router constructor doesn't take arguments, the resource uri is set with the Router's setResourceUri() method instead.
