### PR TITLE
adding dispatchContext support (for PHP 5.4+)

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -419,12 +419,19 @@ class Route
 
     /**
      * Dispatch
-     * @return mixed The return value of the route callable, or FALSE on error
+     * @param  mixed  $context the object context in which the callable should be invoked
+     * @return object          The return value of the route callable, or FALSE on error
      */
-    public function dispatch()
+    public function dispatch($context = null)
     {
         foreach ($this->middleware as $routeMiddleware) {
             call_user_func_array($routeMiddleware, array($this));
+        }
+
+        if ($context // only available in PHP 5.4+
+                && $this->callable instanceof \Closure
+                && method_exists($this->callable, 'bindTo')) {
+            $this->callable = $this->callable->bindTo($context);
         }
 
         return call_user_func_array($this->callable, array_values($this->params));

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -166,7 +166,7 @@ class Router
     /**
      * Add a route group to the array
      * @param  string     $group      The group pattern (ie. "/books/:id")
-     * @param  array|null $middleware Optional parameter array of middleware 
+     * @param  array|null $middleware Optional parameter array of middleware
      * @return int        The index of the new group
      */
     public function pushGroup($group, $middleware = null)
@@ -208,14 +208,15 @@ class Router
 
     /**
      * Dispatch route
-     * @param  \Slim\Route  $route  The route to dispatch
-     * @return bool                 True if route dispatched successfully, else false
+     * @param  \Slim\Route  $route   The route to dispatch
+     * @param  object       $context The object context ($this) in which the callable will be invoked
+     * @return bool                  True if route dispatched successfully, else false
      */
-    public function dispatch(\Slim\Route $route)
+    public function dispatch(\Slim\Route $route, $context = null)
     {
         $this->currentRoute = $route;
 
-        return ($route->dispatch() !== false);
+        return ($route->dispatch($context) !== false);
     }
 
     /**

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -112,6 +112,11 @@ class Slim
     protected $notFound;
 
     /**
+     * @var object The object context for dispatch closures
+     */
+    protected $dispatchContext;
+
+    /**
      * @var array
      */
     protected $hooks = array(
@@ -1049,6 +1054,15 @@ class Slim
         $this->halt($status);
     }
 
+    /**
+     * Set the object context ($this) for dispatch callables
+     *
+     * @param object $context The object context ($this) in which
+     */
+    public function setDispatchContext($context) {
+        $this->dispatchContext = $context;
+    }
+
     /********************************************************************************
     * Flash Messages
     *******************************************************************************/
@@ -1261,7 +1275,7 @@ class Slim
             foreach ($matchedRoutes as $route) {
                 try {
                     $this->applyHook('slim.before.dispatch');
-                    $dispatched = $this->router->dispatch($route);
+                    $dispatched = $this->router->dispatch($route, $this->dispatchContext);
                     $this->applyHook('slim.after.dispatch');
                     if ($dispatched) {
                         break;

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -493,16 +493,18 @@ class SlimTest extends PHPUnit_Framework_TestCase
      */
     public function testRouteWithDispatchContext()
     {
-        \Slim\Environment::mock(array(
-            'REQUEST_METHOD' => 'GET',
-            'SCRIPT_NAME' => '/foo', //<-- Physical
-            'PATH_INFO' => '/bar/', //<-- Virtual
-        ));
-        $s = new \Slim\Slim();
-        $s->setDispatchContext(new \stdClass());
-        $s->get('/bar/', function() { echo '$this instanceof ' . get_class($this); });
-        $s->call();
-        $this->assertEquals('$this instanceof stdClass', $s->response()->body());
+        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            \Slim\Environment::mock(array(
+                'REQUEST_METHOD' => 'GET',
+                'SCRIPT_NAME' => '/foo', //<-- Physical
+                'PATH_INFO' => '/bar/', //<-- Virtual
+            ));
+            $s = new \Slim\Slim();
+            $s->setDispatchContext(new \stdClass());
+            $s->get('/bar/', function() { echo '$this instanceof ' . get_class($this); });
+            $s->call();
+            $this->assertEquals('$this instanceof stdClass', $s->response()->body());
+        }
     }
 
     /************************************************

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -488,6 +488,23 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('jo hnsmi th', $s->response()->body());
     }
 
+    /**
+     * Test if dispatch context is work properly
+     */
+    public function testRouteWithDispatchContext()
+    {
+        \Slim\Environment::mock(array(
+            'REQUEST_METHOD' => 'GET',
+            'SCRIPT_NAME' => '/foo', //<-- Physical
+            'PATH_INFO' => '/bar/', //<-- Virtual
+        ));
+        $s = new \Slim\Slim();
+        $s->setDispatchContext(new \stdClass());
+        $s->get('/bar/', function() { echo '$this instanceof ' . get_class($this); });
+        $s->call();
+        $this->assertEquals('$this instanceof stdClass', $s->response()->body());
+    }
+
     /************************************************
      * VIEW
      ************************************************/


### PR DESCRIPTION
_I'm not sure if this implementation is ideal, however I think the idea itself is quite powerful and I figured it would be best illustrated via a pull request._

When building Slim apps I've often found it desirable to have access to the \Slim\Slim object inside my route callables. Of course, you can always use PHP's `use` keyword:

``` PHP
$slim = new \Slim\Slim();
$slim->map('/foo', function() use($slim) {
  $slim->forward('/bar');
});
```

However, this can be a bit tedious after declaring a lot of routes.
As a shortcut, I propose a _"dispatchContext"_ that will be accessible via `$this` inside the callables.

The pull request implements this in a way that would be used as follows:

``` PHP
$slim = new \Slim\Slim();
$slim->setDispatchContext($slim);
$slim->map('/foo', function() {
  $this->forward('/bar');
});
```

Of course, the dispatch context can be set to anything, which could make it a very powerful controller delegate.
