### PR TITLE
allow prepending to routes

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -401,7 +401,10 @@ class Slim
     protected function mapRoute($args)
     {
         $pattern = array_shift($args);
-        $callable = array_pop($args);
+	$callable = array_pop($args);
+	if(isset($this->settings['prependToRoutes'])) {
+		$pattern = $this->settings['prependToRoutes'] . $pattern;
+	}
         $route = $this->router->map($pattern, $callable);
         if (count($args) > 0) {
             $route->setMiddleware($args);


### PR DESCRIPTION
The ability to prepend to existing routes is ideal for api's that may have multiple versions (i.e. appending api.example.com/1.4/users where the version is the prepend portion).

the ability to pass a setting called 'prependToRoutes' will now allow users to add data such as a version number to the front of all roues for a given app.
