### PR TITLE
Support for query parameters in routing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,7 +65,7 @@ should contain this code:
 
 #### Nginx
 
-Your nginx configuration file should contain this code (along with other settings you may need) in your `location` block:
+The nginx configuration file should contain this code (along with other settings you may need) in your `location` block:
 
     try_files $uri $uri/ /index.php?$args;
 

--- a/Slim/Helper/Set.php
+++ b/Slim/Helper/Set.php
@@ -139,6 +139,20 @@ class Set implements \ArrayAccess, \Countable, \IteratorAggregate
         unset($this->data[$this->normalizeKey($key)]);
     }
 
+	/**
+	 * Property Overloading
+	 */
+
+	public function __get($key)
+	{
+		return $this->get($key);
+	}
+
+	public function __isset($key)
+	{
+		return $this->has($key);
+	}
+
     /**
      * Clear all values
      */

--- a/Slim/Helper/Set.php
+++ b/Slim/Helper/Set.php
@@ -139,19 +139,29 @@ class Set implements \ArrayAccess, \Countable, \IteratorAggregate
         unset($this->data[$this->normalizeKey($key)]);
     }
 
-	/**
-	 * Property Overloading
-	 */
+    /**
+     * Property Overloading
+     */
 
-	public function __get($key)
-	{
-		return $this->get($key);
-	}
+    public function __get($key)
+    {
+        return $this->get($key);
+    }
 
