### PR TITLE
New Feature - Route Groups

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -64,11 +64,17 @@ class Router
     protected $matchedRoutes;
 
     /**
+     * @var array Array containing all route groups
+     */
+    protected $routeGroups;
+
+    /**
      * Constructor
      */
     public function __construct()
     {
         $this->routes = array();
+        $this->routeGroups = array();
     }
 
     /**
@@ -121,10 +127,61 @@ class Router
      */
     public function map($pattern, $callable)
     {
+        list($groupPattern, $groupMiddleware) = $this->processGroups();
+        if (count($this->routeGroups) > 0) {
+            $pattern = $groupPattern . ltrim($pattern, '/');
+        }
         $route = new \Slim\Route($pattern, $callable);
         $this->routes[] = $route;
 
+        if (count($this->routeGroups) > 0) {
+            foreach ($groupMiddleware as $middlewareArr) {
+                if (is_array($middlewareArr)) {
+                    foreach ($middlewareArr as $middleware) {
+                        $route->setMiddleware($middleware);
+                    }
+                }
+            }
+        }
+
         return $route;
+    }
+
+    /**
+     * A helper function for proccesing the group's pattern and middleware
+     * @return array Returns an array with the elements: pattern, middlewareArr
+     */
+    protected function processGroups()
+    {
+        $pattern = "/";
+        $middleware = array();
+        foreach ($this->routeGroups as $group) {
+            $k = key($group);
+            $pattern .= $k . "/";
+            array_push($middleware, $group[$k]);
+        }
+        return array($pattern, $middleware);
+    }
+
+    /**
+     * Add a route group to the array
+     * @param  string     $group      The group pattern (ie. "/books/:id")
+     * @param  array|null $middleware Optional parameter array of middleware 
+     * @return int        The index of the new group
+     */
+    public function pushGroup($group, $middleware = null)
+    {
+        $group = trim($group, '/');
+        return array_push($this->routeGroups, array($group => $middleware));
+    }
+
+    /**
+     * Removes the last route group from the array
+     * @return bool    True if successful, else False
+     */
+    public function popGroup()
+    {
+        return (array_pop($this->routeGroups) !== null);
     }
 
     /**

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -483,6 +483,29 @@ class Slim
     }
 
     /**
+     * Route Groups
+     *
+     * This method accepts a route pattern and a callback all Route
+     * declarations in the callback will be prepended by the group(s)
+     * that it is in
+     *
+     * Accepts the same paramters as a standard route so:
+     * (pattern, middleware1, middleware2, ..., $callback)
+     */
+
+    public function group()
+    {
+        $args = func_get_args();
+        $pattern = array_shift($args);
+        $callable = array_pop($args);
+        $this->router->pushGroup($pattern, $args);
+        if (is_callable($callable)) {
+            call_user_func($callable);
+        }
+        $this->router->popGroup();
+    }
+
+    /**
      * Not Found Handler
      *
      * This method defines or invokes the application-wide Not Found handler.

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -414,6 +414,27 @@ class SlimTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+    * Test route groups
+    */
+    public function testRouteGroups()
+    {
+        \Slim\Environment::mock(array(
+            'REQUEST_METHOD' => 'GET',
+            'SCRIPT_NAME' => '/foo', //<-- Physical
+            'PATH_INFO' => '/bar/baz', //<-- Virtual'
+        ));
+        $s = new \Slim\Slim();
+        $mw1 = function () { echo "foo"; };
+        $mw2 = function () { echo "bar"; };
+        $callable = function () { echo "xyz"; };
+        $s->group('/bar', $mw1, function () use ($s, $mw2, $callable) {
+            $s->get('/baz', $mw2, $callable);
+        });
+        $s->call();
+        $this->assertEquals('foobarxyz', $s->response()->body());
+    }
+
+    /**
      * Test if route does NOT expect trailing slash and URL has one
      */
     public function testRouteWithoutSlashAndUrlWithOne()


### PR DESCRIPTION
# Route Groups

This pull-request adds the ability to declare route groups. It accepts the same parameters as the route functions do (i.e. pattern, mw1, mw2, etc... callable), and will work with placeholders in the pattern.
## Usage
#### Basic Use

``` php
$app->group('/v1.0/', $mw, function () use ($app) {
    $app->get('/users', function() {
        echo "This is a route for '/v1.0/users';
    }
});
```
#### Using Placeholders

``` php
$app->group('/users/:name', function () use ($app) {
    $app->get('/posts/:id', function ($name, $id) {
        echo "Showing post id #" . $id . " for user " . $name; 
    });
});
```
#### Nesting Groups

``` php
$mw = function () { echo "Middleware 1 - "; };
$app->group('/v1.0/', $mw, function () use ($app) {

    $mw = function () { echo "Middleware 2 - "; };
    $app->group('/users/', $mw, function () use ($app) {

        $mw = function () { echo "Middleware 3 - "; };
        $app->get('/:name', $mw, function ($name) {
            echo "Hello " . $name;
        });

    });
});
```
