### PR TITLE
Helper\Set property overloading, restores compatibility with Mustache

### DIFF
--- a/Slim/Helper/Set.php
+++ b/Slim/Helper/Set.php
@@ -139,6 +139,20 @@ class Set implements \ArrayAccess, \Countable, \IteratorAggregate
         unset($this->data[$this->normalizeKey($key)]);
     }
 
+	/**
+	 * Property Overloading
+	 */
+
+	public function __get($key)
+	{
+		return $this->get($key);
+	}
+
+	public function __isset($key)
+	{
+		return $this->has($key);
+	}
+
     /**
      * Clear all values
      */

--- a/Slim/Helper/Set.php
+++ b/Slim/Helper/Set.php
@@ -139,19 +139,29 @@ class Set implements \ArrayAccess, \Countable, \IteratorAggregate
         unset($this->data[$this->normalizeKey($key)]);
     }
 
-	/**
-	 * Property Overloading
-	 */
+    /**
+     * Property Overloading
+     */
 
-	public function __get($key)
-	{
-		return $this->get($key);
-	}
+    public function __get($key)
+    {
+        return $this->get($key);
+    }
 
-	public function __isset($key)
-	{
-		return $this->has($key);
-	}
+    public function __set($key, $value)
+    {
+        $this->set($key, $value);
+    }
+
+    public function __isset($key)
+    {
+        return $this->has($key);
+    }
+
+    public function __unset($key)
+    {
+        return $this->remove($key);
+    }
 
     /**
      * Clear all values

--- a/tests/Helper/SetTest.php
+++ b/tests/Helper/SetTest.php
@@ -166,4 +166,29 @@ class SetTest extends PHPUnit_Framework_TestCase
         $this->property->setValue($this->bag, $data);
         $this->assertInstanceOf('\ArrayIterator', $this->bag->getIterator());
     }
+
+	public function testPropertyOverloadGet()
+	{
+		$data = array(
+			'abc' => '123',
+			'foo' => 'bar'
+		);
+		$this->property->setValue($this->bag, $data);
+
+		$this->assertEquals('123', $this->bag->abc);
+		$this->assertEquals('bar', $this->bag->foo);
+	}
+
+	public function testPropertyOverloadingIsset()
+	{
+		$data = array(
+			'abc' => '123',
+			'foo' => 'bar'
+		);
+		$this->property->setValue($this->bag, $data);
+
+		$this->assertTrue(isset($this->bag->abc));
+		$this->assertTrue(isset($this->bag->foo));
+		$this->assertFalse(isset($this->bag->foobar));
+	}
 }

--- a/tests/Helper/SetTest.php
+++ b/tests/Helper/SetTest.php
@@ -210,7 +210,7 @@ class SetTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(isset($this->bag->abc));
         unset($this->bag->abc);
         $this->assertFalse(isset($this->bag->abc));
-		$this->assertArrayNotHasKey('abc', $this->property->getValue($this->bag));
+        $this->assertArrayNotHasKey('abc', $this->property->getValue($this->bag));
         $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));			
     }
 }

--- a/tests/Helper/SetTest.php
+++ b/tests/Helper/SetTest.php
@@ -43,7 +43,7 @@ class SetTest extends PHPUnit_Framework_TestCase
     {
         $this->bag->set('foo', 'bar');
         $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));
-		$bag =  $this->property->getValue($this->bag);
+        $bag =  $this->property->getValue($this->bag);
         $this->assertEquals('bar', $bag['foo']);
     }
 
@@ -67,7 +67,7 @@ class SetTest extends PHPUnit_Framework_TestCase
         ));
         $this->assertArrayHasKey('abc', $this->property->getValue($this->bag));
         $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));
-		$bag = $this->property->getValue($this->bag);
+        $bag = $this->property->getValue($this->bag);
         $this->assertEquals('123', $bag['abc']);
         $this->assertEquals('bar', $bag['foo']);
     }
@@ -121,7 +121,7 @@ class SetTest extends PHPUnit_Framework_TestCase
         );
         $this->property->setValue($this->bag, $data);
         $this->bag['foo'] = 'changed';
-		$bag = $this->property->getValue($this->bag);
+        $bag = $this->property->getValue($this->bag);
         $this->assertEquals('changed', $bag['foo']);
     }
 
@@ -167,28 +167,50 @@ class SetTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\ArrayIterator', $this->bag->getIterator());
     }
 
-	public function testPropertyOverloadGet()
-	{
-		$data = array(
-			'abc' => '123',
-			'foo' => 'bar'
-		);
-		$this->property->setValue($this->bag, $data);
+    public function testPropertyOverloadGet()
+    {
+        $data = array(
+            'abc' => '123',
+            'foo' => 'bar'
+        );
+        $this->property->setValue($this->bag, $data);
 
-		$this->assertEquals('123', $this->bag->abc);
-		$this->assertEquals('bar', $this->bag->foo);
-	}
+        $this->assertEquals('123', $this->bag->abc);
+        $this->assertEquals('bar', $this->bag->foo);
+    }
 
-	public function testPropertyOverloadingIsset()
-	{
-		$data = array(
-			'abc' => '123',
-			'foo' => 'bar'
-		);
-		$this->property->setValue($this->bag, $data);
+    public function testPropertyOverloadSet()
+    {
+        $this->bag->foo = 'bar';
+        $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));
+        $this->assertEquals('bar', $this->bag->foo);
+    }
 
-		$this->assertTrue(isset($this->bag->abc));
-		$this->assertTrue(isset($this->bag->foo));
-		$this->assertFalse(isset($this->bag->foobar));
-	}
+    public function testPropertyOverloadingIsset()
+    {
+        $data = array(
+            'abc' => '123',
+            'foo' => 'bar'
+        );
+        $this->property->setValue($this->bag, $data);
+
+        $this->assertTrue(isset($this->bag->abc));
+        $this->assertTrue(isset($this->bag->foo));
+        $this->assertFalse(isset($this->bag->foobar));
+    }
+
+    public function testPropertyOverloadingUnset()
+    {
+        $data = array(
+            'abc' => '123',
+            'foo' => 'bar'
+        );
+        $this->property->setValue($this->bag, $data);
+
+        $this->assertTrue(isset($this->bag->abc));
+        unset($this->bag->abc);
+        $this->assertFalse(isset($this->bag->abc));
+		$this->assertArrayNotHasKey('abc', $this->property->getValue($this->bag));
+        $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));			
+    }
 }


### PR DESCRIPTION
Not sure if wanted __set and __unset. So left them out.

Also doesn't seem to affect IoC changes, but obviously that could be an issue?
