### PR TITLE
Allowing addition of Metadata to a Route.

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -81,6 +81,11 @@ class Route
     protected $paramNamesPath = array();
 
     /**
+     * @var array Key-value array of Metadata
+     */
+    protected $metadata = array();
+
+    /**
      * @var array HTTP methods supported by this Route
      */
     protected $methods = array();
@@ -242,6 +247,44 @@ class Route
             throw new \InvalidArgumentException('Route parameter does not exist at specified index');
         }
         $this->params[$index] = $value;
+    }
+
+    /**
+     * Set either a Metadata value, or if only 1 parameter is given, set all Metadata.
+     *
+     * @param  mixed  The Metadata as an array or index
+     * @param  mixed  The Metadata value if given
+     * @throws \InvalidArgumentException
+     */
+    public function setMetadata($metadata, $value = null)
+    {
+        if (func_num_args() == 1 && is_array($metadata)) {
+            $this->metadata = $metadata;
+        } elseif (is_string($metadata) || is_numeric($metadata)) {
+            $this->metadata[$metadata] = $value;
+        } else {
+            throw new \InvalidArgumentException();
+        }
+    }
+
+    /**
+     * Gets a route Metadata value, or returns all Metadata if no index is given
+     *
+     * @param  string|null   $index     Name of Metadata
+     * @return string|array
+     * @throws \InvalidArgumentException If route Metadata does not exist at index
+     */
+    public function getMetadata($index = null)
+    {
+        if (is_null($index)) {
+            return $this->metadata;
+        }
+
+        if (!isset($this->metadata[$index])) {
+            throw new \InvalidArgumentException('Route Metadata does not exist at specified index');
+        }
+
+        return $this->metadata[$index];
     }
 
     /**

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -301,7 +301,11 @@ class RouteTest extends PHPUnit_Framework_TestCase
         );
 
         $route = new \Slim\Route('/foo', function () {});
-        $route->setMetadata($data);
+
+        $property = new ReflectionProperty($route, 'metadata');
+        $property->setAccessible(true);
+        $property->setValue($route, $data);
+
 
         $this->assertEquals($data, $route->getMetadata());
     }
@@ -312,7 +316,10 @@ class RouteTest extends PHPUnit_Framework_TestCase
     public function testGetMetadataWhenExists()
     {
         $route = new \Slim\Route('/foo', function () {});
-        $route->setMetadata(array(
+
+        $property = new ReflectionProperty($route, 'metadata');
+        $property->setAccessible(true);
+        $property->setValue($route, array(
             'foo' => 'bar',
             'baz' => 'yay'
         ));
@@ -329,7 +336,9 @@ class RouteTest extends PHPUnit_Framework_TestCase
     {
         $route = new \Slim\Route('/foo', function () {});
 
-        $route->setMetadata(array(
+        $property = new ReflectionProperty($route, 'metadata');
+        $property->setAccessible(true);
+        $property->setValue($route, array(
             'foo' => 'bar',
             'baz' => 'yay'
         ));

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -243,6 +243,102 @@ class RouteTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * If a single Metadata can be set on a Route
+     */
+    public function testSetOneMetadata()
+    {
+        $route = new \Slim\Route('/foo', 'fooCallable');
+
+        $route->setMetadata('foo', 'bar');
+
+        $property = new ReflectionProperty($route, 'metadata');
+        $property->setAccessible(true);
+        $metadata = $property->getValue($route);
+
+        $this->assertTrue(array_key_exists('foo', $metadata));
+        $this->assertEquals('bar', $metadata['foo']);
+    }
+
+    /**
+     * If a multiple Metadata can be set on a Route
+     */
+    public function testSetMultipleMetadata()
+    {
+        $data = array(
+            'foo' => 'bar',
+            'baz' => 'yay'
+        );
+        $route = new \Slim\Route('/foo', 'fooCallable');
+        $route->setMetadata($data);
+
+        $property = new ReflectionProperty($route, 'metadata');
+        $property->setAccessible(true);
+        $metadata = $property->getValue($route);
+
+        $this->assertEquals($data, $metadata);
+    }
+
+    /**
+     * If setting Multidata with incorrect index throws an InvalidArgumentException
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testSetMetadataWithInvalidIndexType()
+    {
+        $route = new \Slim\Route('/foo', 'fooCallable');
+
+        $route->setMetadata(new stdClass, 'foo');
+    }
+
+    /**
+     * If all Metadata is returned
+     */
+    public function testGetMetadataWithNoParameters()
+    {
+        $data = array(
+            'foo' => 'bar',
+            'baz' => 'yay'
+        );
+
+        $route = new \Slim\Route('/foo', 'fooCallable');
+        $route->setMetadata($data);
+
+        $this->assertEquals($data, $route->getMetadata());
+    }
+
+    /**
+     * If Multidata which exists can be retrieved
+     */
+    public function testGetMetadataWhenExists()
+    {
+        $route = new \Slim\Route('/foo', 'fooCallable');
+        $route->setMetadata(array(
+            'foo' => 'bar',
+            'baz' => 'yay'
+        ));
+
+        $this->assertEquals('yay', $route->getMetadata('baz'));
+    }
+
+    /**
+     * If Multidata which does not exist throws an InvalidArgumentException
+     *
+     * @expectedException InvalidArgumentException
+     */
+    public function testGetMetadataWhenNotExists()
+    {
+        $route = new \Slim\Route('/foo', 'fooCallable');
+
+        $route->setMetadata(array(
+            'foo' => 'bar',
+            'baz' => 'yay'
+        ));
+
+        $route->getMetadata('name');
+    }
+
+
+    /**
      * If route matches a resource URI, param should be extracted.
      */
     public function testRouteMatchesAndParamExtracted()

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -247,7 +247,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
      */
     public function testSetOneMetadata()
     {
-        $route = new \Slim\Route('/foo', 'fooCallable');
+        $route = new \Slim\Route('/foo', function () {});
 
         $route->setMetadata('foo', 'bar');
 
@@ -268,7 +268,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
             'foo' => 'bar',
             'baz' => 'yay'
         );
