### PR TITLE
Routes can be case-insensitive based on a config setting.

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -91,15 +91,22 @@ class Route
     protected $middleware = array();
 
     /**
+     * @var bool Whether or not this route should be matched in a case-sensitive manner
+     */
+    protected $caseSensitive;
+
+    /**
      * Constructor
      * @param string $pattern The URL pattern (e.g. "/books/:id")
      * @param mixed $callable Anything that returns TRUE for is_callable()
+     * @param bool $caseSensitive Whether or not this route should be matched in a case-sensitive manner
      */
-    public function __construct($pattern, $callable)
+    public function __construct($pattern, $callable, $caseSensitive = true)
     {
         $this->setPattern($pattern);
         $this->setCallable($callable);
         $this->setConditions(self::getDefaultConditions());
+        $this->caseSensitive = $caseSensitive;
     }
 
     /**
@@ -362,8 +369,14 @@ class Route
             $patternAsRegex .= '?';
         }
 
+        $regex = '#^' . $patternAsRegex . '$#';
+
+        if ($this->caseSensitive === false) {
+            $regex .= 'i';
+        }
+
         //Cache URL params' names and values if this route matches the current HTTP request
-        if (!preg_match('#^' . $patternAsRegex . '$#', $resourceUri, $paramValues)) {
+        if (!preg_match($regex, $resourceUri, $paramValues)) {
             return false;
         }
         foreach ($this->paramNames as $name) {

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -308,7 +308,9 @@ class Slim
             'cookies.cipher' => MCRYPT_RIJNDAEL_256,
             'cookies.cipher_mode' => MCRYPT_MODE_CBC,
             // HTTP
-            'http.version' => '1.1'
+            'http.version' => '1.1',
+            // Routing
+            'routes.case_sensitive' => true
         );
     }
 
@@ -434,7 +436,7 @@ class Slim
     {
         $pattern = array_shift($args);
         $callable = array_pop($args);
-        $route = new \Slim\Route($pattern, $callable);
+        $route = new \Slim\Route($pattern, $callable, $this->settings['routes.case_sensitive']);
         $this->router->map($route);
         if (count($args) > 0) {
             $route->setMiddleware($args);

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -272,6 +272,20 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array('year' => '2010', 'month' => '05', 'day' => '13'), $route3->getParams());
     }
 
+    public function testMatchesIsCaseSensitiveByDefault()
+    {
+        $route = new \Slim\Route('/case/sensitive', function () {});
+        $this->assertTrue($route->matches('/case/sensitive'));
+        $this->assertFalse($route->matches('/CaSe/SensItiVe'));
+    }
+
+    public function testMatchesCanBeCaseInsensitive()
+    {
+        $route = new \Slim\Route('/Case/Insensitive', function () {}, false);
+        $this->assertTrue($route->matches('/Case/Insensitive'));
+        $this->assertTrue($route->matches('/CaSe/iNSensItiVe'));
+    }
+
     public function testGetConditions()
     {
         $route = new \Slim\Route('/foo', function () {});

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -495,6 +495,22 @@ class SlimTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if route will match in case-insensitive manner if configured to do so
+     */
+    public function testRouteMatchesInCaseInsensitiveMannerIfConfigured()
+    {
+        \Slim\Environment::mock(array(
+            'PATH_INFO' => '/BaR', // Does not match route case
+        ));
+        $s = new \Slim\Slim(array('routes.case_sensitive' => false));
+        $route = $s->get('/bar', function () { echo "xyz"; });
+        $s->call();
+        $this->assertEquals(200, $s->response()->status());
+        $this->assertEquals('xyz', $s->response()->body());
+        $this->assertEquals('/bar', $route->getPattern());
+    }
+
+    /**
      * Test if route contains URL encoded characters
      */
     public function testRouteWithUrlEncodedCharacters()


### PR DESCRIPTION
- New config setting `routes.case_sensitive` 
- `routes.case_sensitive` defaults to `true`
- Setting `routes.case_sensitive` to `true` by default will not break BC for users who rely on case-sensitive routes
- Setting `routes.case_sensitive` = `false` allows routes to be case-insensitive
