### PR TITLE
Support for query parameters in routing

### DIFF
--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -342,6 +342,54 @@ class RouteTest extends PHPUnit_Framework_TestCase
         ), 'params', $route);
     }
 
+    public function testMatchesParamsAndWildcardsAndQuery()
+    {
+        $route = new \Slim\Route('/hello/:path+/world/:year/:month/:day/:path2+?id=7&param=:getParam', function () {});
+
+        $oldGet = $_GET;
+        $_GET = array (
+            'id' => '7',
+            'param' => 'paramValue',
+            'extraUnneeded' => '1',
+        );
+
+        $this->assertTrue($route->matches('/hello/foo/bar/world/2012/03/10/first/second'));
+        $this->assertAttributeEquals(array(
+            'path' => array('foo', 'bar'),
+            'year' => '2012',
+            'month' => '03',
+            'day' => '10',
+            'path2' => array('first', 'second'),
+            'getParam' => 'paramValue',
+        ), 'params', $route);
+
+        $_GET = $oldGet;
+    }
+
+    public function testMatchesParamsAndWildcardsAndQueryFail()
+    {
+        $route = new \Slim\Route('/hello/:path+/world/:year/:month/:day/:path2+?id=7&param=:getParam&needed=1', function () {});
+
+        $oldGet = $_GET;
+        $_GET = array (
+            'id' => '7',
+            'param' => 'paramValue',
+            'extraUnneeded' => 'q',
+        );
+
+        $this->assertFalse($route->matches('/hello/foo/bar/world/2012/03/10/first/second'));
+        $this->assertAttributeEquals(array(
+            'path' => array('foo', 'bar'),
+            'year' => '2012',
+            'month' => '03',
+            'day' => '10',
+            'path2' => array('first', 'second'),
+            'getParam' => 'paramValue',
+        ), 'params', $route);
+
+        $_GET = $oldGet;
+    }
+
     public function testMatchesParamsWithOptionalWildcard()
     {
         $route = new \Slim\Route('/hello(/:foo(/:bar+))', function () {});

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -239,4 +239,22 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $router = new \Slim\Router();
         $router->urlFor('foo', array('abc' => '123'));
     }
+
+    public function testUrlForWithQuery()
+    {
+        $oldGet = $_GET;
+        $router = new \Slim\Router();
+        $route1 = new \Slim\Route('/hello/:first/:last?id=9&param=:param', function () {});
+        $route1 = $route1->via('GET')->name('hello');
+
+        $routes = new \ReflectionProperty($router, 'namedRoutes');
+        $routes->setAccessible(true);
+        $routes->setValue($router, array('hello' => $route1));
+
+        $this->assertEquals('/hello/Josh/Lockhart?id=9&param=value', $router->urlFor('hello', array(
+            'first' => 'Josh', 'last' => 'Lockhart', 'param' => 'value'
+        )));
+
+        $_GET = $oldGet;
+    }
 }


### PR DESCRIPTION
I would like to contribute this bit of code which would let you route $_GET query parameters.

Such a route would look like this: 'urlPart/:anotherUrlPart?obligatoryParam=1&controller=:controller&:action=:action', which would match /urlPart/value?controller=cont&action=act&obligatoryParam=1&unneededGetParam=2. As you can see, the order doesn't matter as long as all the needed parameters are there, and values that do not begin with a colon must equal the value given in the route. Also, any unnecessary parameters are ignored and do not cause the match to fail.

I've also included a few test, although it may be possible that more would be necessary. I also haven't written any documentation.
