### PR TITLE
Refer to $app as $this inside a router

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -426,7 +426,7 @@ class Slim
     {
         $pattern = array_shift($args);
         $callable = array_pop($args);
-        $callable = $callable->bindTo($this);
+        if(PHP_MINOR_VERSION >= 4) $callable = $callable->bindTo($this);
         $route = new \Slim\Route($pattern, $callable);
         $this->router->map($route);
         if (count($args) > 0) {
@@ -535,7 +535,7 @@ class Slim
         $args = func_get_args();
         $pattern = array_shift($args);
         $callable = array_pop($args);
-        $callable = $callable->bindTo($this);
+        if(PHP_MINOR_VERSION >= 4) $callable = $callable->bindTo($this);
         $this->router->pushGroup($pattern, $args);
         if (is_callable($callable)) {
             call_user_func($callable);

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -426,7 +426,9 @@ class Slim
     {
         $pattern = array_shift($args);
         $callable = array_pop($args);
-        if(PHP_MINOR_VERSION >= 4) $callable = $callable->bindTo($this);
+        if (PHP_MINOR_VERSION >= 4) {
+            $callable = $callable->bindTo($this);
+        }
         $route = new \Slim\Route($pattern, $callable);
         $this->router->map($route);
         if (count($args) > 0) {
@@ -535,7 +537,9 @@ class Slim
         $args = func_get_args();
         $pattern = array_shift($args);
         $callable = array_pop($args);
-        if(PHP_MINOR_VERSION >= 4) $callable = $callable->bindTo($this);
+        if (PHP_MINOR_VERSION >= 4) {
+            $callable = $callable->bindTo($this);
+        }
         $this->router->pushGroup($pattern, $args);
         if (is_callable($callable)) {
             call_user_func($callable);

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -426,6 +426,7 @@ class Slim
     {
         $pattern = array_shift($args);
         $callable = array_pop($args);
+        $callable = $callable->bindTo($this);
         $route = new \Slim\Route($pattern, $callable);
         $this->router->map($route);
         if (count($args) > 0) {
@@ -534,6 +535,7 @@ class Slim
         $args = func_get_args();
         $pattern = array_shift($args);
         $callable = array_pop($args);
+        $callable = $callable->bindTo($this);
         $this->router->pushGroup($pattern, $args);
         if (is_callable($callable)) {
             call_user_func($callable);


### PR DESCRIPTION
### Instead of repeating the keyword use everywhere like that....

``` php
$app = new \Slim\Slim();

$app->get('/',function ()  use ($app) {

});

$app->group('/api',function ()  use ($app) {

    $app->get('/',function ()  use ($app) {

    });

});
```
### We can just use $this:

``` php
$app = new \Slim\Slim();

$app->get('/',function () {

});

$app->group('/api',function ()  {

    $this->get('/',function ()  {
          $this->halt(404);
    });

});
```
