### PR TITLE
Added support for custom route subclasses to \Slim\Router

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -64,6 +64,11 @@ class Router
     protected $matchedRoutes;
 
     /**
+     * @var string Name of the class to use for route objects
+     */
+    protected $routeClass = '\Slim\Route';
+
+    /**
      * Constructor
      */
     public function __construct()
@@ -114,6 +119,20 @@ class Router
     }
 
     /**
+     * Sets the route class for the router to use.
+     *
+     * @param  string $routeClass       Route class name
+     * @throws InvalidArgumentException If $routeClass does not specify a subclass of \Slim\Route
+     */
+    public function route($routeClass)
+    {
+        if (!in_array('Slim\Route', class_parents($routeClass))) {
+            throw new \InvalidArgumentException('$routeClass not a subclass of \Slim\Route: ' . $routeClass);
+        }
+        $this->routeClass = $routeClass;
+    }
+
+    /**
      * Map a route object to a callback function
      * @param  string     $pattern      The URL pattern (ie. "/books/:id")
      * @param  mixed      $callable     Anything that returns TRUE for is_callable()
@@ -121,7 +140,7 @@ class Router
      */
     public function map($pattern, $callable)
     {
-        $route = new \Slim\Route($pattern, $callable);
+        $route = new $this->routeClass($pattern, $callable);
         $this->routes[] = $route;
 
         return $route;

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -126,7 +126,7 @@ class Router
      */
     public function route($routeClass)
     {
-        if (!in_array('Slim\Route', class_parents($routeClass))) {
+        if (!class_exists($routeClass) || !in_array('Slim\Route', class_parents($routeClass))) {
             throw new \InvalidArgumentException('$routeClass not a subclass of \Slim\Route: ' . $routeClass);
         }
         $this->routeClass = $routeClass;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="tests/bootstrap.php"
+>
+    <testsuites>
+        <testsuite name="Slim Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./Slim/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -612,11 +612,13 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router->route($routeClass);
         $this->assertInstanceOf($routeClass, $router->map('/foo', $callback));
 
-        try {
-            $router->route('stdClass');
-            $this->fail('Expected exception was not thrown');
-        } catch (\InvalidArgumentException $e) {
-            $this->assertSame('$routeClass not a subclass of \Slim\Route: stdClass', $e->getMessage());
+        foreach (array('stdClass', 'NonExistentClass') as $class) {
+            try {
+                $router->route($class);
+                $this->fail('Expected exception was not thrown');
+            } catch (\InvalidArgumentException $e) {
+                $this->assertSame('$routeClass not a subclass of \Slim\Route: ' . $class, $e->getMessage());
+            }
         }
     }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -599,4 +599,24 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router = new \Slim\Router();
         $route = new \Slim\Route('/hello/:name', 'foo'); // <-- Fail fast
     }
+
+    public function testCustomRoute()
+    {
+        $router = new \Slim\Router();
+        $callback = function () { };
+
+        $this->assertInstanceOf('\Slim\Route', $router->map('/foo', $callback));
+
+        $route = $this->getMock('\Slim\Route', array(), array('/foo', 'foo'));
+        $routeClass = get_class($route);
+        $router->route($routeClass);
+        $this->assertInstanceOf($routeClass, $router->map('/foo', $callback));
+
+        try {
+            $router->route('stdClass');
+            $this->fail('Expected exception was not thrown');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertSame('$routeClass not a subclass of \Slim\Route: stdClass', $e->getMessage());
+        }
+    }
 }


### PR DESCRIPTION
At some point in the past, I threw up [this gist](https://gist.github.com/1832757) as an example of implementing custom routes in Slim. The goal of this particular example was to allow larger Slim-based codebases to separate individual route callbacks into their own files, partly for easier code navigation and partly so that minimal code would be loaded to service any given request.

Right now, using custom routes isn't possible without also implementing a custom router. This pull request removes that need by modifying `\Slim\Router` to accept the name of a subclass of `\Slim\Route` via a new `route()` method and to have its `map()` method create instances of that subclass. These modifications use `\Slim\Route` as the default to maintain backward compatibility.

If this pull request is merged, a developer would only need to subclass `\Slim\Route` rather than having to do both that and subclass `\Slim\Router` as in my gist example.
