### PR TITLE
Add addRoute method to Slim/Router

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -175,6 +175,18 @@ class Router
     }
 
     /**
+     * Add an unnamed route from previously created route object
+     * @param  \Slim\Route       $route  The route object
+     * @return \Slim\Router
+     */
+    public function addRoute(\Slim\Route $route)
+    {
+        $this->routes[] = $route;
+        
+        return $this; // enable chaining
+    }
+
+    /**
      * Add named route
      * @param  string            $name   The route name
      * @param  \Slim\Route       $route  The route object


### PR DESCRIPTION
# Description

Simple method that accepts a Route object and adds to the collection in the Router.
# Justification

Many custom routing configurations methods using the Slim framework favor creating their own Slim\Route objects.  This change allows adding these routes without relying on the Router mapping methods.
# Tests

PHP Unit reports the same 3 failures as with the master branch:

```
PHPUnit 3.7.1 by Sebastian Bergmann.

Configuration read from /home/naicweb/apps/slimfork/phpunit.xml.dist

...............................................................  63 / 352 ( 17%)
............................................................... 126 / 352 ( 35%)
................F..F........................................... 189 / 352 ( 53%)
..........

foo
....F................................................ 252 / 352 ( 71%)
............................................................... 315 / 352 ( 89%)
.....................................

Time: 2 seconds, Memory: 5.50Mb

There were 3 failures:
1) SlimHttpUtilTest::testEncryptAndDecryptWithValidData
Failed asserting that false is true.

/home/naicweb/apps/slimfork/tests/Http/UtilTest.php:86
/tools/webapps/php/5.4.12/bin/phpunit:46

2) SlimHttpUtilTest::testEncryptAndDecryptWhenKeyAndIvAreTooLong
Failed asserting that false is true.

/home/naicweb/apps/slimfork/tests/Http/UtilTest.php:124
/tools/webapps/php/5.4.12/bin/phpunit:46

3) SessionCookieTest::testSessionIsPopulatedFromCookie
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'foo' => 'bar'
 )

/home/naicweb/apps/slimfork/tests/Middleware/SessionCookieTest.php:93
/tools/webapps/php/5.4.12/bin/phpunit:46

FAILURES!
Tests: 352, Assertions: 646, Failures: 3.
```
