### PR TITLE
Fix `urlFor` with regex

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -192,8 +192,8 @@ class Router
         }
         $pattern = preg_replace($search, $params, $this->getNamedRoute($name)->getPattern());
 
-        //Remove remnants of unpopulated, trailing optional pattern segments
-        return preg_replace('#\(/?:.+\)|\(|\)#', '', $pattern);
+        //Remove remnants of unpopulated, trailing optional pattern segments, escaped special characters
+        return preg_replace('#\(/?:.+\)|\(|\)|\\\\#', '', $pattern);
     }
 
     /**

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -222,14 +222,22 @@ class RouterTest extends PHPUnit_Framework_TestCase
     public function testUrlFor()
     {
         $router = new \Slim\Router();
+
         $route1 = new \Slim\Route('/hello/:first/:last', function () {});
-		$route1 = $route1->via('GET')->name('hello');
+        $route1 = $route1->via('GET')->name('hello');
+
+        $route2 = new \Slim\Route('/path/(:foo\.:bar)', function () {});
+        $route2 = $route2->via('GET')->name('regexRoute');
 
         $routes = new \ReflectionProperty($router, 'namedRoutes');
         $routes->setAccessible(true);
-        $routes->setValue($router, array('hello' => $route1));
+        $routes->setValue($router, array(
+            'hello' => $route1,
+            'regexRoute' => $route2
+        ));
 
         $this->assertEquals('/hello/Josh/Lockhart', $router->urlFor('hello', array('first' => 'Josh', 'last' => 'Lockhart')));
+        $this->assertEquals('/path/Hello.Josh', $router->urlFor('regexRoute', array('foo' => 'Hello', 'bar' => 'Josh')));
     }
 
     public function testUrlForIfNoSuchRoute()


### PR DESCRIPTION
Before `urlFor` would return '/path/Hello\.Josh' for a pattern
'/path/(:foo\.:bar)' with parameters
`('foo' => 'Hello', 'bar' => 'Josh')`, when the expected return value
is '/path/Hello.Josh' (this test was introduced in commit cc722cc).

(Pull Request description updated (2013/09/26) because GitHub ate my \)
