### PR TITLE
PATH_INFO in url rewritten applications with public directory

### DIFF
--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -145,7 +145,10 @@ class Environment implements \ArrayAccess, \IteratorAggregate
             } else {
                 $env['SCRIPT_NAME'] = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME']) ); //With URL rewrite
             }
-            $env['PATH_INFO'] = substr_replace($_SERVER['REQUEST_URI'], '', 0, strlen($env['SCRIPT_NAME']));
+            $env['PATH_INFO'] = $_SERVER['REQUEST_URI'];
+            if (strpos($_SERVER['REQUEST_URI'], $env['SCRIPT_NAME']) === 0) {
+                $env['PATH_INFO'] = preg_replace($env['SCRIPT_NAME'], '', $_SERVER['REQUEST_URI'], 1);
+            }
             if (strpos($env['PATH_INFO'], '?') !== false) {
                 $env['PATH_INFO'] = substr_replace($env['PATH_INFO'], '', strpos($env['PATH_INFO'], '?')); //query string is not removed automatically
             }


### PR DESCRIPTION
PATH_INFO was being set to "/" on most of the situations, leading to misrouting.

Example app would be:

/
-- .htaccess
-- webroot
   -- index.php

.htaccess file:

RewriteEngine On

RewriteRule ^.htaccess$ - [F]

RewriteCond %{REQUEST_URI} ^/(javascript|stylesheet|images)/._$
RewriteRule ^(._)$ /webroot/$1 [L]

RewriteCond %{REQUEST_URI} !^/webroot/._$
RewriteRule ^(._)$ /webroot/index.php [QSA,L]
