### PR TITLE
refer to $app as $this inside a router

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -394,6 +394,9 @@ class App extends \Slim\Pimple
     {
         $pattern = array_shift($args);
         $callable = array_pop($args);
+        if (PHP_MINOR_VERSION >= 4 && is_callable($callable)) {
+            $callable = $callable->bindTo($this);
+        }
         $route = new \Slim\Route($pattern, $callable);
         $this->router->map($route);
         if (count($args) > 0) {
@@ -505,6 +508,9 @@ class App extends \Slim\Pimple
         $callable = array_pop($args);
         $this->router->pushGroup($pattern, $args);
         if (is_callable($callable)) {
+            if (PHP_MINOR_VERSION >= 4) {
+                $callable = $callable->bindTo($this);
+            }
             call_user_func($callable);
         }
         $this->router->popGroup();

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -315,7 +315,6 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s->call();
         $this->assertEquals('foobarxyz', $s->response->getBody());
         $this->assertEquals('/bar', $route->getPattern());
-        $this->assertSame($callable, $route->getCallable());
     }
 
     /**
@@ -337,7 +336,6 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s->call();
         $this->assertEquals('foobarxyz', $s->response->getBody());
         $this->assertEquals('/bar', $route->getPattern());
-        $this->assertSame($callable, $route->getCallable());
     }
 
     /**
@@ -359,7 +357,6 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s->call();
         $this->assertEquals('foobarxyz', $s->response->getBody());
         $this->assertEquals('/bar', $route->getPattern());
-        $this->assertSame($callable, $route->getCallable());
     }
 
     /**
@@ -381,7 +378,6 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s->call();
         $this->assertEquals('foobarxyz', $s->response->getBody());
         $this->assertEquals('/bar', $route->getPattern());
-        $this->assertSame($callable, $route->getCallable());
     }
 
     /**
@@ -403,7 +399,6 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s->call();
         $this->assertEquals('foobarxyz', $s->response->getBody());
         $this->assertEquals('/bar', $route->getPattern());
-        $this->assertSame($callable, $route->getCallable());
     }
 
     /**
@@ -425,7 +420,6 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s->call();
         $this->assertEquals('foobarxyz', $s->response->getBody());
         $this->assertEquals('/bar', $route->getPattern());
-        $this->assertSame($callable, $route->getCallable());
     }
 
     /**
@@ -471,7 +465,6 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s->call();
             $this->assertEquals('foobarxyz', $s->response->getBody());
             $this->assertEquals('/bar', $route->getPattern());
-            $this->assertSame($callable, $route->getCallable());
         }
     }
 


### PR DESCRIPTION
## as a sequence to this [pull request](https://github.com/codeguy/Slim/pull/660)
### Instead of repeating the keyword use everywhere like that....

``` php
$app = new \Slim\Slim();

$app->get('/',function ()  use ($app) {

});

$app->group('/api',function ()  use ($app) {

    $app->get('/',function ()  use ($app) {

    });

});
```
### We can just use $this:

``` php
$app = new \Slim\Slim();

$app->get('/',function () {

});

$app->group('/api',function ()  {

    $this->get('/',function ()  {
          $this->halt(404);
    });

});
```
