### PR TITLE
Provides read-only access to Headers and Cookies objects instead of public access

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -53,12 +53,12 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * @var \Slim\Http\Headers
      */
-    public $headers;
+    protected $headers;
 
     /**
      * @var \Slim\Http\Cookies
      */
-    public $cookies;
+    protected $cookies;
 
     /**
      * @var string HTTP response body
@@ -138,7 +138,32 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
         $this->cookies = new \Slim\Http\Cookies();
         $this->write($body);
     }
-
+    
+    /**
+     * Provides read only access to headers and cokkies objects 
+     * 
+     */
+    public function __get($name)
+    {
+        if (property_exists($this, $name)) {
+            switch ($name) {
+                case 'headers':
+                    return $this->headers;
+                    break;
+                case 'cookies':
+                    return $this->cookies;
+                    break;
+                default:
+                    trigger_error("Cannot access protected/private property ".__CLASS__."::$name", E_USER_ERROR);
+                    return;
+            }
+        }
+        trigger_error("Undefined property: ".__CLASS__."::$name", E_USER_NOTICE);
+    }
+    
+    
+    
+    
     public function getStatus()
     {
         return $this->status;

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -140,8 +140,9 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     }
     
     /**
-     * Provides read only access to headers and cokkies objects 
+     * Provides read only access to headers and cookies objects 
      * 
+     * @author Tivie (githib.com/tivie)
      */
     public function __get($name)
     {


### PR DESCRIPTION
Instead of making Headers and Cookies objects publicly accessible, uses __get magic method to provide read only access to them.

This prevents accidental replace of the said objects, while keeping the desired functionality and backwards compatibility.
