### PR TITLE
Support 'ANY' Route Method

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -100,7 +100,7 @@ class Router
         if ($reload || is_null($this->matchedRoutes)) {
             $this->matchedRoutes = array();
             foreach ($this->routes as $route) {
-                if (!$route->supportsHttpMethod($httpMethod)) {
+                if (!$route->supportsHttpMethod($httpMethod) && !$route->supportsHttpMethod("ANY")) {
                     continue;
                 }
 

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -483,6 +483,18 @@ class Slim
     }
 
     /**
+     * Add route for any HTTP method
+     * @see    mapRoute()
+     * @return \Slim\Route
+     */
+    public function any()
+    {
+        $args = func_get_args();
+
+        return $this->mapRoute($args)->via("ANY");
+    }
+
+    /**
      * Not Found Handler
      *
      * This method defines or invokes the application-wide Not Found handler.

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -414,6 +414,30 @@ class SlimTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test ANY route
+     */
+    public function testAnyRoute()
+    {
+        $mw1 = function () { echo "foo"; };
+        $mw2 = function () { echo "bar"; };
+        $callable = function () { echo "xyz"; };
+        $methods = array('GET', 'POST', 'PUT', 'DELETE', 'OPTIONS');
+        foreach ($methods as $i => $method) {
+            \Slim\Environment::mock(array(
+                'REQUEST_METHOD' => $method,
+                'SCRIPT_NAME' => '/foo', //<-- Physical
+                'PATH_INFO' => '/bar', //<-- Virtual
+            ));
+            $s = new \Slim\Slim();
+            $route = $s->any('/bar', $mw1, $mw2, $callable);
+            $s->call();
+            $this->assertEquals('foobarxyz', $s->response()->body());
+            $this->assertEquals('/bar', $route->getPattern());
+            $this->assertSame($callable, $route->getCallable());
+        }
+    }
+
+    /**
      * Test if route does NOT expect trailing slash and URL has one
      */
     public function testRouteWithoutSlashAndUrlWithOne()


### PR DESCRIPTION
## ANY Routes

This adds a 'short circuit' for routes with the ANY method, so that they will match all HTTP methods (even made up ones).

The main functionality comes from the change in the router class. Instead of this:

``` php
if (!$route->supportsHttpMethod($httpMethod)) {
```

I changed it to:

``` php
if (!$route->supportsHttpMethod($httpMethod) && !$route->supportsHttpMethod("ANY")) {
```

Other additions include a helper method inside the Slim class (named <code>any</code>) and a unit-test in the SlimTest.php file
