### PR TITLE
Shouldn't `\Slim\Route::via()` call `\Slim\Route::appendHttpMethods()` instead of duplicating code?

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -277,8 +277,7 @@ class Route
      */
     public function via()
     {
-        $args = func_get_args();
-        $this->methods = array_merge($this->methods, $args);
+        call_user_func_array(array($this, 'appendHttpMethods'), func_get_args());
 
         return $this;
     }


### PR DESCRIPTION
Feel free to call me an idiot, it just seems that `via()` was unnecessarily repeating the code in `appendHttpMethods()` to avoid `call_user_func_array()`... Why can't invoking methods with variable arguments be easier in PHP? Like Ruby, `$this->__send('appendHttpMethods', func_get_args());` would be nicer...
