### PR TITLE
Don't send any content when it's a HEAD request.

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1274,8 +1274,10 @@ class Slim
             }
         }
 
-        //Send body
-        echo $body;
+        //Send body, but only if it isn't a HEAD request
+        if (!$this->request->isHead()) {
+            echo $body;
+        }
 
         restore_error_handler();
     }


### PR DESCRIPTION
Some servers (e.g., Apache) silently discard any content in response to a HEAD request, but others don't...
