### PR TITLE
Make Slim PSR compliant

### DIFF
--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -87,7 +87,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
      */
     public static function mock($userSettings = array())
     {
-        self::$environment = new self(array_merge(array(
+        $defaults = array(
             'REQUEST_METHOD' => 'GET',
             'SCRIPT_NAME' => '',
             'PATH_INFO' => '',
@@ -102,7 +102,8 @@ class Environment implements \ArrayAccess, \IteratorAggregate
             'slim.url_scheme' => 'http',
             'slim.input' => '',
             'slim.errors' => @fopen('php://stderr', 'w')
-        ), $userSettings));
+        );
+        self::$environment = new self(array_merge($defaults, $userSettings));
 
         return self::$environment;
     }
@@ -143,7 +144,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
             if (strpos($_SERVER['REQUEST_URI'], $_SERVER['SCRIPT_NAME']) === 0) {
                 $env['SCRIPT_NAME'] = $_SERVER['SCRIPT_NAME']; //Without URL rewrite
             } else {
-                $env['SCRIPT_NAME'] = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME']) ); //With URL rewrite
+                $env['SCRIPT_NAME'] = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME'])); //With URL rewrite
             }
             $env['PATH_INFO'] = substr_replace($_SERVER['REQUEST_URI'], '', 0, strlen($env['SCRIPT_NAME']));
             if (strpos($env['PATH_INFO'], '?') !== false) {

--- a/Slim/Exception/Pass.php
+++ b/Slim/Exception/Pass.php
@@ -46,5 +46,4 @@ namespace Slim\Exception;
  */
 class Pass extends \Exception
 {
-
 }

--- a/Slim/Exception/Stop.php
+++ b/Slim/Exception/Stop.php
@@ -44,5 +44,4 @@ namespace Slim\Exception;
  */
 class Stop extends \Exception
 {
-
 }

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -444,7 +444,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Exists
      */
-    public function offsetExists( $offset )
+    public function offsetExists($offset)
     {
         return isset($this->headers[$offset]);
     }
@@ -452,7 +452,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Get
      */
-    public function offsetGet( $offset )
+    public function offsetGet($offset)
     {
         return $this->headers[$offset];
     }

--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -58,7 +58,7 @@ class Util
     {
         $strip = is_null($overrideStripSlashes) ? get_magic_quotes_gpc() : $overrideStripSlashes;
         if ($strip) {
-            return self::_stripSlashes($rawData);
+            return self::stripSlashes($rawData);
         } else {
             return $rawData;
         }
@@ -69,9 +69,9 @@ class Util
      * @param  array|string $rawData
      * @return array|string
      */
-    protected static function _stripSlashes($rawData)
+    protected static function stripSlashes($rawData)
     {
-        return is_array($rawData) ? array_map(array('self', '_stripSlashes'), $rawData) : stripslashes($rawData);
+        return is_array($rawData) ? array_map(array('self', 'stripSlashes'), $rawData) : stripslashes($rawData);
     }
 
     /**
@@ -95,10 +95,11 @@ class Util
         }
 
         //Merge settings with defaults
-        $settings = array_merge(array(
+        $defaults = array(
             'algorithm' => MCRYPT_RIJNDAEL_256,
             'mode' => MCRYPT_MODE_CBC
-        ), $settings);
+        );
+        $settings = array_merge($defaults, $settings);
 
         //Get module
         $module = mcrypt_module_open($settings['algorithm'], '', $settings['mode'], '');
@@ -144,10 +145,11 @@ class Util
         }
 
         //Merge settings with defaults
-        $settings = array_merge(array(
+        $defaults = array(
             'algorithm' => MCRYPT_RIJNDAEL_256,
             'mode' => MCRYPT_MODE_CBC
-        ), $settings);
+        );
+        $settings = array_merge($defaults, $settings);
 
         //Get module
         $module = mcrypt_module_open($settings['algorithm'], '', $settings['mode'], '');
@@ -190,11 +192,18 @@ class Util
     public static function encodeSecureCookie($value, $expires, $secret, $algorithm, $mode)
     {
         $key = hash_hmac('sha1', $expires, $secret);
-        $iv = self::get_iv($expires, $secret);
-        $secureString = base64_encode(self::encrypt($value, $key, $iv, array(
-            'algorithm' => $algorithm,
-            'mode' => $mode
-        )));
+        $iv = self::getIv($expires, $secret);
+        $secureString = base64_encode(
+            self::encrypt(
+                $value,
+                $key,
+                $iv,
+                array(
+                    'algorithm' => $algorithm,
+                    'mode' => $mode
+                )
+            )
+        );
         $verificationString = hash_hmac('sha1', $expires . $value, $key);
 
         return implode('|', array($expires, $secureString, $verificationString));
@@ -220,11 +229,16 @@ class Util
             $value = explode('|', $value);
             if (count($value) === 3 && ((int) $value[0] === 0 || (int) $value[0] > time())) {
                 $key = hash_hmac('sha1', $value[0], $secret);
-                $iv = self::get_iv($value[0], $secret);
-                $data = self::decrypt(base64_decode($value[1]), $key, $iv, array(
-                    'algorithm' => $algorithm,
-                    'mode' => $mode
-                ));
+                $iv = self::getIv($value[0], $secret);
+                $data = self::decrypt(
+                    base64_decode($value[1]),
+                    $key,
+                    $iv,
+                    array(
+                        'algorithm' => $algorithm,
+                        'mode' => $mode
+                    )
+                );
                 $verificationString = hash_hmac('sha1', $value[0] . $data, $key);
                 if ($verificationString === $value[2]) {
                     return $data;
@@ -378,7 +392,7 @@ class Util
      * @param  string $secret  The secret key used to hash the cookie value
      * @return binary string with length 40
      */
-    private static function get_iv($expires, $secret)
+    private static function getIv($expires, $secret)
     {
         $data1 = hash_hmac('sha1', 'a'.$expires.'b', $secret);
         $data2 = hash_hmac('sha1', 'z'.$expires.'y', $secret);

--- a/Slim/Log.php
+++ b/Slim/Log.php
@@ -39,11 +39,15 @@ namespace Slim;
  * a Log Writer in conjunction with this Log to write to various output
  * destinations (e.g. a file). This class provides this interface:
  *
- * debug( mixed $object )
- * info( mixed $object )
- * warn( mixed $object )
- * error( mixed $object )
- * fatal( mixed $object )
+ * debug( mixed $object, array $context )
+ * info( mixed $object, array $context )
+ * notice( mixed $object, array $context )
+ * warning( mixed $object, array $context )
+ * error( mixed $object, array $context )
+ * critical( mixed $object, array $context ) 
+ * alert( mixed $object, array $context )
+ * emergency( mixed $object, array $context )
+ * log( mixed $level, mixed $object, array $context )
  *
  * This class assumes only that your Log Writer has a public `write()` method
  * that accepts any object as its one and only argument. The Log Writer
@@ -56,21 +60,28 @@ namespace Slim;
  */
 class Log
 {
-    const FATAL = 0;
-    const ERROR = 1;
-    const WARN = 2;
-    const INFO = 3;
-    const DEBUG = 4;
+    const EMERGENCY = 1;
+    const ALERT     = 2;
+    const CRITICAL  = 3;
+    const FATAL     = 3; //Depracated replace with CRITICAL
+    const ERROR     = 4;
+    const WARN      = 5;
+    const NOTICE    = 6;
+    const INFO      = 7;
+    const DEBUG     = 8;
 
     /**
      * @var array
      */
     protected static $levels = array(
-        self::FATAL => 'FATAL',
-        self::ERROR => 'ERROR',
-        self::WARN =>  'WARN',
-        self::INFO =>  'INFO',
-        self::DEBUG => 'DEBUG'
+        self::EMERGENCY => 'EMERGENCY',
+        self::ALERT     => 'ALERT',
+        self::CRITICAL  => 'CRITICAL',
+        self::ERROR     => 'ERROR',
+        self::WARN      => 'WARNING',
+        self::NOTICE    => 'NOTICE',
+        self::INFO      => 'INFO',
+        self::DEBUG     => 'DEBUG'
     );
 
     /**
@@ -173,54 +184,143 @@ class Log
     /**
      * Log debug message
      * @param  mixed       $object
+     * @param  array       $context
      * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
      */
-    public function debug($object)
+    public function debug($object, $context = array())
     {
-        return $this->write($object, self::DEBUG);
+        return $this->log(self::DEBUG, $object, $context);
     }
 
     /**
      * Log info message
      * @param  mixed       $object
+     * @param  array       $context
      * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
      */
-    public function info($object)
+    public function info($object, $context = array())
     {
-        return $this->write($object, self::INFO);
+        return $this->log(self::INFO, $object, $context);
     }
 
     /**
-     * Log warn message
+     * Log notice message
      * @param  mixed       $object
+     * @param  array       $context
      * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
      */
-    public function warn($object)
+    public function notice($object, $context = array())
     {
-        return $this->write($object, self::WARN);
+        return $this->log(self::NOTICE, $object, $context);
+    }
+
+    /**
+     * Log warning message
+     * @param  mixed       $object
+     * @param  array       $context
+     * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
+     */
+    public function warning($object, $context = array())
+    {
+        return $this->log(self::WARN, $object, $context);
+    }
+
+    /**
+     * DEPRACATED for function warning
+     * Log warning message
+     * @param  mixed       $object
+     * @param  array       $context
+     * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
+     */
+    public function warn($object, $context = array())
+    {
+        return $this->log(self::WARN, $object, $context);
     }
 
     /**
      * Log error message
      * @param  mixed       $object
+     * @param  array       $context
      * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
      */
-    public function error($object)
+    public function error($object, $context = array())
     {
-        return $this->write($object, self::ERROR);
+        return $this->log(self::ERROR, $object, $context);
     }
 
     /**
+     * Log critical message
+     * @param  mixed       $object
+     * @param  array       $context
+     * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
+     */
+    public function critical($object, $context = array())
+    {
+        return $this->log(self::CRITICAL, $object, $context);
+    }
+
+    /**
+     * DEPRACATED for function critical
      * Log fatal message
      * @param  mixed       $object
+     * @param  array       $context
      * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
      */
-    public function fatal($object)
+    public function fatal($object, $context = array())
     {
-        return $this->write($object, self::FATAL);
+        return $this->log(self::CRITICAL, $object, $context);
     }
 
     /**
+     * Log alert message
+     * @param  mixed       $object
+     * @param  array       $context
+     * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
+     */
+    public function alert($object, $context = array())
+    {
+        return $this->log(self::ALERT, $object, $context);
+    }
+
+    /**
+     * Log emergency message
+     * @param  mixed       $object
+     * @param  array       $context
+     * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
+     */
+    public function emergency($object, $context = array())
+    {
+        return $this->log(self::EMERGENCY, $object, $context);
+    }
+
+    /**
+     * Log message
+     * @param  mixed       $level
+     * @param  mixed       $object
+     * @param  array       $context
+     * @return mixed|false What the Logger returns, or false if Logger not set or not enabled
+     */
+    public function log($level, $object, $context = array())
+    {
+        if (!isset(self::$levels[$level])) {
+            throw new \InvalidArgumentException('Invalid log level supplied to function');
+        } else if ($this->enabled && $this->writer && $level <= $this->level) {
+            $message = (string)$object;
+            if (count($context) > 0) {
+                if (isset($context['exception']) && $context['exception'] instanceof \Exception) {
+                    $message .= ' - ' . $context['exception'];
+                    unset($context['exception']);
+                }
+                $message = $this->interpolate($message, $context);
+            }
+            return $this->writer->write($message, $level);
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * DEPRACATED for function log
      * Log message
      * @param   mixed   The object to log
      * @param   int     The message level
@@ -228,10 +328,21 @@ class Log
      */
     protected function write($object, $level)
     {
-        if ($this->enabled && $this->writer && $level <= $this->level) {
-            return $this->writer->write($object, $level);
-        } else {
-            return false;
+        return $this->log($level, $object);
+    }
+
+    /**
+     * Interpolate log message
+     * @param  mixed     The log message
+     * @param  array     An array of placeholder values
+     * @return string    The processed string
+     */
+    protected function interpolate($message, $context = array())
+    {
+        $replace = array();
+        foreach ($context as $key => $value) {
+            $replace['{' . $key . '}'] = $value;
         }
+        return strstr($message, $replace);
     }
 }

--- a/Slim/Log.php
+++ b/Slim/Log.php
@@ -63,7 +63,7 @@ class Log
     const EMERGENCY = 1;
     const ALERT     = 2;
     const CRITICAL  = 3;
-    const FATAL     = 3; //Depracated replace with CRITICAL
+    const FATAL     = 3; //DEPRECATED replace with CRITICAL
     const ERROR     = 4;
     const WARN      = 5;
     const NOTICE    = 6;
@@ -226,7 +226,7 @@ class Log
     }
 
     /**
-     * DEPRACATED for function warning
+     * DEPRECATED for function warning
      * Log warning message
      * @param  mixed       $object
      * @param  array       $context
@@ -260,7 +260,7 @@ class Log
     }
 
     /**
-     * DEPRACATED for function critical
+     * DEPRECATED for function critical
      * Log fatal message
      * @param  mixed       $object
      * @param  array       $context
@@ -320,7 +320,7 @@ class Log
     }
 
     /**
-     * DEPRACATED for function log
+     * DEPRECATED for function log
      * Log message
      * @param   mixed   The object to log
      * @param   int     The message level

--- a/Slim/Log.php
+++ b/Slim/Log.php
@@ -343,6 +343,6 @@ class Log
         foreach ($context as $key => $value) {
             $replace['{' . $key . '}'] = $value;
         }
-        return strstr($message, $replace);
+        return strtr($message, $replace);
     }
 }

--- a/Slim/Middleware/ContentTypes.php
+++ b/Slim/Middleware/ContentTypes.php
@@ -58,12 +58,13 @@ class ContentTypes extends \Slim\Middleware
      */
     public function __construct($settings = array())
     {
-        $this->contentTypes = array_merge(array(
+        $defaults = array(
             'application/json' => array($this, 'parseJson'),
             'application/xml' => array($this, 'parseXml'),
             'text/xml' => array($this, 'parseXml'),
             'text/csv' => array($this, 'parseCsv')
-        ), $settings);
+        );
+        $this->contentTypes = array_merge($defaults, $settings);
     }
 
     /**

--- a/Slim/Middleware/SessionCookie.php
+++ b/Slim/Middleware/SessionCookie.php
@@ -72,7 +72,7 @@ class SessionCookie extends \Slim\Middleware
      */
     public function __construct($settings = array())
     {
-        $this->settings = array_merge(array(
+        $defaults = array(
             'expires' => '20 minutes',
             'path' => '/',
             'domain' => null,
@@ -82,7 +82,8 @@ class SessionCookie extends \Slim\Middleware
             'secret' => 'CHANGE_ME',
             'cipher' => MCRYPT_RIJNDAEL_256,
             'cipher_mode' => MCRYPT_MODE_CBC
-        ), $settings);
+        );
+        $this->settings = array_merge($defaults, $settings);
         if (is_string($this->settings['expires'])) {
             $this->settings['expires'] = strtotime($this->settings['expires']);
         }
@@ -155,14 +156,17 @@ class SessionCookie extends \Slim\Middleware
         if (strlen($value) > 4096) {
             $this->app->getLog()->error('WARNING! Slim\Middleware\SessionCookie data size is larger than 4KB. Content save failed.');
         } else {
-            $this->app->response()->setCookie($this->settings['name'], array(
-                'value' => $value,
-                'domain' => $this->settings['domain'],
-                'path' => $this->settings['path'],
-                'expires' => $this->settings['expires'],
-                'secure' => $this->settings['secure'],
-                'httponly' => $this->settings['httponly']
-            ));
+            $this->app->response()->setCookie(
+                $this->settings['name'],
+                array(
+                    'value' => $value,
+                    'domain' => $this->settings['domain'],
+                    'path' => $this->settings['path'],
+                    'expires' => $this->settings['expires'],
+                    'secure' => $this->settings['secure'],
+                    'httponly' => $this->settings['httponly']
+                )
+            );
         }
         session_destroy();
     }

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -320,7 +320,7 @@ class Route
         if (is_callable($middleware)) {
             $this->middleware[] = $middleware;
         } elseif (is_array($middleware)) {
-            foreach($middleware as $callable) {
+            foreach ($middleware as $callable) {
                 if (!is_callable($callable)) {
                     throw new \InvalidArgumentException('All Route middleware must be callable');
                 }
@@ -347,8 +347,11 @@ class Route
     public function matches($resourceUri)
     {
         //Convert URL params into regex patterns, construct a regex for this route, init params
-        $patternAsRegex = preg_replace_callback('#:([\w]+)\+?#', array($this, 'matchesCallback'),
-            str_replace(')', ')?', (string) $this->pattern));
+        $patternAsRegex = preg_replace_callback(
+            '#:([\w]+)\+?#',
+            array($this, 'matchesCallback'),
+            str_replace(')', ')?', (string) $this->pattern)
+        );
         if (substr($this->pattern, -1) === '/') {
             $patternAsRegex .= '?';
         }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -503,12 +503,13 @@ class Slim
      *
      * @param  mixed $callable Anything that returns true for is_callable()
      */
-    public function notFound( $callable = null ) {
-        if ( is_callable($callable) ) {
+    public function notFound ($callable = null)
+    {
+        if (is_callable($callable)) {
             $this->notFound = $callable;
         } else {
             ob_start();
-            if ( is_callable($this->notFound) ) {
+            if (is_callable($this->notFound)) {
                 call_user_func($this->notFound);
             } else {
                 call_user_func(array($this, 'defaultNotFound'));
@@ -566,7 +567,7 @@ class Slim
     protected function callErrorHandler($argument = null)
     {
         ob_start();
-        if ( is_callable($this->error) ) {
+        if (is_callable($this->error)) {
             call_user_func_array($this->error, array($argument));
         } else {
             call_user_func_array(array($this, 'defaultError'), array($argument));
@@ -726,7 +727,9 @@ class Slim
 
         //Set etag value
         $value = '"' . $value . '"';
-        if ($type === 'weak') $value = 'W/'.$value;
+        if ($type === 'weak') {
+            $value = 'W/'.$value;
+        }
         $this->response['ETag'] = $value;
 
         //Check conditional GET
@@ -779,14 +782,15 @@ class Slim
      */
     public function setCookie($name, $value, $time = null, $path = null, $domain = null, $secure = null, $httponly = null)
     {
-        $this->response->cookies->set($name, array(
+        $settings = array(
             'value' => $value,
             'expires' => is_null($time) ? $this->config('cookies.lifetime') : $time,
             'path' => is_null($path) ? $this->config('cookies.path') : $path,
             'domain' => is_null($domain) ? $this->config('cookies.domain') : $domain,
             'secure' => is_null($secure) ? $this->config('cookies.secure') : $secure,
             'httponly' => is_null($httponly) ? $this->config('cookies.httponly') : $httponly
-        ));
+        );
+        $this->response->cookies->set($name, $settings);
     }
 
     /**
@@ -877,12 +881,13 @@ class Slim
      */
     public function deleteCookie($name, $path = null, $domain = null, $secure = null, $httponly = null)
     {
-        $this->response->cookies->remove($name, array(
+        $settings = array(
             'domain' => is_null($domain) ? $this->config('cookies.domain') : $domain,
             'path' => is_null($path) ? $this->config('cookies.path') : $path,
             'secure' => is_null($secure) ? $this->config('cookies.secure') : $secure,
             'httponly' => is_null($httponly) ? $this->config('cookies.httponly') : $httponly
-        ));
+        );
+        $this->response->cookies->remove($name, $settings);
     }
 
     /********************************************************************************
@@ -1229,7 +1234,7 @@ class Slim
                 }
             }
             if (!$dispatched) {
-               $this->notFound();
+                $this->notFound();
             }
             $this->applyHook('slim.after.router');
             $this->stop();

--- a/index.php
+++ b/index.php
@@ -31,8 +31,10 @@ $app = new \Slim\Slim();
  */
 
 // GET route
-$app->get('/', function () {
-    $template = <<<EOT
+$app->get(
+    '/',
+    function () {
+        $template = <<<EOT
 <!DOCTYPE html>
     <html>
         <head>
@@ -125,23 +127,33 @@ $app->get('/', function () {
         </body>
     </html>
 EOT;
-    echo $template;
-});
+        echo $template;
+    }
+);
 
 // POST route
-$app->post('/post', function () {
-    echo 'This is a POST route';
-});
+$app->post(
+    '/post',
+    function () {
+        echo 'This is a POST route';
+    }
+);
 
 // PUT route
-$app->put('/put', function () {
-    echo 'This is a PUT route';
-});
+$app->put(
+    '/put',
+    function () {
+        echo 'This is a PUT route';
+    }
+);
 
 // DELETE route
-$app->delete('/delete', function () {
-    echo 'This is a DELETE route';
-});
+$app->delete(
+    '/delete',
+    function () {
+        echo 'This is a DELETE route';
+    }
+);
 
 /**
  * Step 4: Run the Slim application

--- a/tests/LogTest.php
+++ b/tests/LogTest.php
@@ -98,6 +98,21 @@ class LogTest extends PHPUnit_Framework_TestCase
     public function testLogInfoExcludedByLevel()
     {
         $log = new \Slim\Log(new MyWriter());
+        $log->setLevel(\Slim\Log::NOTICE);
+        $this->assertFalse($log->info('Info'));
+    }
+
+    public function testLogNotice()
+    {
+        $this->expectOutputString('Notice');
+        $log = new \Slim\Log(new MyWriter());
+        $result = $log->notice('Notice');
+        $this->assertTrue($result);
+    }
+
+    public function testLogNoticeExcludedByLevel()
+    {
+        $log = new \Slim\Log(new MyWriter());
         $log->setLevel(\Slim\Log::WARN);
         $this->assertFalse($log->info('Info'));
     }
@@ -106,7 +121,7 @@ class LogTest extends PHPUnit_Framework_TestCase
     {
         $this->expectOutputString('Warn');
         $log = new \Slim\Log(new MyWriter());
-        $result = $log->warn('Warn');
+        $result = $log->warning('Warn');
         $this->assertTrue($result);
     }
 
@@ -114,7 +129,7 @@ class LogTest extends PHPUnit_Framework_TestCase
     {
         $log = new \Slim\Log(new MyWriter());
         $log->setLevel(\Slim\Log::ERROR);
-        $this->assertFalse($log->warn('Warn'));
+        $this->assertFalse($log->warning('Warn'));
     }
 
     public function testLogError()
@@ -128,15 +143,56 @@ class LogTest extends PHPUnit_Framework_TestCase
     public function testLogErrorExcludedByLevel()
     {
         $log = new \Slim\Log(new MyWriter());
-        $log->setLevel(\Slim\Log::FATAL);
+        $log->setLevel(\Slim\Log::CRITICAL);
         $this->assertFalse($log->error('Error'));
     }
 
-    public function testLogFatal()
+    public function testLogCritical()
     {
-        $this->expectOutputString('Fatal');
+        $this->expectOutputString('Critical');
         $log = new \Slim\Log(new MyWriter());
-        $result = $log->fatal('Fatal');
+        $result = $log->critical('Critical');
+        $this->assertTrue($result);
+    }
+
+    public function testLogCriticalExcludedByLevel()
+    {
+        $log = new \Slim\Log(new MyWriter());
+        $log->setLevel(\Slim\Log::ALERT);
+        $this->assertFalse($log->critical('Critical'));
+    }
+
+    public function testLogAlert()
+    {
+        $this->expectOutputString('Alert');
+        $log = new \Slim\Log(new MyWriter());
+        $result = $log->alert('Alert');
+        $this->assertTrue($result);
+    }
+
+    public function testLogAlertExcludedByLevel()
+    {
+        $log = new \Slim\Log(new MyWriter());
+        $log->setLevel(\Slim\Log::EMERGENCY);
+        $this->assertFalse($log->alert('Alert'));
+    }
+
+    public function testLogEmergency()
+    {
+        $this->expectOutputString('Emergency');
+        $log = new \Slim\Log(new MyWriter());
+        $result = $log->emergency('Emergency');
+        $this->assertTrue($result);
+    }
+
+    public function testInterpolateMessage()
+    {
+        $this->expectOutputString('Hello Slim !');
+        $log = new \Slim\Log(new MyWriter());
+        $result = $log->debug(
+            'Hello {framework} !',
+            array('framework' => "Slim")
+        );
         $this->assertTrue($result);
     }
 


### PR DESCRIPTION
## PSR Compliance

These updates change the <code>Slim/Log</code> class to make it PSR-3 compliant as-well as general tweaks on some other files to make them PSR-2 compliant.

I left support for some old methods in <code>Slim/Log</code> to keep it backwards compatible, but I have marked them with <code>DEPRECATED</code> so they can be removed in the future.
## Slim / Log methods

The new class provides access to the following methods:

``` php
 $log->debug( mixed $object, array $context = array() );
 $log->info( mixed $object, array $context = array() );
 $log->notice( mixed $object, array $context = array() );
 $log->warning( mixed $object, array $context = array() );
 $log->error( mixed $object, array $context = array() );
 $log->critical( mixed $object, array $context = array() );
 $log->alert( mixed $object, array $context = array() );
 $log->emergency( mixed $object, array $context = array() );
 $log->log( mixed $level, mixed $object, array $context = array() );
```

As per the PSR-3 standard, the following functions are marked as <code>DEPRECATED</code> but still work, as they are being mapped to the new methods:

``` php
 $log->warn( mixed $object, array $context = array() );
 $log->fatal( mixed $object, array $context = array() );
 $log->write( mixed $object, int $level);
```
## Placeholders in error messages

As per the PSR-3 standard, messages can contain placeholders in the format <code>{placeholder_name}</code>. No spaces may be used between the placeholder's name and brackets. The optional context array needs to contain the value for each placeholder in-order for it to be replaced.

Here is an example:

``` php
 $log->debug( 
     "{greeting} {place}",
     array(
         "greeting" => "Hello"
     )
 );
```

Will send the message <code>"Hello {place}"</code> to the log writer.
