### PR TITLE
Cleaned up output on tests

### DIFF
--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -1211,7 +1211,9 @@ class SlimTest extends PHPUnit_Framework_TestCase
      */
     public function testSlimError()
     {
-        $s = new \Slim\Slim();
+        $s = new \Slim\Slim(array(
+            "log.enabled" => false
+        ));
         $s->get('/bar', function () use ($s) {
             $s->error();
         });
@@ -1292,7 +1294,8 @@ class SlimTest extends PHPUnit_Framework_TestCase
     public function testErrorWithMultipleApps()
     {
         $s1 = new \Slim\Slim(array(
-            'debug' => false
+            'debug' => false,
+            'log.enabled' => false
         ));
         $s2 = new \Slim\Slim();
         $s1->get('/bar', function () use ($s1) {
@@ -1373,8 +1376,8 @@ class SlimTest extends PHPUnit_Framework_TestCase
      * Slim should throw a Slim_Exception_Stop if error callback is not callable
      */
     public function testErrorHandlerIfNotCallable() {
-       $this->setExpectedException('\Slim\Exception\Stop');
-        $s = new \Slim\Slim();
+        $this->setExpectedException('\Slim\Exception\Stop');
+        $s = new \Slim\Slim(array("log.enabled" => false));
         $errCallback = 'foo';
         $s->error($errCallback);
     }
@@ -1393,7 +1396,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
      * Slim should throw a Slim_Exception_Stop if NotFound callback is not callable
      */
     public function testNotFoundHandlerIfNotCallable() {
-       $this->setExpectedException('\Slim\Exception\Stop');
+        $this->setExpectedException('\Slim\Exception\Stop');
         $s = new \Slim\Slim();
         $notFoundCallback = 'foo';
         $s->notFound($notFoundCallback);
@@ -1489,13 +1492,13 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(array()), $app->getHooks('test.hook.one'));
     }
 
-	/**
+    /**
      * Test late static binding
      *
      * Pre-conditions:
      * Slim app is extended by Derived class and instantiated;
      * Derived class overrides the 'getDefaultSettings' function and adds an extra default config value
-	 * Test that the new config value exists
+     * Test that the new config value exists
      *
      * Post-conditions:
      * Config value exists and is equal to expected value


### PR DESCRIPTION
I am not sure if this was done on purpose (for the tests themselves) but some of the error handling tests were outputting to the console because log.writer was on. This was showing up in PHPUnits results.

I turned off the log writer in the appropriate tests to fix the log issues, you can maybe verify if this is ok or ruins the test.
