### PR TITLE
File streaming

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -136,6 +136,11 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
         $this->headers = new \Slim\Http\Headers(array('Content-Type' => 'text/html'));
         $this->headers->replace($headers);
         $this->cookies = new \Slim\Http\Cookies();
+        $this->body = (object) array(
+           "text" => "",
+           "isStream" => false,
+           "handle" => null
+        );
         $this->write($body);
     }
 
@@ -195,12 +200,17 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
 
     public function getBody()
     {
-        return $this->body;
+        return $this->body->text;
     }
 
     public function setBody($content)
     {
         $this->write($content, true);
+    }
+
+    public function isStream()
+    {
+        return $this->body->isStream;
     }
 
     /**
@@ -216,7 +226,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
             $this->write($body, true);
         }
 
-        return $this->body;
+        return $this->body->text;
     }
 
     /**
@@ -228,13 +238,32 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     public function write($body, $replace = false)
     {
         if ($replace) {
-            $this->body = $body;
+            $this->body->text = $body;
         } else {
-            $this->body .= (string)$body;
+            $this->body->text .= (string)$body;
         }
-        $this->length = strlen($this->body);
+        $this->length = strlen($this->body->text);
 
-        return $this->body;
+        return $this->body->text;
+    }
+
+   /**
+    * Set the response to a stream
+    * @param  resource   $handle    Resource stream to send
+    */
+    public function stream($handle)
+    {
+        $this->body->isStream = true;
+        $this->body->handle = $handle;
+    }
+
+    /**
+     * Get the stream
+     * @return  resource   $handle    Resource stream
+     */
+    public function getStream()
+    {
+        return $this->body->handle;
     }
 
     public function getLength()
@@ -276,7 +305,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
             $this->setBody('');
         }
 
-        return array($this->status, $this->headers, $this->body);
+        return array($this->status, $this->headers, $this->body->text);
     }
 
     /**

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -66,6 +66,11 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     protected $body;
 
     /**
+     * @var string HTTP response body
+     */
+    protected $isStream;
+
+    /**
      * @var int Length of HTTP response body
      */
     protected $length;
@@ -136,12 +141,8 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
         $this->headers = new \Slim\Http\Headers(array('Content-Type' => 'text/html'));
         $this->headers->replace($headers);
         $this->cookies = new \Slim\Http\Cookies();
-        $this->body = (object) array(
-           "text" => "",
-           "isStream" => false,
-           "handle" => null
-        );
-        $this->write($body);
+        $this->isStream = false;
+        $this->write($body, true);
     }
 
     public function getStatus()
@@ -200,7 +201,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
 
     public function getBody()
     {
-        return $this->body->text;
+        return $this->body;
     }
 
     public function setBody($content)
@@ -210,7 +211,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
 
     public function isStream()
     {
-        return $this->body->isStream;
+        return $this->isStream;
     }
 
     /**
@@ -226,7 +227,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
             $this->write($body, true);
         }
 
-        return $this->body->text;
+        return $this->body;
     }
 
     /**
@@ -238,13 +239,13 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     public function write($body, $replace = false)
     {
         if ($replace) {
-            $this->body->text = $body;
+            $this->body = $body;
         } else {
-            $this->body->text .= (string)$body;
+            $this->body .= (string)$body;
         }
-        $this->length = strlen($this->body->text);
+        $this->length = strlen($this->body);
 
-        return $this->body->text;
+        return $this->body;
     }
 
    /**
@@ -253,8 +254,8 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     */
     public function stream($handle)
     {
-        $this->body->isStream = true;
-        $this->body->handle = $handle;
+        $this->isStream = true;
+        $this->body = $handle;
     }
 
     /**
@@ -263,7 +264,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
      */
     public function getStream()
     {
-        return $this->body->handle;
+        return ($this->isStream) ? $this->body : false;
     }
 
     public function getLength()
@@ -305,7 +306,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
             $this->setBody('');
         }
 
-        return array($this->status, $this->headers, $this->body->text);
+        return array($this->status, $this->headers, $this->body);
     }
 
     /**

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -92,6 +92,11 @@ class Slim
     protected $settings;
 
     /**
+     * @var bool
+     */
+    protected $responded;
+
+    /**
      * @var string
      */
     protected $mode;
@@ -205,6 +210,7 @@ class Slim
         $log->setEnabled($this->config('log.enabled'));
         $log->setLevel($this->config('log.level'));
         $this->environment['slim.log'] = $log;
