### PR TITLE
closes Issue #598

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -170,7 +170,7 @@ class Util
         //Decrypt value
         mcrypt_generic_init($module, $key, $iv);
         $decryptedData = @mdecrypt_generic($module, $data);
-        $res = str_replace("\x0", '', $decryptedData);
+        $res = rtrim($decryptedData, "\0");
         mcrypt_generic_deinit($module);
 
         return $res;

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "slim/slim",
+    "name": "solas/slim",
     "type": "library",
     "description": "Slim Framework, a PHP micro framework",
     "keywords": ["microframework","rest","router"],


### PR DESCRIPTION
the use of str_replace("\x0", '', $decryptedData);  result in the content of the cookie being changed

this pull request replaces this function with rtrim($decryptedData, "\0");  which will trim the trailing padding with
affecting the content of the encrypted cookie
