### PR TITLE
Path info is being calculated wrong when route and installation directory have the same name

### DIFF
--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -153,6 +153,42 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test parses script name and path info when route and installation subdirectory starts with the same name
+     *
+     * Pre-conditions:
+     * URL Rewrite enabled;
+     * App installed in subdirectory;
+     * Route and installation subdirectory starts with the same name
+     */
+    public function testParsesPathsWithCommonPrefixForSubdirectoryAndRouteNameWithUrlRewriteInSubdirectory()
+    {
+        $_SERVER['SCRIPT_NAME'] = '/foo/index.php';
+        $_SERVER['REQUEST_URI'] = '/foo/foobar';
+        unset($_SERVER['PATH_INFO']);
+        $env = \Slim\Environment::getInstance(true);
+        $this->assertEquals('/foobar', $env['PATH_INFO']);
+        $this->assertEquals('/foo', $env['SCRIPT_NAME']);
+    }
+
+    /**
+     * Test parses script name and path info when route and installation subdirectory have the same name
+     *
+     * Pre-conditions:
+     * URL Rewrite enabled;
+     * App installed in subdirectory;
+     * Route and installation subdirectory have with the same name
+     */
+    public function testParsesPathsWithCommonSubdirectoryAndRouteNameWithUrlRewriteInSubdirectory()
+    {
+        $_SERVER['SCRIPT_NAME'] = '/foo/index.php';
+        $_SERVER['REQUEST_URI'] = '/foo/foo';
+        unset($_SERVER['PATH_INFO']);
+        $env = \Slim\Environment::getInstance(true);
+        $this->assertEquals('/foo', $env['PATH_INFO']);
+        $this->assertEquals('/foo', $env['SCRIPT_NAME']);
+    }
+
+    /**
      * Test parses script name and path info
      *
      * Pre-conditions:


### PR DESCRIPTION
When Slim is installed on a subdirectory and a route with the same subdirectory name is called, PATH_INFO is calculated wrong. This bug seems to be introduced on 2.3.3 with commit a35767746009ff818e6375b72f23a2cf7de5f1a4 (Add HHVM compatibility)

These are the tests to trigger the bug.

```
There were 2 failures:

1) EnvironmentTest::testParsesPathsWithCommonPrefixForSubdirectoryAndRouteNameWithUrlRewriteInSubdirectory
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'/foobar'
+'/bar'

2) EnvironmentTest::testParsesPathsWithCommonSubdirectoryAndRouteNameWithUrlRewriteInSubdirectory
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'/foo'
+'/'
```
