### PR TITLE
Add support for coveralls.io

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+src_dir: Slim

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,12 @@ language: php
 php:
   - 5.3
   - 5.4
+  
+before_script:
+  - composer install --dev --no-interaction
+  - mkdir -p ./build/logs
 
-script: phpunit --coverage-text
+script: ./vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml
+
+after_script:
+  - php ./vendor/bin/coveralls

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,10 @@
         "php": ">=5.3.0",
         "ext-mcrypt": "*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "*",
+        "satooshi/php-coveralls": "0.6.*"
+    },
     "autoload": {
         "psr-0": { "Slim": "." }
     }


### PR DESCRIPTION
Up to you, just records historical coverage data and statistics.

Examples:

https://coveralls.io/r/zomble/Slim
https://coveralls.io/builds/67915

Also the travis-ci build https://travis-ci.org/zomble/Slim/jobs/7917818 I've left the text coverage intact.
.
To activate, you'd just need to go to https://coveralls.io/ and turn it on for this repo.

Cheers.
