### PR TITLE
Add Support for PATCH HTTP Verb

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -48,6 +48,7 @@ class Request
     const METHOD_GET = 'GET';
     const METHOD_POST = 'POST';
     const METHOD_PUT = 'PUT';
+    const METHOD_PATCH = 'PATCH';
     const METHOD_DELETE = 'DELETE';
     const METHOD_OPTIONS = 'OPTIONS';
     const METHOD_OVERRIDE = '_METHOD';
@@ -106,6 +107,15 @@ class Request
     public function isPut()
     {
         return $this->getMethod() === self::METHOD_PUT;
+    }
+
+    /**
+     * Is this a PATCH request?
+     * @return bool
+     */
+    public function isPatch()
+    {
+        return $this->getMethod() === self::METHOD_PATCH;
     }
 
     /**
@@ -259,6 +269,16 @@ class Request
      * @return array|mixed|null
      */
     public function put($key = null)
+    {
+        return $this->post($key);
+    }
+
+    /**
+     * Fetch PATCH data (alias for \Slim\Http\Request::post)
+     * @param  string           $key
+     * @return array|mixed|null
+     */
+    public function patch($key = null)
     {
         return $this->post($key);
     }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -369,7 +369,7 @@ class Slim
     *******************************************************************************/
 
     /**
-     * Add GET|POST|PUT|DELETE route
+     * Add GET|POST|PUT|PATCH|DELETE route
      *
      * Adds a new route to the router with associated callable. This
      * route will only be invoked when the HTTP request's method matches
@@ -456,6 +456,18 @@ class Slim
         $args = func_get_args();
 
         return $this->mapRoute($args)->via(\Slim\Http\Request::METHOD_PUT);
+    }
+
+    /**
+     * Add PATCH route
+     * @see    mapRoute()
+     * @return \Slim\Route
+     */
+    public function patch()
+    {
+        $args = func_get_args();
+
+        return $this->mapRoute($args)->via(\Slim\Http\Request::METHOD_PATCH);
     }
 
     /**
@@ -653,7 +665,7 @@ class Slim
     /**
      * Render a template
      *
-     * Call this method within a GET, POST, PUT, DELETE, NOT FOUND, or ERROR
+     * Call this method within a GET, POST, PUT, PATCH, DELETE, NOT FOUND, or ERROR
      * callable to render a template whose output is appended to the
      * current HTTP response body. How the template is rendered is
      * delegated to the current View.

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@ $app = new \Slim\Slim();
  *
  * Here we define several Slim application routes that respond
  * to appropriate HTTP request methods. In this example, the second
- * argument for `Slim::get`, `Slim::post`, `Slim::put`, and `Slim::delete`
+ * argument for `Slim::get`, `Slim::post`, `Slim::put`, `Slim::patch`, and `Slim::delete`
  * is an anonymous function.
  */
 
