### PR TITLE
Pretty exceptions only in debug

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1234,7 +1234,10 @@ class Slim
         set_error_handler(array('\Slim\Slim', 'handleErrors'));
 
         //Apply final outer middleware layers
-        $this->add(new \Slim\Middleware\PrettyExceptions());
+        if($this->config('debug')){
+        	//Apply pretty exceptions only in debug to avoid accidental information leakage in production
+        	$this->add(new \Slim\Middleware\PrettyExceptions());
+        }
 
         //Invoke middleware and application stack
         $this->middleware[0]->call();


### PR DESCRIPTION
Fixes issue with Pretty Exceptions catching all unhandled exceptions in any mode, any debug state. There MUST not be any semi-global exception handler for applications in production environments as it can lead to serious information leakage issues. 
