### PR TITLE
On some environments fopen('php://stderr', 'w') can produce a PHP Warning

### DIFF
--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -183,7 +183,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
             $env['slim.input'] = $rawInput;
 
             //Error stream
-            $env['slim.errors'] = fopen('php://stderr', 'w');
+            $env['slim.errors'] = @fopen('php://stderr', 'w');
 
             $this->properties = $env;
         }


### PR DESCRIPTION
We'd like to get rid of that
