### PR TITLE
Added support for custom router implementations to \Slim\Slim

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -607,11 +607,25 @@ class Slim
     }
 
     /**
-     * Get the Router object
+     * Get and/or set the Router object
+     *
+     * @param  string|\Slim\Router      $routerClass The name or instance of a \Slim\Router subclass
+     * @throws InvalidArgumentException If $routerClass is not the name or a \Slim\Router subclass
      * @return \Slim\Router
      */
-    public function router()
+    public function router($routerClass = null)
     {
+        if ($routerClass !== null) {
+            if ($routerClass instanceof \Slim\Router) {
+                $this->router = $routerClass;
+            } elseif (class_exists($routerClass) && in_array('Slim\Router', class_parents($routerClass))) {
+                $this->router = new $routerClass($this->request);
+            } else {
+                throw new \InvalidArgumentException('$routerClass is not an instance or name of a subclass of \Slim\Router');
+            }
+        } elseif (!$this->router) {
+            $this->router = new \Slim\Router();
+        }
         return $this->router;
     }
 

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -291,6 +291,27 @@ class SlimTest extends PHPUnit_Framework_TestCase
      ************************************************/
 
     /**
+     * Test custom router
+     */
+    public function testCustomRouter()
+    {
+        $router = $this->getMock('\Slim\Router');
+        $routerClass = get_class($router);
+        $s = new \Slim\Slim();
+
+        $this->assertInstanceOf($routerClass, $s->router($routerClass));
+
+        $this->assertSame($router, $s->router($router));
+
+        try {
+            $s->router('stdClass');
+            $this->fail('Expected exception was not thrown');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertSame('$routerClass is not an instance or name of a subclass of \Slim\Router', $e->getMessage());
+        }
+    }
+
+    /**
      * Test GENERIC route
      */
     public function testGenericRoute()


### PR DESCRIPTION
This pull request is intended to complement [this one](https://github.com/codeguy/Slim/pull/465). While it's no longer necessary to implement custom routers if the latter is merged, the former makes it easier to do so anyway.
