### PR TITLE
Wouldn't it be nice if class dependencies were (somewhat) configurable?

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -53,6 +53,20 @@ class Request
     const METHOD_OVERRIDE = '_METHOD';
 
     /**
+     * @var string classname to use for $headers instance
+     * @see \Slim\Http\Request::$headers
+     * @see \Slim\Http\Request::__construct()
+     */
+    public static $CLASS_HTTP_HEADERS = '\Slim\Http\Headers';
+
+    /**
+     * @var string classname to use for $cookies instance
+     * @see \Slim\Http\Request::$cookies
+     * @see \Slim\Http\Request::__construct()
+     */
+    public static $CLASS_COOKIE_JAR = '\Slim\Helper\Set';
+
+    /**
      * @var array
      */
     protected static $formDataMediaTypes = array('application/x-www-form-urlencoded');
@@ -84,8 +98,12 @@ class Request
     public function __construct(\Slim\Environment $env)
     {
         $this->env = $env;
-        $this->headers = new \Slim\Http\Headers(\Slim\Http\Headers::extract($env));
-        $this->cookies = new \Slim\Helper\Set(\Slim\Http\Util::parseCookieHeader($env['HTTP_COOKIE']));
+
+        $this->headers = new static::$CLASS_HTTP_HEADERS(
+            \Slim\Http\Headers::extract($env));
+
+        $this->cookies = new static::$CLASS_COOKIE_JAR(
+            \Slim\Http\Util::parseCookieHeader($env['HTTP_COOKIE']));
     }
 
     /**

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -45,6 +45,21 @@ namespace Slim\Http;
  */
 class Response implements \ArrayAccess, \Countable, \IteratorAggregate
 {
+
+    /**
+     * @var string classname to use for $headers instance
+     * @see \Slim\Http\Response::$headers
+     * @see \Slim\Http\Response::__construct()
+     */
+    public static $CLASS_HTTP_HEADERS = '\Slim\Http\Headers';
+
+    /**
+     * @var string classname to use for $cookies instance
+     * @see \Slim\Http\Response::$cookies
+     * @see \Slim\Http\Response::__construct()
+     */
+    public static $CLASS_HTTP_COOKIES = '\Slim\Http\Cookies';
+
     /**
      * @var int HTTP status code
      */
@@ -133,9 +148,13 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     public function __construct($body = '', $status = 200, $headers = array())
     {
         $this->setStatus($status);
-        $this->headers = new \Slim\Http\Headers(array('Content-Type' => 'text/html'));
+
+        $this->headers = new static::$CLASS_HTTP_HEADERS(array('Content-Type' => 'text/html'));
+
         $this->headers->replace($headers);
-        $this->cookies = new \Slim\Http\Cookies();
+
+        $this->cookies = new static::$CLASS_HTTP_COOKIES();
+
         $this->write($body);
     }
 

--- a/Slim/Middleware/MethodOverride.php
+++ b/Slim/Middleware/MethodOverride.php
@@ -84,7 +84,12 @@ class MethodOverride extends \Slim\Middleware
             $env['REQUEST_METHOD'] = strtoupper($env['X_HTTP_METHOD_OVERRIDE']);
         } elseif (isset($env['REQUEST_METHOD']) && $env['REQUEST_METHOD'] === 'POST') {
             // HTML Form Override
-            $req = new \Slim\Http\Request($env);
+
+            $reqClass = get_class($this->app->request());
+            // new Request should match the classname of the old...
+
+            $req = new $reqClass($env);
+
             $method = $req->post($this->settings['key']);
             if ($method) {
                 $env['slim.method_override.original_method'] = $env['REQUEST_METHOD'];

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -44,6 +44,12 @@ namespace Slim;
 class Router
 {
     /**
+     * @var string classname to use for constructing new routes
+     * @see \Slim\Router::map()
+     */
+    public static $CLASS_ROUTE = '\Slim\Route';
+
+    /**
      * @var Route The current route (most recently dispatched)
      */
     protected $currentRoute;
@@ -131,7 +137,7 @@ class Router
         if (count($this->routeGroups) > 0) {
             $pattern = $groupPattern . ltrim($pattern, '/');
         }
-        $route = new \Slim\Route($pattern, $callable);
+        $route = new static::$CLASS_ROUTE($pattern, $callable);
         $this->routes[] = $route;
 
         if (count($this->routeGroups) > 0) {
@@ -166,7 +172,7 @@ class Router
     /**
      * Add a route group to the array
      * @param  string     $group      The group pattern (ie. "/books/:id")
-     * @param  array|null $middleware Optional parameter array of middleware 
+     * @param  array|null $middleware Optional parameter array of middleware
      * @return int        The index of the new group
      */
     public function pushGroup($group, $middleware = null)

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -51,6 +51,12 @@ class Slim
      */
     const VERSION = '2.2.0';
 
+    public static $CLASS_HTTP_REQUEST = '\Slim\Http\Request';
+
+    public static $CLASS_HTTP_RESPONSE = '\Slim\Http\Response';
+
+    public static $CLASS_ROUTER = '\Slim\Router';
+
     /**
      * @var array[\Slim]
      */
@@ -177,10 +183,15 @@ class Slim
     {
         // Setup Slim application
         $this->settings = array_merge(static::getDefaultSettings(), $userSettings);
+
         $this->environment = \Slim\Environment::getInstance();
-        $this->request = new \Slim\Http\Request($this->environment);
-        $this->response = new \Slim\Http\Response();
-        $this->router = new \Slim\Router();
+
+        $this->request = new static::$CLASS_HTTP_REQUEST($this->environment);
+
+        $this->response = new static::$CLASS_HTTP_RESPONSE();
+
+        $this->router = new static::$CLASS_ROUTER();
+
         $this->middleware = array($this);
         $this->add(new \Slim\Middleware\Flash());
         $this->add(new \Slim\Middleware\MethodOverride());

--- a/Slim/View.php
+++ b/Slim/View.php
@@ -50,6 +50,13 @@ namespace Slim;
 class View
 {
     /**
+     * @var string classname for $data instance
+     * @see \Slim\View::$data
+     * @see \Slim\View::__construct
+     */
+    public static $CLASS_HELPER_SET = '\Slim\Helper\Set';
+
+    /**
      * Data available to the view templates
      * @var \Slim\Helper\Set
      */
@@ -66,7 +73,7 @@ class View
      */
     public function __construct()
     {
-        $this->data = new \Slim\Helper\Set();
+        $this->data = new static::$CLASS_HELPER_SET();
     }
 
     /********************************************************************************

--- a/tests/Middleware/MethodOverrideTest.php
+++ b/tests/Middleware/MethodOverrideTest.php
@@ -48,6 +48,10 @@ class CustomAppMethod
         return $this->environment;
     }
 
+    public function request() {
+        return new \Slim\Http\Request($this->environment());
+    }
+
     public function call()
     {
         //Do nothing

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -67,6 +67,12 @@ class CustomMiddleware extends \Slim\Middleware
     }
 }
 
+//Mock Router
+class MockRouter
+{
+    function __call($method, $arguments) { return $this; }
+}
+
 class SlimTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
@@ -134,6 +140,20 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s = new \Slim\Slim();
         $s->setName('foo');
         $this->assertSame($s, \Slim\Slim::getInstance('foo'));
+    }
+
+
+    public function testWithCustomRouter()
+    {
+        $oldRouter = \Slim\Slim::$CLASS_ROUTER;
+
+        \Slim\Slim::$CLASS_ROUTER = 'MockRouter';
+
+        $s = new \Slim\Slim;
+
+        $this->assertInstanceOf('MockRouter', $s->router);
+
+        \Slim\Slim::$CLASS_ROUTER = $oldRouter;
     }
 
     /**


### PR DESCRIPTION
Then I wouldn't have to subclass `\Slim\Slim`, `\Slim\Router`, and `\Slim\Route` just to change some behavior in `\Slim\Route`...! I could _only_ subclass `\Slim\Route` and inform `\Slim\Router` of the dependency change, e.g.

``` php
<?php // index.php

class CustomRoute extends \Slim\Route
{
    function supportsHttpMethod($method)
    {
        // Respond to all HTTP methods by default...
        if ( !$this->methods ) return true;

        return parent::supportsHttpMethod($method);
    }
}

\Slim\Router::$CLASS_ROUTE = 'CustomRoute';

$app = new \Slim\Slim();

// Route "/some/route" for _any_ HTTP method...
$app->map('/some/route', function(){
    echo 'Do Something Awesome';
});

$app->run();
```

I thought about using `\Slim\Slim::config()` but not all classes in the package receive the instance of `\Slim\Slim` to call `config()` on, so I thought better to encapsulate dependencies with static variables acting as psuedo-constants.
- PRO: Each class is responsible for its own dependencies.
- CON: The dependency can only be overridden for the entire class.

Discussion?