-	public function __isset($key)
-	{
-		return $this->has($key);
-	}
+    public function __set($key, $value)
+    {
+        $this->set($key, $value);
+    }
+
+    public function __isset($key)
+    {
+        return $this->has($key);
+    }
+
+    public function __unset($key)
+    {
+        return $this->remove($key);
+    }
 
     /**
      * Clear all values

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1234,7 +1234,10 @@ class Slim
         set_error_handler(array('\Slim\Slim', 'handleErrors'));
 
         //Apply final outer middleware layers
-        $this->add(new \Slim\Middleware\PrettyExceptions());
+        if($this->config('debug')){
+        	//Apply pretty exceptions only in debug to avoid accidental information leakage in production
+        	$this->add(new \Slim\Middleware\PrettyExceptions());
+        }
 
         //Invoke middleware and application stack
         $this->middleware[0]->call();

--- a/tests/Helper/SetTest.php
+++ b/tests/Helper/SetTest.php
@@ -166,4 +166,29 @@ class SetTest extends PHPUnit_Framework_TestCase
         $this->property->setValue($this->bag, $data);
         $this->assertInstanceOf('\ArrayIterator', $this->bag->getIterator());
     }
+
+	public function testPropertyOverloadGet()
+	{
+		$data = array(
+			'abc' => '123',
+			'foo' => 'bar'
+		);
+		$this->property->setValue($this->bag, $data);
+
+		$this->assertEquals('123', $this->bag->abc);
+		$this->assertEquals('bar', $this->bag->foo);
+	}
+
+	public function testPropertyOverloadingIsset()
+	{
+		$data = array(
+			'abc' => '123',
+			'foo' => 'bar'
+		);
+		$this->property->setValue($this->bag, $data);
+
+		$this->assertTrue(isset($this->bag->abc));
+		$this->assertTrue(isset($this->bag->foo));
+		$this->assertFalse(isset($this->bag->foobar));
+	}
 }

--- a/tests/Helper/SetTest.php
+++ b/tests/Helper/SetTest.php
@@ -210,7 +210,7 @@ class SetTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(isset($this->bag->abc));
         unset($this->bag->abc);
         $this->assertFalse(isset($this->bag->abc));
-		$this->assertArrayNotHasKey('abc', $this->property->getValue($this->bag));
+        $this->assertArrayNotHasKey('abc', $this->property->getValue($this->bag));
         $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));			
     }
 }

--- a/tests/Helper/SetTest.php
+++ b/tests/Helper/SetTest.php
@@ -43,7 +43,7 @@ class SetTest extends PHPUnit_Framework_TestCase
     {
         $this->bag->set('foo', 'bar');
         $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));
-		$bag =  $this->property->getValue($this->bag);
+        $bag =  $this->property->getValue($this->bag);
         $this->assertEquals('bar', $bag['foo']);
     }
 
@@ -67,7 +67,7 @@ class SetTest extends PHPUnit_Framework_TestCase
         ));
         $this->assertArrayHasKey('abc', $this->property->getValue($this->bag));
         $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));
-		$bag = $this->property->getValue($this->bag);
+        $bag = $this->property->getValue($this->bag);
         $this->assertEquals('123', $bag['abc']);
         $this->assertEquals('bar', $bag['foo']);
     }
@@ -121,7 +121,7 @@ class SetTest extends PHPUnit_Framework_TestCase
         );
         $this->property->setValue($this->bag, $data);
         $this->bag['foo'] = 'changed';
-		$bag = $this->property->getValue($this->bag);
+        $bag = $this->property->getValue($this->bag);
         $this->assertEquals('changed', $bag['foo']);
     }
 
@@ -167,28 +167,50 @@ class SetTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\ArrayIterator', $this->bag->getIterator());
     }
 
-	public function testPropertyOverloadGet()
-	{
-		$data = array(
-			'abc' => '123',
-			'foo' => 'bar'
-		);
-		$this->property->setValue($this->bag, $data);
+    public function testPropertyOverloadGet()
+    {
+        $data = array(
+            'abc' => '123',
+            'foo' => 'bar'
+        );
+        $this->property->setValue($this->bag, $data);
 
-		$this->assertEquals('123', $this->bag->abc);
-		$this->assertEquals('bar', $this->bag->foo);
-	}
+        $this->assertEquals('123', $this->bag->abc);
+        $this->assertEquals('bar', $this->bag->foo);
+    }
 
-	public function testPropertyOverloadingIsset()
-	{
-		$data = array(
-			'abc' => '123',
-			'foo' => 'bar'
-		);
-		$this->property->setValue($this->bag, $data);
+    public function testPropertyOverloadSet()
+    {
+        $this->bag->foo = 'bar';
+        $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));
+        $this->assertEquals('bar', $this->bag->foo);
+    }
 
-		$this->assertTrue(isset($this->bag->abc));
-		$this->assertTrue(isset($this->bag->foo));
-		$this->assertFalse(isset($this->bag->foobar));
-	}
+    public function testPropertyOverloadingIsset()
+    {
+        $data = array(
+            'abc' => '123',
+            'foo' => 'bar'
+        );
+        $this->property->setValue($this->bag, $data);
+
+        $this->assertTrue(isset($this->bag->abc));
+        $this->assertTrue(isset($this->bag->foo));
+        $this->assertFalse(isset($this->bag->foobar));
+    }
+
+    public function testPropertyOverloadingUnset()
+    {
+        $data = array(
+            'abc' => '123',
+            'foo' => 'bar'
+        );
+        $this->property->setValue($this->bag, $data);
+
+        $this->assertTrue(isset($this->bag->abc));
+        unset($this->bag->abc);
+        $this->assertFalse(isset($this->bag->abc));
+		$this->assertArrayNotHasKey('abc', $this->property->getValue($this->bag));
+        $this->assertArrayHasKey('foo', $this->property->getValue($this->bag));			
+    }
 }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -342,6 +342,54 @@ class RouteTest extends PHPUnit_Framework_TestCase
         ), 'params', $route);
     }
 
+    public function testMatchesParamsAndWildcardsAndQuery()
+    {
+        $route = new \Slim\Route('/hello/:path+/world/:year/:month/:day/:path2+?id=7&param=:getParam', function () {});
+
+        $oldGet = $_GET;
+        $_GET = array (
+            'id' => '7',
+            'param' => 'paramValue',
+            'extraUnneeded' => '1',
+        );
+
+        $this->assertTrue($route->matches('/hello/foo/bar/world/2012/03/10/first/second'));
+        $this->assertAttributeEquals(array(
+            'path' => array('foo', 'bar'),
+            'year' => '2012',
+            'month' => '03',
+            'day' => '10',
+            'path2' => array('first', 'second'),
+            'getParam' => 'paramValue',
+        ), 'params', $route);
+
+        $_GET = $oldGet;
+    }
+
+    public function testMatchesParamsAndWildcardsAndQueryFail()
+    {
+        $route = new \Slim\Route('/hello/:path+/world/:year/:month/:day/:path2+?id=7&param=:getParam&needed=1', function () {});
+
+        $oldGet = $_GET;
+        $_GET = array (
+            'id' => '7',
+            'param' => 'paramValue',
+            'extraUnneeded' => 'q',
+        );
+
+        $this->assertFalse($route->matches('/hello/foo/bar/world/2012/03/10/first/second'));
+        $this->assertAttributeEquals(array(
+            'path' => array('foo', 'bar'),
+            'year' => '2012',
+            'month' => '03',
+            'day' => '10',
+            'path2' => array('first', 'second'),
+            'getParam' => 'paramValue',
+        ), 'params', $route);
+
+        $_GET = $oldGet;
+    }
+
     public function testMatchesParamsWithOptionalWildcard()
     {
         $route = new \Slim\Route('/hello(/:foo(/:bar+))', function () {});

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -239,4 +239,22 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router = new \Slim\Router();
         $router->urlFor('foo', array('abc' => '123'));
     }
+
+    public function testUrlForWithQuery()
+    {
+        $oldGet = $_GET;
+        $router = new \Slim\Router();
+        $route1 = new \Slim\Route('/hello/:first/:last?id=9&param=:param', function () {});
+        $route1 = $route1->via('GET')->name('hello');
+
+        $routes = new \ReflectionProperty($router, 'namedRoutes');
+        $routes->setAccessible(true);
+        $routes->setValue($router, array('hello' => $route1));
+
+        $this->assertEquals('/hello/Josh/Lockhart?id=9&param=value', $router->urlFor('hello', array(
+            'first' => 'Josh', 'last' => 'Lockhart', 'param' => 'value'
+        )));
+
+        $_GET = $oldGet;
+    }
 }

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -1211,7 +1211,9 @@ class SlimTest extends PHPUnit_Framework_TestCase
      */
     public function testSlimError()
     {
-        $s = new \Slim\Slim();
+        $s = new \Slim\Slim(array(
+            "log.enabled" => false
+        ));
         $s->get('/bar', function () use ($s) {
             $s->error();
         });
@@ -1292,7 +1294,8 @@ class SlimTest extends PHPUnit_Framework_TestCase
     public function testErrorWithMultipleApps()
     {
         $s1 = new \Slim\Slim(array(
-            'debug' => false
+            'debug' => false,
+            'log.enabled' => false
         ));
         $s2 = new \Slim\Slim();
         $s1->get('/bar', function () use ($s1) {
@@ -1373,8 +1376,8 @@ class SlimTest extends PHPUnit_Framework_TestCase
      * Slim should throw a Slim_Exception_Stop if error callback is not callable
      */
     public function testErrorHandlerIfNotCallable() {
-       $this->setExpectedException('\Slim\Exception\Stop');
-        $s = new \Slim\Slim();
+        $this->setExpectedException('\Slim\Exception\Stop');
+        $s = new \Slim\Slim(array("log.enabled" => false));
         $errCallback = 'foo';
         $s->error($errCallback);
     }
@@ -1393,7 +1396,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
      * Slim should throw a Slim_Exception_Stop if NotFound callback is not callable
      */
     public function testNotFoundHandlerIfNotCallable() {
-       $this->setExpectedException('\Slim\Exception\Stop');
+        $this->setExpectedException('\Slim\Exception\Stop');
         $s = new \Slim\Slim();
         $notFoundCallback = 'foo';
         $s->notFound($notFoundCallback);
@@ -1489,13 +1492,13 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array(array()), $app->getHooks('test.hook.one'));
     }
 
-	/**
+    /**
      * Test late static binding
      *
      * Pre-conditions:
      * Slim app is extended by Derived class and instantiated;
      * Derived class overrides the 'getDefaultSettings' function and adds an extra default config value
-	 * Test that the new config value exists
+     * Test that the new config value exists
      *
      * Post-conditions:
      * Config value exists and is equal to expected value


### PR DESCRIPTION
I would like to contribute this bit of code which would let you route $_GET query parameters.

Such a route would look like this: 'urlPart/:anotherUrlPart?obligatoryParam=1&controller=:controller&:action=:action', which would match /urlPart/value?controller=cont&action=act&obligatoryParam=1&unneededGetParam=2. As you can see, the order doesn't matter as long as all the needed parameters are there, and values that do not begin with a colon must equal the value given in the route. Also, any unnecessary parameters are ignored and do not cause the match to fail.

I've also included a few test, although it may be possible that more would be necessary. I also haven't written any documentation.
