### PR TITLE
Don't rely on system setting for error_reporting level

### DIFF
--- a/tests/Middleware/SessionCookieTest.php
+++ b/tests/Middleware/SessionCookieTest.php
@@ -135,6 +135,7 @@ class SessionCookieTest extends PHPUnit_Framework_TestCase
 
         $logWriter->expects($this->once())
             ->method('write');
+        $oldLevel = error_reporting(E_ALL);
 
         $app = new \Slim\Slim(array(
             'log.writer' => $logWriter
@@ -149,6 +150,8 @@ class SessionCookieTest extends PHPUnit_Framework_TestCase
         $mw->setNextMiddleware($app);
         $mw->call();
         $this->assertEquals(array(), $_SESSION);
+
+        error_reporting($oldLevel);
     }
 
     /**


### PR DESCRIPTION
This test shouldn't fail if the system's php.ini setting differs on the error level (This was failing in HHVM's test environment)
