### PR TITLE
Issue 568 fix serialization secure cookie

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -186,9 +186,15 @@ class Util
     {
         if ($config['cookies.encrypt']) {
             foreach ($cookies as $name => $settings) {
+                if (is_string($settings['expires'])) {
+                    $expires = strtotime($settings['expires']);
+                } else {
+                    $expires = (int) $settings['expires'];
+                }
+
                 $settings['value'] = static::encodeSecureCookie(
                     $settings['value'],
-                    $settings['expires'],
+                    $expires,
                     $config['cookies.secret_key'],
                     $config['cookies.cipher'],
                     $config['cookies.cipher_mode']


### PR DESCRIPTION
The `\Slim\Http\Util::encodeSecureCookie` function requires the
expires parameter to be an int. A string typed 'expires' or
'cookie.lifetime' would pass a string in this case, which causes the
response cookie to be broken when parsed by `decodeSecureCookie`.
