### PR TITLE
Update Router.php

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -193,7 +193,7 @@ class Router
         $pattern = preg_replace($search, $params, $this->getNamedRoute($name)->getPattern());
 
         //Remove remnants of unpopulated, trailing optional pattern segments
-        return preg_replace('#\(/?:.+\)|\(|\)#', '', $pattern);
+        return preg_replace('#\(/?:[^)]+\)+|\(|\)#', '', $pattern);
     }
 
     /**


### PR DESCRIPTION
Fixed bug where urlForl remove all characters after an empty optional segment.

Ie.
//Old behavior
testroute: /partA/partB(/:partC)/partD(.html)
$url = $app->urlFor('testroute'); //Would become /partA/partB

//New behavior
testroute: /partA/partB(/:partC)/partD(.html)
$url = $app->urlFor('testroute'); //Would become /partA/partB/pardD.html
