### PR TITLE
new feature on Router: list all defined routes with method

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -281,7 +281,7 @@ class Router
      * Get all the defined routes
      * @param string $separator separator between the method and the route ( default: "::" )
      * @param bool $showMethods show the method of the route ( default: true )
-     * @return string
+     * @return array
      */
     public function listRoutes( $separator = '::', $showMethods = true ) {
       $allRoutes = array();

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -166,7 +166,7 @@ class Router
     /**
      * Add a route group to the array
      * @param  string     $group      The group pattern (ie. "/books/:id")
-     * @param  array|null $middleware Optional parameter array of middleware 
+     * @param  array|null $middleware Optional parameter array of middleware
      * @return int        The index of the new group
      */
     public function pushGroup($group, $middleware = null)
@@ -275,5 +275,25 @@ class Router
         }
 
         return new \ArrayIterator($this->namedRoutes);
+    }
+
+    /**
+     * Get all the defined routes
+     * @param string $separator separator between the method and the route ( default: "::" )
+     * @param bool $showMethods show the method of the route ( default: true )
+     * @return string
+     */
+    public function listRoutes( $separator = '::', $showMethods = true ) {
+      $allRoutes = array();
+      if ( count( $this->routes ) > 0 ) {
+        foreach( $this->routes AS $route ) {
+          if ( !$showMethods ) {
+            $allRoutes[] = $route->getPattern();
+          } else {
+            $allRoutes[] = implode( ',', $route->getHttpMethods() ) . $separator . $route->getPattern();
+          }
+        }
+      }
+      return $allRoutes;
     }
 }


### PR DESCRIPTION
Hi,

we are using Slim on our RESTful APIs and one thing that we do is to list all our available routes, so who ever needs our API they know which routes are available.

$app->router->listRoutes();
This will return an array of routes:
array(
  'GET::/foo',
  'POST::/bar'
);

You can also change the separator or don't show the method
$app->router->listRoutes( '->' );
array(
  'GET->/foo',
  'POST->/bar'
);

$app->router->listRoutes( '::', false );
array(
  '/foo',
  '/bar'
);

Just thought that maybe someone else would be interested in this feature.

T1gr0u
