### PR TITLE
Fixes flash messaging/SessionCookie decoding failure when cookies.encrypt = true

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -44,6 +44,14 @@ namespace Slim\Http;
 class Util
 {
     /**
+     * An array of md5 hashed cookie values that will be excluded from
+     * encryption during the serialization process.
+     *
+     * @var array Exclude from encryption in Util::serializeCookies()
+     */
+    protected static $encryptionExclusions = array();
+
+    /**
      * Strip slashes from string or array
      *
      * This method strips slashes from its input. By default, this method will only
@@ -192,13 +200,15 @@ class Util
                     $expires = (int) $settings['expires'];
                 }
 
-                $settings['value'] = static::encodeSecureCookie(
-                    $settings['value'],
-                    $expires,
-                    $config['cookies.secret_key'],
-                    $config['cookies.cipher'],
-                    $config['cookies.cipher_mode']
-                );
+                if (!in_array(md5($settings['value']), self::$encryptionExclusions)) {
+                    $settings['value'] = static::encodeSecureCookie(
+                        $settings['value'],
+                        $expires,
+                        $config['cookies.secret_key'],
+                        $config['cookies.cipher'],
+                        $config['cookies.cipher_mode']
+                    );
+                }
                 static::setCookieHeader($headers, $name, $settings);
             }
         } else {
@@ -432,4 +442,33 @@ class Util
         return pack("h*", $data1.$data2);
     }
 
+    /**
+     * Add an exclusion to the encryption exclusion list
+     *
+     * @param string $hash MD5 hash of the cookie value to exclude
+     */
+    public static function addEncryptionExclusion($hash)
+    {
+        self::$encryptionExclusions[] = $hash;
+    }
+
+    /**
+     * Get the exclusion list
+     *
+     * @return array Exclusion list
+     */
+    public static function getEncryptionExclusions()
+    {
+        return self::$encryptionExclusions;
+    }
+
+    /**
+     * Get the exclusion list
+     *
+     * @return array Exclusion list
+     */
+    public static function clearEncryptionExclusions()
+    {
+        self::$encryptionExclusions = array();
+    }
 }

--- a/Slim/Middleware/SessionCookie.php
+++ b/Slim/Middleware/SessionCookie.php
@@ -166,6 +166,10 @@ class SessionCookie extends \Slim\Middleware
                     'httponly' => $this->settings['httponly']
                 )
             );
+
+            if ($this->app->config('cookies.encrypt')) {
+                \Slim\Http\Util::addEncryptionExclusion(md5($value));
+            }
         }
         session_destroy();
     }


### PR DESCRIPTION
Without a way to check if a cookie is already encoded, `\Slim\Http\Util::serializeCookies()` will encode an already encoded cookie. This is an issue when `\Slim\Middleware\SessionCookie` sets an encoded cookie value on the response object during `\Slim\Middleware\SessionCookie::saveSession()` (as `\Slim\Http\Util::serializeCookies()` will encode every cookie it gets if `cookies.encrypt` = `true`).  Since the cookie is only decoded once during `\Slim\Middleware\SessionCookie::loadSession()`, the cookie's actual decoded value is never available to the application, and `unserialize()` in `\Slim\Middleware\SessionCookie::loadSession()` will fail.

This PR adds the ability to tell `\Slim\Http\Util::serializeCookies()` to skip encoding a cookie during the serialization process.
