### PR TITLE
Add (string) case in encodeSecureCookie call to hash_hmac

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -224,7 +224,7 @@ class Util
      */
     public static function encodeSecureCookie($value, $expires, $secret, $algorithm, $mode)
     {
-        $key = hash_hmac('sha1', $expires, $secret);
+        $key = hash_hmac('sha1', (string) $expires, $secret);
         $iv = self::getIv($expires, $secret);
         $secureString = base64_encode(
             self::encrypt(


### PR DESCRIPTION
Per http://php.net/manual/en/function.hash-hmac.php, the second argument to hash_hmac is supposed to be a string. HHVM (http://www.hhvm.com) is more strict about checking the arguments.

(note: this functionality is no longer present on develop)
