### PR TITLE
Added slim.before.render default hook

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -118,6 +118,7 @@ class Slim
         'slim.before' => array(array()),
         'slim.before.router' => array(array()),
         'slim.before.dispatch' => array(array()),
+        'slim.before.render' => array(array()),
         'slim.after.dispatch' => array(array()),
         'slim.after.router' => array(array()),
         'slim.after' => array(array())
@@ -670,6 +671,7 @@ class Slim
         }
         $this->view->setTemplatesDirectory($this->config('templates.path'));
         $this->view->appendData($data);
+        $this->applyHook('slim.before.render');
         $this->view->display($template);
     }
 


### PR DESCRIPTION
This hook is applied directly before the template render call.

A common use case for this hook would be:

``` php
$app->hook('slim.before.render', function () use ($twig) {
  $twig->addGlobal("session",$_SESSION);
});
```

So the latest possible values in the $_SESSION will be available to the view template regardless of where they are set in the app life cycle.
