### PR TITLE
Able to pass arg for group route callback

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -230,12 +230,14 @@ class Slim
     {
         $this->container[$name] = $value;
     }
-    
-    public function __isset($name){
+
+    public function __isset($name)
+    {
     	return isset($this->container[$name]);
     }
-  
-    public function __unset($name){
+
+    public function __unset($name)
+    {
     	unset($this->container[$name]);
     }
 
@@ -533,8 +535,15 @@ class Slim
         $pattern = array_shift($args);
         $callable = array_pop($args);
         $this->router->pushGroup($pattern, $args);
+
+        // Get params
+        $route = new \Slim\Route($pattern, $callable);
+        $resourceUri = explode('/', $this->request->getResourceUri());
+        $patternLength = count(explode('/', $pattern));
+        $groupResourceUri = array_slice($resourceUri, 0, $patternLength);
+        $route->matches(implode('/', $groupResourceUri));
         if (is_callable($callable)) {
-            call_user_func($callable);
+            call_user_func_array($callable, $route->getParams());
         }
         $this->router->popGroup();
     }

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -442,17 +442,18 @@ class SlimTest extends PHPUnit_Framework_TestCase
         \Slim\Environment::mock(array(
             'REQUEST_METHOD' => 'GET',
             'SCRIPT_NAME' => '/foo', //<-- Physical
-            'PATH_INFO' => '/bar/baz', //<-- Virtual'
+            'PATH_INFO' => '/abc/bar/baz', //<-- Virtual'
         ));
         $s = new \Slim\Slim();
         $mw1 = function () { echo "foo"; };
         $mw2 = function () { echo "bar"; };
         $callable = function () { echo "xyz"; };
-        $s->group('/bar', $mw1, function () use ($s, $mw2, $callable) {
+        $s->group('/:arg/bar', $mw1, function ($arg) use ($s, $mw2, $callable) {
+            $s->response()->setBody($arg);
             $s->get('/baz', $mw2, $callable);
         });
         $s->call();
-        $this->assertEquals('foobarxyz', $s->response()->body());
+        $this->assertEquals('abcfoobarxyz', $s->response()->body());
     }
 
     /*


### PR DESCRIPTION
will let us the ability to pass args callback of group route : 

```
$app->group('/:foo/bar', function($foo) use($app)
{
    echo $foo;
    $app->get('/whatever', ....
});
```
