### PR TITLE
Test for mcrypt in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-mcrypt": "*"
     },
     "autoload": {
         "psr-0": { "Slim": "." }


### PR DESCRIPTION
Since mcrypt is needed to for the encrypt/decrypt methods and the unit test will fail if mcrypt is not present, a check in composer would be handy.

Problem is that if the mcrypt library is not present NO encryption is being performed without warning, thus returning the string from the \Slim\Http\Util::encrypt method the same as it was passed.

Another possibility is to alter the test to not fail if mcrypt is not present, but then an alternate encryption method is needed that not depends on mcrpyt.
