### PR TITLE
Container

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -44,32 +44,12 @@ if (!extension_loaded('mcrypt')) {
  * @author  Josh Lockhart
  * @since   1.0.0
  */
-class Slim
+class Slim extends \Slim\Helper\Set
 {
     /**
      * @const string
      */
     const VERSION = '2.3.0';
-
-    /**
-     * @var \Slim\Helper\Set
-     */
-    public $container;
-
-    /**
-     * @var array[\Slim]
-     */
-    protected static $apps = array();
-
-    /**
-     * @var string
-     */
-    protected $name;
-
-    /**
-     * @var array
-     */
-    protected $middleware;
 
     /**
      * @var mixed Callable to be invoked if application error
@@ -145,17 +125,16 @@ class Slim
      */
     public function __construct(array $userSettings = array())
     {
-        // Setup IoC container
-        $this->container = new \Slim\Helper\Set();
-        $this->container['settings'] = array_merge(static::getDefaultSettings(), $userSettings);
+        // Default and overriding settings
+        $this->set('settings', array_merge(static::getDefaultSettings(), $userSettings));
 
         // Default environment
-        $this->container->singleton('environment', function ($c) {
+        $this->singleton('environment', function ($c) {
             return \Slim\Environment::getInstance();
         });
 
         // Default request
-        $this->container->singleton('request', function ($c) {
+        $this->singleton('request', function ($c) {
             $request = new \Slim\Http\Request($c['environment']);
             if ($c['settings']['cookies.encrypt'] ===  true) {
                 $request->cookies->decrypt($c['crypt']);
@@ -165,17 +144,17 @@ class Slim
         });
 
         // Default response
-        $this->container->singleton('response', function ($c) {
+        $this->singleton('response', function ($c) {
             return new \Slim\Http\Response();
         });
 
         // Default router
-        $this->container->singleton('router', function ($c) {
+        $this->singleton('router', function ($c) {
             return new \Slim\Router();
         });
 
         // Default view
-        $this->container->singleton('view', function ($c) {
+        $this->singleton('view', function ($c) {
             $viewClass = $c['settings']['view'];
 
             return ($viewClass instanceOf \Slim\View) ? $viewClass : new $viewClass;
@@ -203,14 +182,14 @@ class Slim
         });
 
         // Default log writer
-        $this->container->singleton('logWriter', function ($c) {
+        $this->singleton('logWriter', function ($c) {
             $logWriter = $c['settings']['log.writer'];
 
             return is_object($logWriter) ? $logWriter : new \Slim\LogWriter($c['environment']['slim.errors']);
         });
 
         // Default log
-        $this->container->singleton('log', function ($c) {
+        $this->singleton('log', function ($c) {
             $log = new \Slim\Log($c['logWriter']);
             $log->setEnabled($c['settings']['log.enabled']);
             $log->setLevel($c['settings']['log.level']);
@@ -221,7 +200,7 @@ class Slim
         });
 
         // Default mode
-        $this->container['mode'] = function ($c) {
+        $this->set('mode', function ($c) {
             $mode = $c['settings']['mode'];
 
             if (isset($_ENV['SLIM_MODE'])) {
@@ -234,35 +213,22 @@ class Slim
             }
 
             return $mode;
-        };
+        });
 
         // Define default middleware stack
-        $this->middleware = array($this);
+        $this->set('middleware', array($this));
+
+        // Create a singleton container for app instances
+        $this->singleton('apps', function ($c) {
+            $apps = new \Slim\Helper\Set();
+
+            return $apps;
+        });
 
         // Make default if first instance
         if (is_null(static::getInstance())) {
             $this->setName('default');
         }
-    }
-
-    public function __get($name)
-    {
-        return $this->container[$name];
-    }
-
-    public function __set($name, $value)
-    {
-        $this->container[$name] = $value;
-    }
-
-    public function __isset($name)
-    {
-        return isset($this->container[$name]);
-    }
-
-    public function __unset($name)
-    {
-        unset($this->container[$name]);
     }
 
     /**
@@ -272,7 +238,7 @@ class Slim
      */
     public static function getInstance($name = 'default')
     {
-        return isset(static::$apps[$name]) ? static::$apps[$name] : null;
+        return isset($this->apps[$name]) ? $this->apps[$name] : null;
     }
 
     /**
@@ -282,7 +248,7 @@ class Slim
     public function setName($name)
     {
         $this->name = $name;
-        static::$apps[$name] = $this;
+        $this->apps[$name] = $this;
     }
 
     /**
@@ -361,9 +327,7 @@ class Slim
                 return isset($this->settings[$name]) ? $this->settings[$name] : null;
             }
         } else {
-            $settings = $this->settings;
-            $settings[$name] = $value;
-            $this->settings = $settings;
+            $this->settings[$name] = $value;
         }
     }
 
@@ -457,6 +421,7 @@ class Slim
         $callable = array_pop($args);
         $route = new \Slim\Route($pattern, $callable);
         $this->router->map($route);
+
         if (count($args) > 0) {
             $route->setMiddleware($args);
         }


### PR DESCRIPTION
The only issue I see here may be the code on line 193. I don't know what passing `$this` into a property of itself as a container will do.

As mentioned on the issue tracker, I can't get the tests to run, which is probably my lack of understanding on that front. They complain that `Slim\Helper\Set` is not found:

```
PHP Fatal error:  Class 'Slim\Helper\Set' not found in /Users/designermonkey/Projects/Slim/Slim/Slim/Slim.php on line 52
PHP Stack trace:
PHP   1. {main}() /usr/local/Cellar/phpunit/3.7.22/libexec/phpunit-3.7.22.phar:0
PHP   2. PHPUnit_TextUI_Command::main() /usr/local/Cellar/phpunit/3.7.22/libexec/phpunit-3.7.22.phar:531
PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/local/Cellar/phpunit/3.7.22/libexec/phpunit-3.7.22.phar/PHPUnit/TextUI/Command.php:129
PHP   4. PHPUnit_TextUI_Command->handleArguments() phar:///usr/local/Cellar/phpunit/3.7.22/libexec/phpunit-3.7.22.phar/PHPUnit/TextUI/Command.php:138
PHP   5. PHPUnit_TextUI_Command->handleBootstrap() phar:///usr/local/Cellar/phpunit/3.7.22/libexec/phpunit-3.7.22.phar/PHPUnit/TextUI/Command.php:606
PHP   6. PHPUnit_Util_Fileloader::checkAndLoad() phar:///usr/local/Cellar/phpunit/3.7.22/libexec/phpunit-3.7.22.phar/PHPUnit/TextUI/Command.php:778
PHP   7. PHPUnit_Util_Fileloader::load() phar:///usr/local/Cellar/phpunit/3.7.22/libexec/phpunit-3.7.22.phar/PHPUnit/Util/Fileloader.php:76
PHP   8. include_once() phar:///usr/local/Cellar/phpunit/3.7.22/libexec/phpunit-3.7.22.phar/PHPUnit/Util/Fileloader.php:92
PHP   9. require_once() /Users/designermonkey/Projects/Slim/Slim/tests/bootstrap.php:4
```

If you can find the problem there, let me know and I'll ensure this is fully tested before it's pulled.
