### PR TITLE
fix misspelled word

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1309,6 +1309,6 @@ class Slim
      */
     protected function defaultError()
     {
-        echo self::generateTemplateMarkup('Error', '<p>A website error has occured. The website administrator has been notified of the issue. Sorry for the temporary inconvenience.</p>');
+        echo self::generateTemplateMarkup('Error', '<p>A website error has occurred. The website administrator has been notified of the issue. Sorry for the temporary inconvenience.</p>');
     }
 }


### PR DESCRIPTION
The word "occurred" was misspelled in the defaultError method.
