### PR TITLE
Last-Modified header is incorrect when server time zone is not GMT

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -754,7 +754,7 @@ class Slim
     public function lastModified($time)
     {
         if (is_integer($time)) {
-            $this->response->headers->set('Last-Modified', date(DATE_RFC1123, $time));
+            $this->response->headers->set('Last-Modified', gmdate('D, d M Y H:i:s T', $time));
             if ($time === strtotime($this->request->headers->get('IF_MODIFIED_SINCE'))) {
                 $this->halt(304);
             }


### PR DESCRIPTION
Hi!

I came across a small bug with the Last-Modified header that is generated by Slim. It uses PHP's `DATE_RFC1123`, but this is not sufficient to meet the standards of the HTTP specification. Specifically, the [specification](http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1) requires that:

```
All HTTP date/time stamps MUST be represented in Greenwich Mean Time (GMT), without exception.
```

However the output of `date( DATE_RFC1123, $time )` depends on the server time zone:

``` php
$time = time();
date_default_timezone_set("GMT");
echo date( DATE_RFC1123, $time );
date_default_timezone_set("Africa/Nairobi");   // GMT+3
echo date( DATE_RFC1123, $time );
```

The output is:

```
Mon, 15 Jul 2013 12:27:30 GMT   // Correctly formatted
Mon, 15 Jul 2013 15:27:30 +0300    // Not correct - HTTP timestamps must be in GMT
```

Patch fixes it to ensure that the timestamp always adheres to the format required by the HTTP specification.
