### PR TITLE
Modify tests for Last-Modified and Expires headers to enforce RFC compliance

### DIFF
--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -611,7 +611,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             'REQUEST_METHOD' => 'GET',
             'SCRIPT_NAME' => '/foo', //<-- Physical
             'PATH_INFO' => '/bar', //<-- Virtual
-            'HTTP_IF_MODIFIED_SINCE' => 'Sun, 03 Oct 2010 17:00:52 -0400',
+            'HTTP_IF_MODIFIED_SINCE' => 'Sun, 03 Oct 2010 21:00:52 GMT',
         ));
         $s = new \Slim\Slim();
         $s->get('/bar', function () use ($s) {
@@ -629,7 +629,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         \Slim\Environment::mock(array(
             'SCRIPT_NAME' => '/foo', //<-- Physical
             'PATH_INFO' => '/bar', //<-- Virtual
-            'IF_MODIFIED_SINCE' => 'Sun, 03 Oct 2010 17:00:52 -0400',
+            'IF_MODIFIED_SINCE' => 'Sun, 03 Oct 2010 21:00:52 GMT',
         ));
         $s = new \Slim\Slim();
         $s->get('/bar', function () use ($s) {
@@ -651,6 +651,25 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s->lastModified('Test');
         });
         $s->call();
+    }
+
+    /**
+     * Test Last Modified header format
+     */
+    public function testLastModifiedHeaderFormat()
+    {
+        \Slim\Environment::mock(array(
+            'SCRIPT_NAME' => '/foo', //<-- Physical
+            'PATH_INFO' => '/bar', //<-- Virtual
+        ));
+        $s = new \Slim\Slim();
+        $s->get('/bar', function () use ($s) {
+            $s->lastModified(1286139652);
+        });
+        $s->call();
+        list($status, $header, $body) = $s->response()->finalize();
+        $this->assertTrue(isset($header['Last-Modified']));
+        $this->assertEquals('Sun, 03 Oct 2010 21:00:52 GMT', $header['Last-Modified']);
     }
 
     /**
@@ -716,7 +735,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             'SCRIPT_NAME' => '/foo', //<-- Physical
             'PATH_INFO' => '/bar', //<-- Virtual
         ));
-        $expectedDate = gmdate('D, d M Y', strtotime('5 days')); //Just the day, month, and year
+        $expectedDate = gmdate('D, d M Y H:i:s T', strtotime('5 days'));
         $s = new \Slim\Slim();
         $s->get('/bar', function () use ($s) {
             $s->expires('5 days');
@@ -724,7 +743,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s->call();
         list($status, $header, $body) = $s->response()->finalize();
         $this->assertTrue(isset($header['Expires']));
-        $this->assertEquals(0, strpos($header['Expires'], $expectedDate));
+        $this->assertEquals($header['Expires'], $expectedDate);
     }
 
     /**
@@ -737,7 +756,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             'PATH_INFO' => '/bar', //<-- Virtual
         ));
         $fiveDaysFromNow = time() + (60 * 60 * 24 * 5);
-        $expectedDate = gmdate('D, d M Y', $fiveDaysFromNow); //Just the day, month, and year
+        $expectedDate = gmdate('D, d M Y H:i:s T', $fiveDaysFromNow);
         $s = new \Slim\Slim();
         $s->get('/bar', function () use ($s, $fiveDaysFromNow) {
             $s->expires($fiveDaysFromNow);
@@ -745,7 +764,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s->call();
         list($status, $header, $body) = $s->response()->finalize();
         $this->assertTrue(isset($header['Expires']));
-        $this->assertEquals(0, strpos($header['Expires'], $expectedDate));
+        $this->assertEquals($header['Expires'], $expectedDate);
     }
 
     /************************************************


### PR DESCRIPTION
Hi,

I've made a few changes to the tests for `lastModified()` and `expires()`:
- Change timestamps to use GMT.
- Add a test to check the format of the Last-Modified header.
- Check the full string for the Expires headers (thereby enforcing correct format)

Incidentally, running this through phpunit gave me a separate failure:

```
1) ViewTest::testSetTemplatesDirectory
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'templates'
+'templates/'
```