+        $this->responded = false;
     }
 
     /**
@@ -1168,6 +1174,94 @@ class Slim
     }
 
     /********************************************************************************
+     * Streaming Files
+     *******************************************************************************/
+
+
+    /**
+     * Send a File
+     *
+     * This method streams a local or remote file to the client
+     *
+     * @param string $file          The URI of the file, can be local or remote
+     * @param string $contentType   Optional content type of the stream, if not specified Slim will attempt to get this
+     */
+
+    public function sendFile($file, $contentType = false) {
+        $fp = fopen($file, "r");
+        $this->response()->stream($fp);
+        if ($contentType) {
+            $this->response()->header("Content-Type", $contentType);
+        } else {
+            if (file_exists($file)) {
+                //Set Content-Type
+                if ($contentType) {
+                    $this->response()->header("Content-Type", $contentType);
+                } else {
+                    $finfo = new \finfo(FILEINFO_MIME_TYPE);
+                    $type = $finfo->file($file);
+                    $this->response()->header("Content-Type", $type);
+                }
+
+                //Set Content-Length
+                $stat = fstat($fp);
+                $this->response()->header("Content-Length", $stat['size']);
+
+            } else {
+                //Set Content-Type and Content-Length
+                $data = stream_get_meta_data($fp);
+
+                foreach ($data['wrapper_data'] as $header) {
+                    list($k, $v) = explode(": ", $header, 2);
+
+                    if ($k === "Content-Type") {
+                        if ($contentType) {
+                            $this->response()->header("Content-Type", $contentType);
+                        } else {
+                            $this->response()->header("Content-Type", $v);
+                        }
+                    } else if ($k === "Content-Length") {
+                        $this->response()->header("Content-Length", $v);
+                    }
+                }
+            }
+        }
+        $this->finalize($this->response);
+    }
+
+    /**
+     * Send a Process
+     *
+     * This method streams a process to a client
+     *
+     * @param string $command       The command to run
+     * @param string $contentType   Optional content type of the stream
+     */
+
+    public function sendProc($command, $contentType = "text/plain") {
+        $ph = popen($command, 'r');
+        $this->response()->stream($ph);
+        $this->response()->header("Content-Type", $contentType);
+        $this->finalize($this->response);
+    }
+
+    /**
+     * Set Download
+     *
+     * This method triggers a download in the browser
+     *
+     * @param string $filename      Optional filename for the download
+     */
+
+    public function setDownload($filename = false) {
+        $h = "attachment;";
+        if ($filename) {
+            $h .= "filename='" . $filename . "'";
+        }
+        $this->response()->header("Content-Disposition", $h);
+    }
+
+    /********************************************************************************
     * Middleware
     *******************************************************************************/
 
@@ -1206,35 +1300,6 @@ class Slim
 
         //Invoke middleware and application stack
         $this->middleware[0]->call();
-
-        //Fetch status, header, and body
-        list($status, $headers, $body) = $this->response->finalize();
-
-        // Serialize cookies (with optional encryption)
-        \Slim\Http\Util::serializeCookies($headers, $this->response->cookies, $this->settings);
-
-        //Send headers
-        if (headers_sent() === false) {
-            //Send status
-            if (strpos(PHP_SAPI, 'cgi') === 0) {
-                header(sprintf('Status: %s', \Slim\Http\Response::getMessageForCode($status)));
-            } else {
-                header(sprintf('HTTP/%s %s', $this->config('http.version'), \Slim\Http\Response::getMessageForCode($status)));
-            }
-
-            //Send headers
-            foreach ($headers as $name => $value) {
-                $hValues = explode("\n", $value);
-                foreach ($hValues as $hVal) {
-                    header("$name: $hVal", false);
-                }
-            }
-        }
-
-        //Send body
-        echo $body;
-
-        restore_error_handler();
     }
 
     /**
@@ -1269,10 +1334,7 @@ class Slim
                $this->notFound();
             }
             $this->applyHook('slim.after.router');
-            $this->stop();
         } catch (\Slim\Exception\Stop $e) {
-            $this->response()->write(ob_get_clean());
-            $this->applyHook('slim.after');
         } catch (\Exception $e) {
             if ($this->config('debug')) {
                 throw $e;
@@ -1283,6 +1345,61 @@ class Slim
                     // Do nothing
                 }
             }
+            exit;
+        }
+        $this->response()->write(ob_get_clean());
+        $this->applyHook('slim.after');
+        $this->finalize($this->response);
+    }
+
+    /**
+     * Finalize send response
+     *
+     * This method accepts a response object and sends
+     * @param \Slim\Http\Response
+     */
+    public function finalize(\Slim\Http\Response $resp) {
+        if (!$this->responded) {
+            $this->responded = true;
+            //Fetch status, header, and body
+            list($status, $headers, $body) = $resp->finalize();
+
+            // Serialize cookies (with optional encryption)
+            \Slim\Http\Util::serializeCookies($headers, $resp->cookies, $this->settings);
+
+            //Send headers
+            if (headers_sent() === false) {
+                //Send status
+                if (strpos(PHP_SAPI, 'cgi') === 0) {
+                    header(sprintf('Status: %s', \Slim\Http\Response::getMessageForCode($status)));
+                } else {
+                    header(sprintf('HTTP/%s %s', $this->config('http.version'), \Slim\Http\Response::getMessageForCode($status)));
+                }
+
+                //Send headers
+                foreach ($headers as $name => $value) {
+                    $hValues = explode("\n", $value);
+                    foreach ($hValues as $hVal) {
+                        header("$name: $hVal", false);
+                    }
+                }
+            }
+            if ($resp->isStream()) {
+
+                echo ob_get_clean();
+                $fp = $resp->getStream();
+                while (!feof($fp)) {
+                    ob_start();
+                    echo fread($fp, 1024);
+                    echo ob_get_clean();
+                    ob_flush();
+                }
+            } else {
+                //Send body
+                echo $body;
+            }
+
+            restore_error_handler();
         }
     }
 

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1334,7 +1334,13 @@ class Slim
                $this->notFound();
             }
             $this->applyHook('slim.after.router');
