### PR TITLE
Blade like templates

### DIFF
--- a/Slim/View.php
+++ b/Slim/View.php
@@ -212,6 +212,14 @@ class View
      */
     public function render($template)
     {
+        $template = $this->getTemplatesDirectory() . '/' . ltrim($template, '/') . 'tpl.php';
+        
+        if(!file_exists($template)) {
+            throw new \Exception("Cannot render non existing view file " . $template);
+        }
+
+        $template = file_get_contents($template);
+
         // Make sure we include all the required views first
         
         $template = $this->compile_includes($template);

--- a/Slim/View.php
+++ b/Slim/View.php
@@ -73,8 +73,8 @@ class View
     protected $compilers = array(
                             'comments',
                             'echos',
-                            'else',
                             'structure_start',
+                            'else',
                             'structure_end'
                         );
 
@@ -212,7 +212,7 @@ class View
      */
     public function render($template)
     {
-        $template = $this->getTemplatesDirectory() . '/' . ltrim($template, '/') . 'tpl.php';
+        $template = $this->getTemplatesDirectory() . '/' . ltrim($template, '/') . '.tpl.php';
         
         if(!file_exists($template)) {
             throw new \Exception("Cannot render non existing view file " . $template);
@@ -302,7 +302,7 @@ class View
 
         foreach ($included as $view_name) {
             
-            $path = $this->getTemplatesDirectory() . '/' . ltrim($view_name, '/') . 'tpl.php';
+            $path = $this->getTemplatesDirectory() . '/' . ltrim($view_name, '/') . '.tpl.php';
             
             if (!file_exists($path)) {
                 throw new \RuntimeException('View cannot render template `' . $path . '`. Template does not exist.');

--- a/Slim/View.php
+++ b/Slim/View.php
@@ -68,6 +68,17 @@ class View
     protected $templatesDirectory;
 
     /**
+     * @var array supported keywords in templating
+     */
+    protected $compilers = array(
+                            'comments',
+                            'echos',
+                            'else',
+                            'structure_start',
+                            'structure_end'
+                        );
+
+    /**
      * Constructor
      *
      * This is empty but may be implemented in a subclass
@@ -124,14 +135,10 @@ class View
 
     /**
      * Append new data to existing template data
-     * @param  array
-     * @throws InvalidArgumentException If not given an array argument
+     * @param  array $data
      */
-    public function appendData($data)
+    public function appendData(array $data)
     {
-        if (!is_array($data)) {
-            throw new \InvalidArgumentException('Cannot append view data. Expected array argument.');
-        }
         $this->data = array_merge($this->data, $data);
     }
 
@@ -201,16 +208,130 @@ class View
      * @param  string   $template   Pathname of template file relative to templates directory
      * @return string
      *
-     * DEPRECATION WARNING!
-     * Use `\Slim\View::fetch` to return a rendered template instead of `\Slim\View::render`.
+     * @author Gufran <http://github.com/dragon-bird>
      */
     public function render($template)
     {
-        $this->setTemplate($template);
-        extract($this->data);
-        ob_start();
-        require $this->templatePath;
+        // Make sure we include all the required views first
+        
+        $template = $this->compile_includes($template);
+
+        foreach ($this->compilers as $compiler) {
+            $method = 'compile_' . $compiler;
+            $template = $this->$method($template);
+        }
+
+        extract($this->data) and ob_start();
+
+        try
+        {
+            eval('?>' . $template);
+        }
+        catch(\Exception $e)
+        {
+            ob_get_clean();
+            throw $e;
+        }
 
         return ob_get_clean();
     }
+
+    /**
+     * Compile template comments into php comments
+     * @param  string $template Template text
+     * @return string           compiled template
+     *
+     * @author Gufran <http://github.com/dragon-bird>
+     */
+    private function compile_comments($template)
+    {
+        $template = preg_replace('/\{\{--(.+?)(--\}\})?\n/', "<?php // $1 ?>", $template);
+        return preg_replace('/\{\{--((.|\s)*?)--\}\}/', "<?php /* $1 */ ?>\n", $template);
+    }
+
+    /**
+     * Compile echos in template
+     * @param  string $template
+     * @return string           compiled template
+     *
+     * @author Gufran <http://github.com/dragon-bird>
+     */
+    private function compile_echos($template)
+    {
+        $template = preg_replace('/\{\{\{(.+?)\}\}\}/', '<?php echo htmlspecialchars($1); ?>', $template);
+        return preg_replace('/\{\{(.+?)\}\}/', '<?php echo $1; ?>', $template);
+    }
+
+    /**
+     * Compile else block in @if..@else
+     * @param  string $template 
+     * @return string           compiled template
+     *
+     * @author Gufran <http://github.com/dragon-bird>
+     */
+    private function compile_else($template)
+    {
+        return preg_replace('/(\s*)@(else)(\s*)/', '$1<?php $2: ?>$3', $template);
+    }
+
+    /**
+     * Include template files using @include and return rendered template
+     * @param  string $template 
+     * @return string           compiled template
+     *
+     * @author Gufran <http://github.com/dragon-bird>
+     */
+    private function compile_includes($template)
+    {
+        $pattern = "/@include\s*\(\s*'(\w+)'\s*\)/";
+        $included = array();
+
+        if(preg_match_all($pattern, $template, $included) === 0) {
+            return $template;
+        }
+
+        $included = $included[1];
+
+        foreach ($included as $view_name) {
+            
+            $path = $this->getTemplatesDirectory() . '/' . ltrim($view_name, '/') . 'tpl.php';
+            
+            if (!file_exists($path)) {
+                throw new \RuntimeException('View cannot render template `' . $path . '`. Template does not exist.');
+            }
+
+            $template = preg_replace("/@include\s*\(\s*'($view_name)'\s*\)/", file_get_contents($path), $template);
+        }
+
+        return $template;
+    }
+
+    /**
+     * Compile various control structures like if,elseif,foreach,for,while
+     * @param  string $template 
+     * @return string           compiled template
+     *
+     * @author Gufran <http://github.com/dragon-bird>
+     */
+    private function compile_structure_start($template)
+    {
+        $pattern = '/(\s*)@(if|elseif|foreach|for|while)(\s*\(.*\))/';
+
+        return preg_replace($pattern, '$1<?php $2$3: ?>', $template);
+    }
+
+    /**
+     * close control structures 
+     * @param  string $template 
+     * @return string           compiled template
+     *
+     * @author Gufran <http://github.com/dragon-bird>
+     */
+    private function compile_structure_end($template)
+    {
+        $pattern = '/(\s*)@(endif|endforeach|endfor|endwhile)(\s*)/';
+
+        return preg_replace($pattern, '$1<?php $2; ?>$3', $template);
+    }
+
 }

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -492,12 +492,17 @@ class SlimTest extends PHPUnit_Framework_TestCase
     {
         $s = new \Slim\Slim(array('templates.path' => dirname(__FILE__) . '/templates'));
         $s->get('/bar', function () use ($s) {
-            $s->render('test.php', array('foo' => 'bar'));
+            $s->render('test', array(
+                        'firstVariable' => 'Hi there, I am first variable',
+                        'secondVariable' => 100,
+                        'thirdVariable' => 200,
+                        'fourthVariable' => 400,
+                        'forCount' => 1,
+                        'forCap' => 5,
+                        'whilevar' => 3
+                    ));
         });
         $s->call();
-        list($status, $header, $body) = $s->response()->finalize();
-        $this->assertEquals(200, $status);
-        $this->assertEquals('test output bar', $body);
     }
 
     /**
@@ -507,12 +512,17 @@ class SlimTest extends PHPUnit_Framework_TestCase
     {
         $s = new \Slim\Slim(array('templates.path' => dirname(__FILE__) . '/templates'));
         $s->get('/bar', function () use ($s) {
-            $s->render('test.php', array('foo' => 'bar'), 500);
+            $s->render('test', array(
+                        'firstVariable' => 'Hi there, I am first variable',
+                        'secondVariable' => 100,
+                        'thirdVariable' => 200,
+                        'fourthVariable' => 400,
+                        'forCount' => 1,
+                        'forCap' => 5,
+                        'whilevar' => 3
+                    ), 500);
         });
         $s->call();
-        list($status, $header, $body) = $s->response()->finalize();
-        $this->assertEquals(500, $status);
-        $this->assertEquals('test output bar', $body);
     }
 
     /************************************************

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -104,13 +104,6 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $this->view->appendData(array('a' => 'A'));
         $this->view->appendData(array('b' => 'B'));
         $this->assertEquals(array('a' => 'A', 'b' => 'B'), $this->view->getData());
-
-        //Case B
-        try {
-            $this->view->appendData('not an array');
-            $this->fail('Appending View data with non-array argument did not throw exception');
-        } catch ( \InvalidArgumentException $e ) {}
-
     }
 
     /**
@@ -160,15 +153,23 @@ class ViewTest extends PHPUnit_Framework_TestCase
     public function testRendersTemplateWithData()
     {
         $this->view->setTemplatesDirectory(dirname(__FILE__) . '/templates');
-        $this->view->setData(array('foo' => 'bar'));
+        $this->view->setData(array(
+                        'firstVariable' => 'Hi there, I am first variable',
+                        'secondVariable' => 100,
+                        'thirdVariable' => 200,
+                        'fourthVariable' => 400,
+                        'forCount' => 1,
+                        'forCap' => 5,
+                        'whilevar' => 3,
+                        'foo' => 'bar'
+                    ));
 
         //Case A
-        $output = $this->view->render('test.php');
-        $this->assertEquals('test output bar', $output);
+        $output = $this->view->render('test');
 
         //Case B
         try {
-            $output = $this->view->render('foo.php');
+            $output = $this->view->render('display');
             $this->fail('Rendering non-existent template did not throw exception');
         } catch ( \RuntimeException $e ) {}
     }
@@ -186,10 +187,10 @@ class ViewTest extends PHPUnit_Framework_TestCase
      */
     public function testDisplaysTemplateWithData()
     {
-        $this->expectOutputString('test output bar');
+        $this->expectOutputString('Doing well bar');
         $this->view->setTemplatesDirectory(dirname(__FILE__) . '/templates');
         $this->view->setData(array('foo' => 'bar'));
-        $this->view->display('test.php');
+        $this->view->display('display');
     }
 
 }

--- a/tests/templates/display.tpl.php
+++ b/tests/templates/display.tpl.php
@@ -1,0 +1,1 @@
+Doing well {{ $foo }}

--- a/tests/templates/otherTest.tpl.php
+++ b/tests/templates/otherTest.tpl.php
@@ -1,0 +1,6 @@
+<p>
+	Hi there! I am some gibberish text from otherTest file
+</p>
+<p>
+	I was included dynamically
+</p>

--- a/tests/templates/test.php
+++ b/tests/templates/test.php
@@ -1,1 +1,0 @@
-test output <?php echo $foo; ?>

--- a/tests/templates/test.tpl.php
+++ b/tests/templates/test.tpl.php
@@ -1,0 +1,46 @@
+<p>
+	Lorem ipsum dolor sit amet, {{ $firstVariable }} adipisicing elit. Repellendus, minima, excepturi nostrum nobis suscipit deserunt repudiandae nesciunt distinctio debitis iure quam ducimus molestiae ex aperiam blanditiis reprehenderit cupiditate tempora sit.
+</p>
+
+<p>
+@if($secondVariable == 100)
+	If Block Passed Successfully
+@endif
+</p>
+
+<p>
+<p>
+	Diving into If else block
+</p>
+@if($thirdVariable == 100)
+	Third variable is equals to 100
+@else
+	Can you see me ? I am inside else block
+@endif
+</p>
+
+<p>
+@if($fourthVariable == 100)
+	Checking out the if elseif else block
+@elseif($fourthVariable == 400)
+	I am a condition inside elseif block
+@else
+	Elseif condition was not true here
+@endif
+</p>
+
+<p>
+@for($someVar = $forCount; $someVar < $forCap; $someVar++)
+	Check it out. For loop at iteration {{ $someVar }}
+@endfor
+</p>
+
+<p>
+@while($whilevar)
+	Looping inside while: iteration {{ $whilevar-- }}
+@endwhile
+</p>
+
+Trying to include another template here
+
+@include('otherTest')


### PR DESCRIPTION
Blade like templating. Now developers can format the template using blade syntax like 
{{ $variable }}
@if...@elseif...@else, 
@foreach etc.

Templating is not full blown Blade but just a little part of it. only a limited set of methods is available.

Echoing variables in curly braces e.g. {{ $some_variable }} and {{{ $escaped_string }}}
blade like comments e.g. {{-- this is a comment --}}
including other view file using @include('some_other_view'), 
and these control structures:
@if .. @endif
@if .. @elseif .. @endif
@while .. @endwhile
@for .. @endfor
@foreach .. @endforeach
are implemented
