### PR TITLE
Update Autoloader.php - to work properly with include_path

### DIFF
--- a/Slim/Autoloader.php
+++ b/Slim/Autoloader.php
@@ -54,7 +54,7 @@ class Autoloader
         $fileName .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
 
         // Require file only if it exists. Else let other registered autoloaders worry about it.
-        if (file_exists($fileName)) {
+        if (stream_resolve_include_path($fileName)) {
             require $fileName;
         }
     }


### PR DESCRIPTION
If you want to include Slim via include_path, better use "stream_resolve_include_path" here. Be aware that the function might cache the results (see http://us1.php.net/manual/en/function.stream-resolve-include-path.php#111790).