-        $route = new \Slim\Route('/foo', 'fooCallable');
+        $route = new \Slim\Route('/foo', function () {});
         $route->setMetadata($data);
 
         $property = new ReflectionProperty($route, 'metadata');
@@ -285,7 +285,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
      */
     public function testSetMetadataWithInvalidIndexType()
     {
-        $route = new \Slim\Route('/foo', 'fooCallable');
+        $route = new \Slim\Route('/foo', function () {});
 
         $route->setMetadata(new stdClass, 'foo');
     }
@@ -300,7 +300,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
             'baz' => 'yay'
         );
 
-        $route = new \Slim\Route('/foo', 'fooCallable');
+        $route = new \Slim\Route('/foo', function () {});
         $route->setMetadata($data);
 
         $this->assertEquals($data, $route->getMetadata());
@@ -311,7 +311,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
      */
     public function testGetMetadataWhenExists()
     {
-        $route = new \Slim\Route('/foo', 'fooCallable');
+        $route = new \Slim\Route('/foo', function () {});
         $route->setMetadata(array(
             'foo' => 'bar',
             'baz' => 'yay'
@@ -327,7 +327,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
      */
     public function testGetMetadataWhenNotExists()
     {
-        $route = new \Slim\Route('/foo', 'fooCallable');
+        $route = new \Slim\Route('/foo', function () {});
 
         $route->setMetadata(array(
             'foo' => 'bar',


### PR DESCRIPTION
This allows for a nice place to store some Metadata about a route which can then be used later in numerous different ways.  The way I would like to use it is in our API.  Different endpoint require different "kinds" of authentication.  For example:

``` php
<?php
$app->get('/test', function () use ($app) {
    // Do Stuff
})->setMetadata(array(
    'internal' => true,
    'auth' => false,
));
```

So here you see that this endpoint is an internal endpoint, thus requiring an Internal Only API key, but the request does not need to use any authentication.

I have this data then being read by a hook:

``` php
<?php
$app->hook('slim.before.dispatch', function () use ($app)
{
    $metadata = $app->router()->current()->getMetadata();
    $metadata += array(
        'key'      => true,
        'internal' => false,
        'auth'     => true
    );

    // Secret DB/Header Sauce to get the Api-Key here

    if ($metadata['key']) {
        if (
            (is_null($key) || $key->active != 1) ||
            ($params['internal'] && $key->is_internal != 1)
        ) {
            $app->halt(401, 'Invalid Key');
        }
    }

    // Auth Stuff Here
}, 1);
```

It is very useful and removes the need to write some convoluted code to make this sort of thing work.

**Edit:** Modified examples to not use the PHP 5.4 short array syntax
