### PR TITLE
Missing __isset and __unset

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -234,6 +234,10 @@ class Slim
     public function __isset($name){
     	return isset($this->container[$name]);
     }
+  
+    public function __unset($name){
+    	unset($this->container[$name]);
+    }
 
     /**
      * Get application instance by name

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -230,6 +230,10 @@ class Slim
     {
         $this->container[$name] = $value;
     }
+    
+    public function __isset($name){
+    	return isset($this->container[$name]);
+    }
 
     /**
      * Get application instance by name


### PR DESCRIPTION
Fixes critical issue with missing __isset and __unset magic methods. 

Because IoC container is now used, all implementations before 2.3 which explicitly relied upon setting properties directly to Slim object instance are now broken, because isset() returns false although value is present.

Needless to say I just debugged some 12k lines of code to find out that Slim's __isset is missing. 
