### PR TITLE
Add property typehints for proper IDE support.

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -40,9 +40,14 @@ if (!extension_loaded('mcrypt')) {
 
 /**
  * Slim
- * @package Slim
- * @author  Josh Lockhart
- * @since   1.0.0
+ * @package  Slim
+ * @author   Josh Lockhart
+ * @since    1.0.0
+ *
+ * @property $environment \Slim\Environment
+ * @property $response    \Slim\Http\Response
+ * @property $request     \Slim\Http\Request
+ * @property $router      \Slim\Router
  */
 class Slim
 {

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -44,10 +44,10 @@ if (!extension_loaded('mcrypt')) {
  * @author   Josh Lockhart
  * @since    1.0.0
  *
- * @property $environment \Slim\Environment
- * @property $response    \Slim\Http\Response
- * @property $request     \Slim\Http\Request
- * @property $router      \Slim\Router
+ * @property \Slim\Environment   $environment
+ * @property \Slim\Http\Response $response
+ * @property \Slim\Http\Request  $request
+ * @property \Slim\Router        $router
  */
 class Slim
 {


### PR DESCRIPTION
With the introduction of the Resource Locator in 2.3.0, we are able to directly access the `response`, `request`, `environment` and `router` (and others?) properties on a `Slim\Slim` app object. This is really great for chaining, as it removes the unnecessary `()`.

The downside of this, however, is that in most IDE's you lose the code completion that come with specifying the return type. You can get around this by using the old style syntax `->request()`, `->response()`, but then we're right back where we're started.

This PR proposes to add support specifically for IDE's to restore code completion abilities.

`@property` is supported by Netbeans, PHPStorm, PDT, ZendStudio, Eclipse and possibly others. (I think anything based on IntelliJ)
