### PR TITLE
Addresses 

### DIFF
--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -145,7 +145,11 @@ class Environment implements \ArrayAccess, \IteratorAggregate
             } else {
                 $env['SCRIPT_NAME'] = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME']) ); //With URL rewrite
             }
-            $env['PATH_INFO'] = substr_replace($_SERVER['REQUEST_URI'], '', 0, strlen($env['SCRIPT_NAME']));
+            if (strpos($_SERVER['REQUEST_URI'], $env['SCRIPT_NAME']) === 0) {
+               $env['PATH_INFO'] = substr_replace($_SERVER['REQUEST_URI'], '', 0, strlen($env['SCRIPT_NAME']));
+            } else {
+                $env['PATH_INFO'] = $_SERVER['REQUEST_URI'];
+            }
             if (strpos($env['PATH_INFO'], '?') !== false) {
                 $env['PATH_INFO'] = substr_replace($env['PATH_INFO'], '', strpos($env['PATH_INFO'], '?')); //query string is not removed automatically
             }

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -184,6 +184,24 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test parses script name and path info
+     *
+     * Pre-conditions:
+     * URL Rewrite all requests from root directory into subdirectory (e.g. '/public');
+     * Slim URL Rewrite enabled in subdirectory;
+     * App installed in subdirectory;
+     */
+    public function testParsesPathsWithUrlRewriteInRootAndSubDirectory()
+    {
+        $_SERVER['SCRIPT_NAME'] = '/public/index.php';
+        $_SERVER['REQUEST_URI'] = '/bar/xyz';
+        unset($_SERVER['PATH_INFO']);
+        $env = \Slim\Environment::getInstance(true);
+        $this->assertEquals('/bar/xyz', $env['PATH_INFO']);
+        $this->assertEquals('/public', $env['SCRIPT_NAME']);
+    }
+
+    /**
      * Test parses query string
      *
      * Pre-conditions:


### PR DESCRIPTION
Using AppFog to host.  Shifted web root to `/public` using following Apache .htaccess:

```
RewriteEngine on
RewriteCond %{HTTP_HOST} ^sub.myhostname.com$
RewriteCond %{REQUEST_URI} !public/
RewriteRule ^(.*)$ /public/$1 [L]
```

`/public` directory contains its own Apache .htaccess:

```
RewriteEngine on

RewriteCond %{REQUEST_FILENAME} !-f
RewriteCond %{REQUEST_FILENAME}\.php !-f
RewriteCond %{REQUEST_URI} (.*)
RewriteRule ^(.*)$ index.php/$1 [L]
```

With this configuration, the source (prior to this change) was creating an invalid `$env['PATH_INFO']`value when requesting `http://sub.myhostname.com/hello`:

```
$_SERVER["REQUEST_URI"]: string '/hello' (length=6)
$_SERVER["SCRIPT_NAME"]: string '/public/index.php' (length=17)
$env["SCRIPT_NAME"]: string '/public' (length=7)
$env["PATH_INFO"]: string '' (length=0)
```

This change set removes the (incorrect, in this particular instance) assumption that `$_SERVER['REQUEST_URI']` is prefixed with the `$env['SCRIPT_NAME']` contents.
