### PR TITLE
Added query params support to nginx

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,7 +66,7 @@ should contain this code:
 
 Your nginx configuration file should contain this code (along with other settings you may need) in your `location` block:
 
-    try_files $uri $uri/ /index.php;
+    try_files $uri $uri/ /index.php?$args;
 
 This assumes that Slim's `index.php` is in the root folder of your project (www root).
 


### PR DESCRIPTION
The documentation for the nginx configuration did not send query parameters in
the URL to the calling code. This means something like /test?hello=world would
fail to set the $_GET superglobal with the 'hello' key.
