### PR TITLE
Fixed Route::setCallable not matching some valid controller names

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -155,7 +155,7 @@ class Route
     public function setCallable($callable)
     {
         $matches = array();
-        if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
+        if (is_string($callable) && preg_match('!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!', $callable, $matches)) {
             $callable = array(new $matches[1], $matches[2]);
         }
 


### PR DESCRIPTION
Regexp used for matching valid controller names doesn't match "_" and some other valid characters in the method name. Replaced with a regexp specified in the PHP manual (http://www.php.net/manual/en/functions.user-defined.php).
