### PR TITLE
Fail fast if route callable or any route middleware is not callable.

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -150,9 +150,14 @@ class Route
     /**
      * Set route callable
      * @param  mixed $callable
+     * @throws \InvalidArgumentException If argument is not callable
      */
     public function setCallable($callable)
     {
+        if (!is_callable($callable)) {
+            throw new \InvalidArgumentException('Route callable must be callable');
+        }
+
         $this->callable = $callable;
     }
 
@@ -303,19 +308,23 @@ class Route
      * If the method argument `is_callable` (including callable arrays!),
      * we directly append the argument to `$this->middleware`. Else, we
      * assume the argument is an array of callables and merge the array
-     * with `$this->middleware`. Even if non-callables are included in the
-     * argument array, we still merge them; we lazily check each item
-     * against `is_callable` during Router::dispatch().
+     * with `$this->middleware`.  Each middleware is checked for is_callable()
+     * and an InvalidArgumentException is thrown immediately if it isn't.
      *
      * @param  Callable|array[Callable]
      * @return \Slim\Route
-     * @throws \InvalidArgumentException If argument is not callable or not an array
+     * @throws \InvalidArgumentException If argument is not callable or not an array of callables.
      */
     public function setMiddleware($middleware)
     {
         if (is_callable($middleware)) {
             $this->middleware[] = $middleware;
         } elseif (is_array($middleware)) {
+            foreach($middleware as $callable) {
+                if (!is_callable($callable)) {
+                    throw new \InvalidArgumentException('All Route middleware must be callable');
+                }
+            }
             $this->middleware = array_merge($this->middleware, $middleware);
         } else {
             throw new \InvalidArgumentException('Route middleware must be callable or an array of callables');

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -190,19 +190,13 @@ class Router implements \Iterator
 
         //Invoke middleware
         foreach ($route->getMiddleware() as $mw) {
-            if (is_callable($mw)) {
-                call_user_func_array($mw, array($route));
-            }
+            call_user_func_array($mw, array($route));
         }
 
         //Invoke callable
-        if (is_callable($route->getCallable())) {
-            call_user_func_array($route->getCallable(), array_values($route->getParams()));
+        call_user_func_array($route->getCallable(), array_values($route->getParams()));
 
-            return true;
-        }
-
-        return false;
+        return true;
     }
 
     /**

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -30,6 +30,9 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+// Used for passing callable via string
+function testCallable() {}
+
 class RouteTest extends PHPUnit_Framework_TestCase
 {
     /**
@@ -56,7 +59,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
      */
     public function testRouteSetsPatternWithParams()
     {
-        $route = new \Slim\Route('/hello/:first/:last', 'hello');
+        $route = new \Slim\Route('/hello/:first/:last', function () {});
         $this->assertEquals('/hello/:first/:last', $route->getPattern());
     }
 
@@ -65,7 +68,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
      */
     public function testRouteSetsCustomTemplate()
     {
-        $route = new \Slim\Route('/hello/*', 'hello');
+        $route = new \Slim\Route('/hello/*', function () {});
         $route->setPattern('/hello/:name');
         $this->assertEquals('/hello/:name', $route->getPattern());
     }
@@ -92,13 +95,35 @@ class RouteTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Route should throw exception when creating with an invalid callable
+     */
+    public function testRouteThrowsExecptionWithInvalidCallable()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $route = new \Slim\Route('/foo/bar', 'fnDoesNotExist');
+    }
+
+    /**
+     * Route should throw exception when setting an invalid callable
+     */
+    public function testRouteThrowsExecptionWhenSettingInvalidCallable()
+    {
+        $route = new \Slim\Route('/foo/bar', function () {});
+        try
+        {
+            $route->setCallable('fnDoesNotExist');
+            $this->fail('Did not catch InvalidArgumentException when setting invalid callable');
+        } catch(\InvalidArgumentException $e) {}
+    }
+
+    /**
      * Test gets all params
      */
     public function testGetRouteParams()
     {
         // Prepare route
         $requestUri = '/hello/mr/anderson';
-        $route = new \Slim\Route('/hello/:first/:last', 'fooCallable');
+        $route = new \Slim\Route('/hello/:first/:last', function () {});
 
         // Parse route params
         $this->assertTrue($route->matches($requestUri));
@@ -117,7 +142,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
     {
         // Prepare route
         $requestUri = '/hello/mr/anderson';
-        $route = new \Slim\Route('/hello/:first/:last', 'fooCallable');
+        $route = new \Slim\Route('/hello/:first/:last', function () {});
 
         // Parse route params
         $this->assertTrue($route->matches($requestUri));
@@ -148,7 +173,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
     {
         // Prepare route
         $requestUri = '/hello/mr/anderson';
-        $route = new \Slim\Route('/hello/:first/:last', 'fooCallable');
+        $route = new \Slim\Route('/hello/:first/:last', function () {});
 
         // Parse route params
         $this->assertTrue($route->matches($requestUri));
@@ -164,7 +189,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
     {
         // Prepare route
         $requestUri = '/hello/mr/anderson';
-        $route = new \Slim\Route('/hello/:first/:last', 'fooCallable');
+        $route = new \Slim\Route('/hello/:first/:last', function () {});
 
         // Parse route params
         $this->assertTrue($route->matches($requestUri));
@@ -183,7 +208,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
     {
         // Prepare route
         $requestUri = '/hello/mr/anderson';
-        $route = new \Slim\Route('/hello/:first/:last', 'fooCallable');
+        $route = new \Slim\Route('/hello/:first/:last', function () {});
 
         // Parse route params
         $this->assertTrue($route->matches($requestUri));
@@ -205,7 +230,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
     {
         // Prepare route
         $requestUri = '/hello/mr/anderson';
-        $route = new \Slim\Route('/hello/:first/:last', 'fooCallable');
+        $route = new \Slim\Route('/hello/:first/:last', function () {});
 
         // Parse route params
         $this->assertTrue($route->matches($requestUri));
@@ -461,6 +486,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
      * Case C: Middleware set as array of callables
      * Case D: Middleware set as a callable array
      * Case E: Middleware is invalid; throws InvalidArgumentException
+     * Case F: Middleware is an array with one invalid callable; throws InvalidArgumentException
      */
     public function testRouteMiddleware()
     {
@@ -492,6 +518,11 @@ class RouteTest extends PHPUnit_Framework_TestCase
         try {
             $r3->setMiddleware('sdjfsoi788');
             $this->fail('Did not catch InvalidArgumentException when setting invalid route middleware');
+        } catch ( \InvalidArgumentException $e ) {}
+        //Case F
+        try {
+            $r3->setMiddleware(array($callable1, $callable2, 'sdjfsoi788'));
+            $this->fail('Did not catch InvalidArgumentException when setting an array with one invalid route middleware');
         } catch ( \InvalidArgumentException $e ) {}
     }
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -460,28 +460,4 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $route->matches($req->getResourceUri()); //<-- Extracts params from resource URI
         $router->dispatch($route);
     }
-
-    public function testDispatchWithoutCallable()
-    {
-        \Slim\Environment::mock(array(
-            'REQUEST_METHOD' => 'GET',
-            'REMOTE_ADDR' => '127.0.0.1',
-            'SCRIPT_NAME' => '', //<-- Physical
-            'PATH_INFO' => '/hello/josh', //<-- Virtual
-            'QUERY_STRING' => 'one=1&two=2&three=3',
-            'SERVER_NAME' => 'slim',
-            'SERVER_PORT' => 80,
-            'slim.url_scheme' => 'http',
-            'slim.input' => '',
-            'slim.errors' => fopen('php://stderr', 'w'),
-            'HTTP_HOST' => 'slim'
-        ));
-        $env = \Slim\Environment::getInstance();
-        $req = new \Slim\Http\Request($env);
-        $router = new \Slim\Router();
-        $router->setResourceUri($req->getResourceUri());
-        $route = new \Slim\Route('/hello/:name', 'foo');
-        $route->matches($req->getResourceUri()); //<-- Extracts params from resource URI
-        $this->assertFalse($router->dispatch($route));
-    }
 }


### PR DESCRIPTION
Fail fast if route callable or any route middleware is not callable and simplified Router::dispatch accordingly.
