### PR TITLE
FIX: hook slim.after is called before response was sent

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1291,6 +1291,8 @@ class Slim
             echo $body;
         }
 
+        $this->applyHook('slim.after');
+
         restore_error_handler();
     }
 
@@ -1329,7 +1331,6 @@ class Slim
             $this->stop();
         } catch (\Slim\Exception\Stop $e) {
             $this->response()->write(ob_get_clean());
-            $this->applyHook('slim.after');
         } catch (\Exception $e) {
             if ($this->config('debug')) {
                 throw $e;


### PR DESCRIPTION
Hi there,

I noticed, that the slim documentation says:
"slim.after: This hook is invoked after output buffering is turned off and after the Response is sent to the client. This hook is invoked once during the Slim application lifecycle."

The response is not sent to the client until line 1291 (inside function run()) in Slim.php, but slim.after is already invoked in function call() (Slim.php line 1332).

I therefore suggest moving the invocation of slim.after to line 1293 in Slim.php (function run() after echo $body) to comply with the documented behavior.

kind regards,

qyanu