+            $this->response()->write(ob_get_clean());
+            $this->applyHook('slim.after');
+            $this->finalize($this->response);
         } catch (\Slim\Exception\Stop $e) {
+            $this->response()->write(ob_get_clean());
+            $this->applyHook('slim.after');
+            $this->finalize($this->response);
         } catch (\Exception $e) {
             if ($this->config('debug')) {
                 throw $e;
@@ -1345,11 +1351,7 @@ class Slim
                     // Do nothing
                 }
             }
-            exit;
         }
-        $this->response()->write(ob_get_clean());
-        $this->applyHook('slim.after');
-        $this->finalize($this->response);
     }
 
     /**
@@ -1387,10 +1389,9 @@ class Slim
             if ($resp->isStream()) {
 
                 echo ob_get_clean();
-                $fp = $resp->getStream();
-                while (!feof($fp)) {
+                while (!feof($body)) {
                     ob_start();
-                    echo fread($fp, 1024);
+                    echo fread($body, 1024);
                     echo ob_get_clean();
                     ob_flush();
                 }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1238,7 +1238,7 @@ class Slim
      * @param string $contentType   Optional content type of the stream
      */
 
-    public function sendProc($command, $contentType = "text/plain") {
+    public function sendProcess($command, $contentType = "text/plain") {
         $ph = popen($command, 'r');
         $this->response()->stream($ph);
         $this->response()->header("Content-Type", $contentType);

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1387,7 +1387,6 @@ class Slim
             }
             if ($this->response->isStream()) {
 
-                echo ob_get_clean();
                 while (!feof($body)) {
                     ob_start();
                     echo fread($body, 1024);

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -489,6 +489,30 @@ class SlimTest extends PHPUnit_Framework_TestCase
     }
 
     /************************************************
+     * File Streaming
+     ************************************************/
+
+    public function testStreamingAFile()
+    {
+        $this->expectOutputString(file_get_contents("composer.json"));
+        $s = new \Slim\Slim();
+        $s->get('/bar', function() use ($s) {
+            $s->sendFile("composer.json");
+        });
+        $s->run();
+    }
+
+    public function testStreamingAProc()
+    {
+        $this->expectOutputString("FooBar\n");
+        $s = new \Slim\Slim();
+        $s->get('/bar', function() use ($s) {
+            $s->sendProc("echo 'FooBar'");
+        });
+        $s->run();
+    }
+
+    /************************************************
      * VIEW
      ************************************************/
 

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -507,7 +507,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $this->expectOutputString("FooBar\n");
         $s = new \Slim\Slim();
         $s->get('/bar', function() use ($s) {
-            $s->sendProc("echo 'FooBar'");
+            $s->sendProcess("echo 'FooBar'");
         });
         $s->run();
     }


### PR DESCRIPTION
# File Streaming

This PR adds two functions $app->sendProc() and $app->sendFile() as-well as a modified call loop which is backwards compatible.
### $app->sendProc($command, $contentType = "text-plain")

This function accepts a command and optionally a content type and will transfer the output to the client.
### $app->sendFile($file, $contentType = false)

This function accepts a URI either a local file or a remote URL, you can also specify a content type as the second parameter. If left blank the function will attempt to process and find an appropriate file type. 
