### PR TITLE
Fixed Tests for PHP 5.3

### DIFF
--- a/tests/Helper/SetTest.php
+++ b/tests/Helper/SetTest.php
@@ -43,7 +43,8 @@ class SetTest extends PHPUnit_Framework_TestCase
     {
         $this->bag->set('foo', 'bar');
         $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));
-        $this->assertEquals('bar', $this->property->getValue($this->bag)['foo']);
+		$bag =  $this->property->getValue($this->bag);
+        $this->assertEquals('bar', $bag['foo']);
     }
 
     public function testGet()
@@ -66,8 +67,9 @@ class SetTest extends PHPUnit_Framework_TestCase
         ));
         $this->assertArrayHasKey('abc', $this->property->getValue($this->bag));
         $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));
-        $this->assertEquals('123', $this->property->getValue($this->bag)['abc']);
-        $this->assertEquals('bar', $this->property->getValue($this->bag)['foo']);
+		$bag = $this->property->getValue($this->bag);
+        $this->assertEquals('123', $bag['abc']);
+        $this->assertEquals('bar', $bag['foo']);
     }
 
     public function testAll()
@@ -119,7 +121,8 @@ class SetTest extends PHPUnit_Framework_TestCase
         );
         $this->property->setValue($this->bag, $data);
         $this->bag['foo'] = 'changed';
-        $this->assertEquals('changed', $this->property->getValue($this->bag)['foo']);
+		$bag = $this->property->getValue($this->bag);
+        $this->assertEquals('changed', $bag['foo']);
     }
 
     public function testArrayAccessExists()

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -66,7 +66,8 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $property = new \ReflectionProperty($router, 'namedRoutes');
         $property->setAccessible(true);
 
-        $this->assertSame($route, $property->getValue($router)['foo']);
+		$rV = $property->getValue($router);
+        $this->assertSame($route, $rV['foo']);
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -211,9 +211,15 @@ class RouterTest extends PHPUnit_Framework_TestCase
     public function testGetMatchedRoutes()
     {
         $router = new \Slim\Router();
-        $route1 = (new \Slim\Route('/foo', function () {}))->via('GET');
-        $route2 = (new \Slim\Route('/foo', function () {}))->via('POST');
-        $route3 = (new \Slim\Route('/bar', function () {}))->via('PUT');
+
+        $route1 = new \Slim\Route('/foo', function () {});
+		$route1 = $route1->via('GET');
+
+        $route2 = new \Slim\Route('/foo', function () {});
+		$route2 = $route2->via('POST');
+
+        $route3 = new \Slim\Route('/bar', function () {});
+		$route3 = $route3->via('PUT');
 
         $routes = new \ReflectionProperty($router, 'routes');
         $routes->setAccessible(true);
@@ -228,7 +234,8 @@ class RouterTest extends PHPUnit_Framework_TestCase
     public function testUrlFor()
     {
         $router = new \Slim\Router();
-        $route1 = (new \Slim\Route('/hello/:first/:last', function () {}))->via('GET')->name('hello');
+        $route1 = new \Slim\Route('/hello/:first/:last', function () {});
+		$route1 = $route1->via('GET')->name('hello');
 
         $routes = new \ReflectionProperty($router, 'namedRoutes');
         $routes->setAccessible(true);


### PR DESCRIPTION
There were a few function dereferencing in the tests which caused the tests to fail in PHP 5.3
