### PR TITLE
Nicely formatted error messages when using cURL

### DIFF
--- a/Slim/Middleware/PrettyExceptions.php
+++ b/Slim/Middleware/PrettyExceptions.php
@@ -82,33 +82,56 @@ class PrettyExceptions extends \Slim\Middleware
      */
     protected function renderBody(&$env, $exception)
     {
+        // Check for cURL user-agent to detect whether to send HTML or not:
+        $send_html = true;
+        if (substr($_SERVER['HTTP_USER_AGENT'], 0, 4) == 'curl') {
+            $send_html = false;
+        }
+        
         $title = 'Slim Application Error';
         $code = $exception->getCode();
         $message = $exception->getMessage();
         $file = $exception->getFile();
         $line = $exception->getLine();
         $trace = $exception->getTraceAsString();
-        $html = sprintf('<h1>%s</h1>', $title);
-        $html .= '<p>The application could not run because of the following error:</p>';
-        $html .= '<h2>Details</h2>';
-        $html .= sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
+        
+        if ($send_html) {
+            $content = sprintf('<h1>%s</h1>', $title);
+            $content .= '<p>The application could not run because of the following error:</p>';
+            $content .= '<h2>Details</h2>';
+            $content .= sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
+        } else {
+            $content = "The application could not run because of the following error:\n";
+            $content .= sprintf("Type:     %s\n", get_class($exception));
+        }
+        
         if ($code) {
-            $html .= sprintf('<div><strong>Code:</strong> %s</div>', $code);
+            $content .= $send_html ? sprintf('<div><strong>Code:</strong> %s</div>', $code) :
+                                     sprintf("Code:     %s\n", $code);
         }
         if ($message) {
-            $html .= sprintf('<div><strong>Message:</strong> %s</div>', $message);
+            $content .= $send_html ? sprintf('<div><strong>Message:</strong> %s</div>', $message) :
+                                     sprintf("Message:  %s\n", $message);
         }
         if ($file) {
-            $html .= sprintf('<div><strong>File:</strong> %s</div>', $file);
+            $content .= $send_html ? sprintf('<div><strong>File:</strong> %s</div>', $file) :
+                                     sprintf("File:     %s\n", $file);
         }
         if ($line) {
-            $html .= sprintf('<div><strong>Line:</strong> %s</div>', $line);
+            $content .= $send_html ? sprintf('<div><strong>Line:</strong> %s</div>', $line) :
+                                     sprintf("Line:     %s\n\n", $line);
         }
         if ($trace) {
-            $html .= '<h2>Trace</h2>';
-            $html .= sprintf('<pre>%s</pre>', $trace);
+            $content .= $send_html ? '<h2>Trace</h2>' :
+                                     "Trace: \n";
+            $content .= $send_html ? sprintf('<pre>%s</pre>', $trace) :
+                                     $trace;
         }
-
-        return sprintf("<html><head><title>%s</title><style>body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana,sans-serif;}h1{margin:0;font-size:48px;font-weight:normal;line-height:48px;}strong{display:inline-block;width:65px;}</style></head><body>%s</body></html>", $title, $html);
+        
+        if ($send_html) {
+            return sprintf("<html><head><title>%s</title><style>body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana,sans-serif;}h1{margin:0;font-size:48px;font-weight:normal;line-height:48px;}strong{display:inline-block;width:65px;}</style></head><body>%s</body></html>", $title, $content);
+        } else {
+            return sprintf("%s\n\n%s\n", $title, $content);
+        }
     }
 }


### PR DESCRIPTION
I have been building an API for a website I built using Slim and, whilst testing, have been using cURL to post data to the API. Whenever I made a mistake in the code, the error messages I received were hard to read and obfuscated by HTML tags, no linebreaks, etc.

To help my testing, I added a check into Slim/Middleware/PrettyExceptions.php to detect whether the user is connecting with cURL and, if they are, output the error message and debugging information as plaintext.

This has been quite useful to me and I predict that others will find it useful too as I suspect that a popular use of Slim may be developing simple APIs. If it's something you'd rather not include however, that's ok too :-)
