### PR TITLE
Match path items on whole words.

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -357,13 +357,12 @@ class Route
             $patternAsRegex .= '?';
         }
 
+        // Match path fragments as whole words
         $patternAsRegex = preg_replace(
             '#/([\w]+)/#',
             '/\b${1}\b/',
             $patternAsRegex
         );
-
-        error_log('#^' . $patternAsRegex . '$#');
 
         //Cache URL params' names and values if this route matches the current HTTP request
         if (!preg_match('#^' . $patternAsRegex . '$#', $resourceUri, $paramValues)) {

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -357,6 +357,14 @@ class Route
             $patternAsRegex .= '?';
         }
 
+        $patternAsRegex = preg_replace(
+            '#/([\w]+)/#',
+            '/\b${1}\b/',
+            $patternAsRegex
+        );
+
+        error_log('#^' . $patternAsRegex . '$#');
+
         //Cache URL params' names and values if this route matches the current HTTP request
         if (!preg_match('#^' . $patternAsRegex . '$#', $resourceUri, $paramValues)) {
             return false;


### PR DESCRIPTION
Hi there,

I recently ran into some issues with routing, where the callbacks for a route were executed that had a substring of the requested path in it.

An example:

``` php
$app->get("/me/", function() {
     echo("Nice to meet you.");
});

$app->get("/message/", function() {
     echo("No message for you this time.");
});
```

**GET /message/** would execute the callback for the "me" route in this scenario.

The proposed CR tries to fix this by checking if items in the route definition are candidates for matching on whole words and modifying the given parts of the matching regex.

Cheers,
marionebl
