### PR TITLE
Fix HTTP method override middleware

### DIFF
--- a/Slim/Middleware/MethodOverride.php
+++ b/Slim/Middleware/MethodOverride.php
@@ -76,10 +76,10 @@ class MethodOverride extends \Slim\Middleware
     public function call()
     {
         $env = $this->app->environment();
-        if (isset($env['X_HTTP_METHOD_OVERRIDE'])) {
+        if (isset($env['HTTP_X_HTTP_METHOD_OVERRIDE'])) {
             // Header commonly used by Backbone.js and others
             $env['slim.method_override.original_method'] = $env['REQUEST_METHOD'];
-            $env['REQUEST_METHOD'] = strtoupper($env['X_HTTP_METHOD_OVERRIDE']);
+            $env['REQUEST_METHOD'] = strtoupper($env['HTTP_X_HTTP_METHOD_OVERRIDE']);
         } elseif (isset($env['REQUEST_METHOD']) && $env['REQUEST_METHOD'] === 'POST') {
             // HTML Form Override
             $req = new \Slim\Http\Request($env);

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -296,6 +296,19 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests X-HTTP-Method-Override is allowed through unmolested.
+     *
+     * Pre-conditions:
+     * X_HTTP_METHOD_OVERRIDE is sent in client HTTP request;
+     * X_HTTP_METHOD_OVERRIDE is not empty;
+     */
+    public function testSetsHttpMethodOverrideHeader() {
+        $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'DELETE';
+        $env = \Slim\Environment::getInstance(true);
+        $this->assertEquals('DELETE', $env['HTTP_X_HTTP_METHOD_OVERRIDE']);
+    }
+
+    /**
      * Test detects HTTPS
      *
      * Pre-conditions:

--- a/tests/Middleware/MethodOverrideTest.php
+++ b/tests/Middleware/MethodOverrideTest.php
@@ -134,7 +134,7 @@ class MethodOverrideTest extends PHPUnit_Framework_TestCase
             'CONTENT_TYPE' => 'application/json',
             'CONENT_LENGTH' => 0,
             'slim.input' => '',
-            'X_HTTP_METHOD_OVERRIDE' => 'DELETE'
+            'HTTP_X_HTTP_METHOD_OVERRIDE' => 'DELETE'
         ));
         $app = new CustomAppMethod();
         $mw = new \Slim\Middleware\MethodOverride();


### PR DESCRIPTION
It appears that Slim used to strip HTTP_ off $_SERVER variables and the MethodOverride middlware expects that to happen, but it looks like Slim isn't doing that anymore. I've updated MethodOverride to use the correct environment variable and added some tests to confirm this.
