### PR TITLE
Wrong return type

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -210,7 +210,7 @@ class Slim
     /**
      * Get application instance by name
      * @param  string    $name The name of the Slim application
-     * @return \Slim|null
+     * @return Slim|null
      */
     public static function getInstance($name = 'default')
     {


### PR DESCRIPTION
getInstance returns \Slim\Slim or Slim (in namespace \Slim), not Slim.