@@ -136,6 +136,11 @@ $app->post('/post', function () {
 // PUT route
 $app->put('/put', function () {
     echo 'This is a PUT route';
+});
+
+// PATCH route
+$app->patch('/patch', function () {
+    echo 'This is a PATCH route';
 });
 
 // DELETE route

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -56,6 +56,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($req->isGet());
         $this->assertFalse($req->isPost());
         $this->assertFalse($req->isPut());
+        $this->assertFalse($req->isPatch());
         $this->assertFalse($req->isDelete());
         $this->assertFalse($req->isOptions());
         $this->assertFalse($req->isHead());
@@ -73,6 +74,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($req->isGet());
         $this->assertTrue($req->isPost());
         $this->assertFalse($req->isPut());
+        $this->assertFalse($req->isPatch());
         $this->assertFalse($req->isDelete());
         $this->assertFalse($req->isOptions());
         $this->assertFalse($req->isHead());
@@ -90,6 +92,25 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($req->isGet());
         $this->assertFalse($req->isPost());
         $this->assertTrue($req->isPut());
+        $this->assertFalse($req->isPatch());
+        $this->assertFalse($req->isDelete());
+        $this->assertFalse($req->isOptions());
+        $this->assertFalse($req->isHead());
+    }
+
+    /**
+     * Test HTTP PATCH method detection
+     */
+    public function testIsPatch()
+    {
+        $env = \Slim\Environment::mock(array(
+            'REQUEST_METHOD' => 'PATCH',
+        ));
+        $req = new \Slim\Http\Request($env);
+        $this->assertFalse($req->isGet());
+        $this->assertFalse($req->isPost());
+        $this->assertFalse($req->isPut());
+        $this->assertTrue($req->isPatch());
         $this->assertFalse($req->isDelete());
         $this->assertFalse($req->isOptions());
         $this->assertFalse($req->isHead());
@@ -107,6 +128,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($req->isGet());
         $this->assertFalse($req->isPost());
         $this->assertFalse($req->isPut());
+        $this->assertFalse($req->isPatch());
         $this->assertTrue($req->isDelete());
         $this->assertFalse($req->isOptions());
         $this->assertFalse($req->isHead());
@@ -124,6 +146,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($req->isGet());
         $this->assertFalse($req->isPost());
         $this->assertFalse($req->isPut());
+        $this->assertFalse($req->isPatch());
         $this->assertFalse($req->isDelete());
         $this->assertTrue($req->isOptions());
         $this->assertFalse($req->isHead());
@@ -141,6 +164,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($req->isGet());
         $this->assertFalse($req->isPost());
         $this->assertFalse($req->isPut());
+        $this->assertFalse($req->isPatch());
         $this->assertFalse($req->isDelete());
         $this->assertFalse($req->isOptions());
         $this->assertTrue($req->isHead());
@@ -337,6 +361,24 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $req->put('foo'));
         $this->assertEquals('bar', $req->params('foo'));
         $this->assertNull($req->put('xyz'));
+    }
+
+    /**
+     * Test fetch PATCH params
+     */
+    public function testPatch()
+    {
+        $env = \Slim\Environment::mock(array(
+            'REQUEST_METHOD' => 'PATCH',
+            'slim.input' => 'foo=bar&abc=123',
+            'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH' => 15
+        ));
+        $req = new \Slim\Http\Request($env);
+        $this->assertEquals(2, count($req->patch()));
+        $this->assertEquals('bar', $req->patch('foo'));
+        $this->assertEquals('bar', $req->params('foo'));
+        $this->assertNull($req->patch('xyz'));
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -287,8 +287,9 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router->map('/foo', function () {})->via('GET');
         $router->map('/foo', function () {})->via('POST');
         $router->map('/foo', function () {})->via('PUT');
+        $router->map('/foo', function () {})->via('PATCH');
         $router->map('/foo/bar/xyz', function () {})->via('DELETE');
-        $this->assertEquals(3, count($router->getMatchedRoutes()));
+        $this->assertEquals(4, count($router->getMatchedRoutes()));
     }
 
     /**

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -344,6 +344,27 @@ class SlimTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test PATCH route
+     */
+    public function testPatchRoute()
+    {
+        \Slim\Environment::mock(array(
+            'REQUEST_METHOD' => 'PATCH',
+            'SCRIPT_NAME' => '/foo', //<-- Physical
+            'PATH_INFO' => '/bar', //<-- Virtual
+        ));
+        $s = new \Slim\Slim();
+        $mw1 = function () { echo "foo"; };
+        $mw2 = function () { echo "bar"; };
+        $callable = function () { echo "xyz"; };
+        $route = $s->patch('/bar', $mw1, $mw2, $callable);
+        $s->call();
+        $this->assertEquals('foobarxyz', $s->response()->body());
+        $this->assertEquals('/bar', $route->getPattern());
+        $this->assertSame($callable, $route->getCallable());
+    }
+
+    /**
      * Test DELETE route
      */
     public function testDeleteRoute()


### PR DESCRIPTION
This patch provides explicit support for the PATCH HTTP Verb. I thought this would be nice since Backbone and other libraries support it.
