### PR TITLE
Add default return value for request data

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -209,9 +209,10 @@ class Request
      * the value of the array key if requested; if the array key does not exist, NULL is returned.
      *
      * @param  string           $key
+     * @param  mixed            $default Default return value when key does not exist
      * @return array|mixed|null
      */
-    public function get($key = null)
+    public function get($key = null, $default = null)
     {
         if (!isset($this->env['slim.request.query_hash'])) {
             $output = array();
@@ -226,7 +227,7 @@ class Request
             if (isset($this->env['slim.request.query_hash'][$key])) {
                 return $this->env['slim.request.query_hash'][$key];
             } else {
-                return null;
+                return $default;
             }
         } else {
             return $this->env['slim.request.query_hash'];
@@ -240,10 +241,11 @@ class Request
      * the value of a hash key if requested; if the array key does not exist, NULL is returned.
      *
      * @param  string           $key
+     * @param  mixed            $default Default return value when key does not exist
      * @return array|mixed|null
      * @throws \RuntimeException If environment input is not available
      */
-    public function post($key = null)
+    public function post($key = null, $default = null)
     {
         if (!isset($this->env['slim.input'])) {
             throw new \RuntimeException('Missing slim.input in environment variables');
@@ -266,7 +268,7 @@ class Request
             if (isset($this->env['slim.request.form_hash'][$key])) {
                 return $this->env['slim.request.form_hash'][$key];
             } else {
-                return null;
+                return $default;
             }
         } else {
             return $this->env['slim.request.form_hash'];
@@ -276,31 +278,34 @@ class Request
     /**
      * Fetch PUT data (alias for \Slim\Http\Request::post)
      * @param  string           $key
+     * @param  mixed            $default Default return value when key does not exist
      * @return array|mixed|null
      */
-    public function put($key = null)
+    public function put($key = null, $default = null)
     {
-        return $this->post($key);
+        return $this->post($key, $default);
     }
 
     /**
      * Fetch PATCH data (alias for \Slim\Http\Request::post)
      * @param  string           $key
+     * @param  mixed            $default Default return value when key does not exist
      * @return array|mixed|null
      */
-    public function patch($key = null)
+    public function patch($key = null, $default = null)
     {
-        return $this->post($key);
+        return $this->post($key, $default);
     }
 
     /**
      * Fetch DELETE data (alias for \Slim\Http\Request::post)
      * @param  string           $key
+     * @param  mixed            $default Default return value when key does not exist
      * @return array|mixed|null
      */
-    public function delete($key = null)
+    public function delete($key = null, $default = null)
     {
-        return $this->post($key);
+        return $this->post($key, $default);
     }
 
     /**

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -221,6 +221,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(3, count($req->get()));
         $this->assertEquals('1', $req->get('one'));
         $this->assertNull($req->get('foo'));
+        $this->assertFalse($req->get('foo', false));
     }
 
     /**
@@ -236,6 +237,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(3, count($req->get()));
         $this->assertEquals('1', $req->get('one'));
         $this->assertNull($req->get('foo'));
+        $this->assertFalse($req->get('foo', false));
     }
 
     /**
@@ -253,6 +255,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($req->post()));
         $this->assertEquals('bar', $req->post('foo'));
         $this->assertNull($req->post('xyz'));
+        $this->assertFalse($req->post('xyz', false));
     }
 
     /**
@@ -271,6 +274,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($req->post()));
         $this->assertEquals('bar', $req->post('foo'));
         $this->assertNull($req->post('xyz'));
+        $this->assertFalse($req->post('xyz', false));
     }
 
     /**
@@ -319,6 +323,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $req->put('foo'));
         $this->assertEquals('bar', $req->params('foo'));
         $this->assertNull($req->put('xyz'));
+        $this->assertFalse($req->put('xyz', false));
     }
 
     /**
@@ -337,6 +342,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $req->patch('foo'));
         $this->assertEquals('bar', $req->params('foo'));
         $this->assertNull($req->patch('xyz'));
+        $this->assertFalse($req->patch('xyz', false));
     }
 
     /**
@@ -355,6 +361,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $req->delete('foo'));
         $this->assertEquals('bar', $req->params('foo'));
         $this->assertNull($req->delete('xyz'));
+        $this->assertFalse($req->delete('xyz', false));
     }
 
     /**


### PR DESCRIPTION
Allow overloading of the default return value of NULL when
requesting request data.

Example:
  http://host/action?foo=bar&abc=123

  $app->request->get('foo')        -- [bar]
  $app->request->get('bar')        -- [NULL]
  $app->request->get('bar', false) -- [FALSE]
