### PR TITLE
Configuration Handler

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -89,7 +89,6 @@ class App extends \Pimple
         // Settings
         $this['settings'] = $this->share(function ($c) use ($userSettings) {
             $config = new \Slim\Configuration(new \Slim\ConfigurationHandler);
-            $config->setDefaults();
             $config->setArray($userSettings);
 
             return $config;

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -88,7 +88,11 @@ class App extends \Pimple
     {
         // Settings
         $this['settings'] = $this->share(function ($c) use ($userSettings) {
-            return new \Slim\Configuration($userSettings);
+            $config = new \Slim\Configuration(new \Slim\ConfigurationHandler);
+            $config->setDefaults();
+            $config->setArray($userSettings);
+
+            return $config;
         });
 
         // Environment

--- a/Slim/Configuration.php
+++ b/Slim/Configuration.php
@@ -132,21 +132,40 @@ class Configuration implements \ArrayAccess, \IteratorAggregate
         return call_user_func_array(array($this->handler, $method), $params);
     }
 
+    /**
+     * Get a value
+     * @param  string $key
+     * @return mixed
+     */
     public function offsetGet($key)
     {
         return $this->handler[$key];
     }
 
+    /**
+     * Set a value
+     * @param  string $key
+     * @param  mixed $value
+     */
     public function offsetSet($key, $value)
     {
         $this->handler[$key] = $value;
     }
 
+    /**
+     * Check a value exists
+     * @param  string $key
+     * @return boolean
+     */
     public function offsetExists($key)
     {
         return isset($this->handler[$key]);
     }
 
+    /**
+     * Remove a value
+     * @param  string $key
+     */
     public function offsetUnset($key)
     {
         unset($this->handler[$key]);

--- a/Slim/Configuration.php
+++ b/Slim/Configuration.php
@@ -34,7 +34,7 @@ namespace Slim;
 
 /**
  * Configuration
- * Provides app configuration values stored as nested arrays, which can be accessed and stored using dot separated keys.
+ * Uses a ConfigurationHandler class to parse configuration data, accessed as an array.
  *
  * @package    Slim
  * @author     John Porter
@@ -43,22 +43,15 @@ namespace Slim;
 class Configuration implements \ArrayAccess, \IteratorAggregate
 {
     /**
-     * Cache of previously parsed keys
-     * @var array
+     * Handler for Configuration values
+     * @var mixed
      */
-    protected $keys = array();
-
+    protected $handler;
     /**
      * Storage array of values
      * @var array
      */
     protected $values = array();
-
-    /**
-     * Expected nested key separator
-     * @var string
-     */
-    protected $separator = '.';
 
     /**
      * Default values
@@ -90,12 +83,33 @@ class Configuration implements \ArrayAccess, \IteratorAggregate
 
     /**
      * Constructor
-     * Merge provided values with the defaults to ensure all required values are set
-     * @param array $values
+     * @param mixed $handler
      */
-    public function __construct(array $values = array())
+    public function __construct(\Slim\ConfigurationHandler $handler)
     {
-        $this->values = $this->mergeArrays($this->getDefaults(), $values);
+        if (!$handler instanceof \ArrayAccess) {
+            throw new \InvalidArgumentException("ConfigurationHandler must implement \\ArrayAccess.");
+        }
+
+        $this->handler = $handler;
+
+        $this->setDefaults();
+    }
+
+    /**
+     * Set Slim's defaults using the handler
+     */
+    public function setArray(array $values)
+    {
+        $this->handler->setArray($values);
+    }
+
+    /**
+     * Set Slim's defaults using the handler
+     */
+    public function setDefaults()
+    {
+        $this->handler->setArray($this->defaults);
     }
 
     /**
@@ -108,184 +122,34 @@ class Configuration implements \ArrayAccess, \IteratorAggregate
     }
 
     /**
-     * Get all values as nested array
-     * @return array
-     */
-    public function getAllNested()
-    {
-        return $this->values;
-    }
-
-    /**
-     * Get all values as flattened key array
-     * @return array
-     */
-    public function getAllFlat()
-    {
-        return $this->flattenArray($this->values);
-    }
-
-    /**
-     * Get all flattened array keys
-     * @return array
-     */
-    public function getKeys()
-    {
-        $flattened = $this->flattenArray($this->values);
-        return array_keys($flattened);
-    }
-
-    /**
-     * Get a value from a nested array based on a separated key
-     * @param  string $key
+     * Call a method from the handler
+     * @param  string $method
+     * @param  array $params
      * @return mixed
      */
+    public function callHandlerMethod($method, array $params = array())
+    {
+        return call_user_func_array(array($this->handler, $method), $params);
+    }
+
     public function offsetGet($key)
     {
-        return $this->getValue($key, $this->values);
+        return $this->handler[$key];
     }
 
-    /**
-     * Set nested array values based on a separated key
-     * @param  string  $key
-     * @param  mixed   $value
-     * @return array
-     */
     public function offsetSet($key, $value)
     {
-        $this->setValue($key, $value, $this->values);
+        $this->handler[$key] = $value;
     }
 
-    /**
-     * Check an array has a value based on a separated key
-     * @param  string  $key
-     * @return boolean
-     */
     public function offsetExists($key)
     {
-        return (bool)$this->getValue($key, $this->values);
+        return isset($this->handler[$key]);
     }
 
-    /**
-     * Remove nested array value based on a separated key
-     * @param  string  $key
-     */
     public function offsetUnset($key)
     {
-        $keys = $this->parseKey($key);
-        $array = &$this->values;
-
-        while (count($keys) > 1) {
-            $key = array_shift($keys);
-
-            if (!isset($array[$key]) || !is_array($array[$key])) {
-                return;
-            }
-
-            $array =& $array[$key];
-        }
-
-        unset($array[array_shift($keys)]);
-    }
-
-    /**
-     * Parse a separated key and cache the result
-     * @param  string $key
-     * @return array
-     */
-    protected function parseKey($key)
-    {
-        if (!isset($this->keys[$key])) {
-            $this->keys[$key] = explode($this->separator, $key);
-        }
-
-        return $this->keys[$key];
-    }
-
-    /**
-     * Get a value from a nested array based on a separated key
-     * @param  string $key
-     * @param  array  $array
-     * @return mixed
-     */
-    protected function getValue($key, array $array = array())
-    {
-        $keys = $this->parseKey($key);
-
-        while (count($keys) > 0 and !is_null($array)) {
-            $key = array_shift($keys);
-            $array = isset($array[$key]) ? $array[$key] : null;
-        }
-
-        return $array;
-    }
-
-    /**
-     * Set nested array values based on a separated key
-     *
-     * @param  string  $key
-     * @param  mixed   $value
-     * @param  array   $array
-     * @return array
-     */
-    protected function setValue($key, $value, array &$array = array())
-    {
-        $keys = $this->parseKey($key, $this->separator);
-        $pointer = &$array;
-
-        while (count($keys) > 0) {
-            $key = array_shift($keys);
-            $pointer[$key] = (isset($pointer[$key]) ? $pointer[$key] : array());
-            $pointer = &$pointer[$key];
-        }
-
-        $pointer = $value;
-        return $array;
-    }
-
-    /**
-     * Merge arrays with nested keys
-     * Usage: $this->mergeArrays(array $array [, array $...])
-     * @return array
-     */
-    protected function mergeArrays()
-    {
-        $arrays = func_get_args();
-        $merged = array();
-
-        foreach ($arrays as $array) {
-            foreach ($array as $key => $value) {
-                $merged = $this->setValue($key, $value, $merged);
-            }
-        }
-
-        return $merged;
-    }
-
-    /**
-     * Flatten a nested array to a separated key
-     *
-     * @param  array  $array
-     * @param  string $separator
-     * @return array
-     */
-    protected function flattenArray(array $array, $separator = null)
-    {
-        $flattened = array();
-
-        if (is_null($separator)) {
-            $separator = $this->separator;
-        }
-
-        foreach ($array as $key => $value) {
-            if (is_array($value)) {
-                $flattened = array_merge($flattened, $this->flattenArray($value, $key.$separator));
-            } else {
-                $flattened[trim($separator.$key, $this->separator)] = $value;
-            }
-        }
-
-        return $flattened;
+        unset($this->handler[$key]);
     }
 
     /**

--- a/Slim/ConfigurationHandler.php
+++ b/Slim/ConfigurationHandler.php
@@ -1,0 +1,264 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     2.3.0
+ * @package     Slim
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+namespace Slim;
+
+/**
+ * ConfigurationHandler
+ * A default Configuration class which provides app configuration values stored as nested arrays, which can be accessed and stored using dot separated keys.
+ *
+ * @package    Slim
+ * @author     John Porter
+ * @since      3.0.0
+ */
+class ConfigurationHandler implements \ArrayAccess, \IteratorAggregate
+{
+    /**
+     * Cache of previously parsed keys
+     * @var array
+     */
+    protected $keys = array();
+
+    /**
+     * Storage array of values
+     * @var array
+     */
+    protected $values = array();
+
+    /**
+     * Expected nested key separator
+     * @var string
+     */
+    protected $separator = '.';
+
+    /**
+     * Set an array of configuration options
+     * Merge provided values with the defaults to ensure all required values are set
+     * @param array $values
+     * @required
+     */
+    public function setArray(array $values = array())
+    {
+        $this->values = $this->mergeArrays($this->values, $values);
+    }
+
+    /**
+     * Get all values as nested array
+     * @return array
+     */
+    public function getAllNested()
+    {
+        return $this->values;
+    }
+
+    /**
+     * Get all values as flattened key array
+     * @return array
+     */
+    public function getAllFlat()
+    {
+        return $this->flattenArray($this->values);
+    }
+
+    /**
+     * Get all flattened array keys
+     * @return array
+     */
+    public function getKeys()
+    {
+        $flattened = $this->flattenArray($this->values);
+        return array_keys($flattened);
+    }
+
+    /**
+     * Get a value from a nested array based on a separated key
+     * @param  string $key
+     * @return mixed
+     */
+    public function offsetGet($key)
+    {
+        return $this->getValue($key, $this->values);
+    }
+
+    /**
+     * Set nested array values based on a separated key
+     * @param  string  $key
+     * @param  mixed   $value
+     * @return array
+     */
+    public function offsetSet($key, $value)
+    {
+        $this->setValue($key, $value, $this->values);
+    }
+
+    /**
+     * Check an array has a value based on a separated key
+     * @param  string  $key
+     * @return boolean
+     */
+    public function offsetExists($key)
+    {
+        return (bool)$this->getValue($key, $this->values);
+    }
+
+    /**
+     * Remove nested array value based on a separated key
+     * @param  string  $key
+     */
+    public function offsetUnset($key)
+    {
+        $keys = $this->parseKey($key);
+        $array = &$this->values;
+
+        while (count($keys) > 1) {
+            $key = array_shift($keys);
+
+            if (!isset($array[$key]) || !is_array($array[$key])) {
+                return;
+            }
+
+            $array =& $array[$key];
+        }
+
+        unset($array[array_shift($keys)]);
+    }
+
+    /**
+     * Parse a separated key and cache the result
+     * @param  string $key
+     * @return array
+     */
+    protected function parseKey($key)
+    {
+        if (!isset($this->keys[$key])) {
+            $this->keys[$key] = explode($this->separator, $key);
+        }
+
+        return $this->keys[$key];
+    }
+
+    /**
+     * Get a value from a nested array based on a separated key
+     * @param  string $key
+     * @param  array  $array
+     * @return mixed
+     */
+    protected function getValue($key, array $array = array())
+    {
+        $keys = $this->parseKey($key);
+
+        while (count($keys) > 0 and !is_null($array)) {
+            $key = array_shift($keys);
+            $array = isset($array[$key]) ? $array[$key] : null;
+        }
+
+        return $array;
+    }
+
+    /**
+     * Set nested array values based on a separated key
+     *
+     * @param  string  $key
+     * @param  mixed   $value
+     * @param  array   $array
+     * @return array
+     */
+    protected function setValue($key, $value, array &$array = array())
+    {
+        $keys = $this->parseKey($key, $this->separator);
+        $pointer = &$array;
+
+        while (count($keys) > 0) {
+            $key = array_shift($keys);
+            $pointer[$key] = (isset($pointer[$key]) ? $pointer[$key] : array());
+            $pointer = &$pointer[$key];
+        }
+
+        $pointer = $value;
+        return $array;
+    }
+
+    /**
+     * Merge arrays with nested keys into the values store
+     * Usage: $this->mergeArrays(array $array [, array $...])
+     * @return array
+     */
+    protected function mergeArrays()
+    {
+        $arrays = func_get_args();
+        $merged = array();
+
+        foreach ($arrays as $array) {
+            foreach ($array as $key => $value) {
+                $merged = $this->setValue($key, $value, $merged);
+            }
+        }
+
+        return $merged;
+    }
+
+    /**
+     * Flatten a nested array to a separated key
+     *
+     * @param  array  $array
+     * @param  string $separator
+     * @return array
+     */
+    protected function flattenArray(array $array, $separator = null)
+    {
+        $flattened = array();
+
+        if (is_null($separator)) {
+            $separator = $this->separator;
+        }
+
+        foreach ($array as $key => $value) {
+            if (is_array($value)) {
+                $flattened = array_merge($flattened, $this->flattenArray($value, $key.$separator));
+            } else {
+                $flattened[trim($separator.$key, $this->separator)] = $value;
+            }
+        }
+
+        return $flattened;
+    }
+
+    /**
+     * Get an ArrayIterator for the stored items
+     *
+     * @return ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->items);
+    }
+}

--- a/tests/ConfigurationHandlerTest.php
+++ b/tests/ConfigurationHandlerTest.php
@@ -30,73 +30,45 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-use \Slim\Configuration;
 use \Slim\ConfigurationHandler;
-
-class HandlerTest extends ConfigurationHandler
-{}
 
 /**
  * Configuration Test
  */
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    public $defaults = array(
-        // Application
-        'mode' => 'development',
-        'view' => null,
-        // Cookies
-        'cookies.encrypt' => false,
-        'cookies.lifetime' => '20 minutes',
-        'cookies.path' => '/',
-        'cookies.domain' => null,
-        'cookies.secure' => false,
-        'cookies.httponly' => false,
-        // Encryption
-        'crypt.key' => 'A9s_lWeIn7cML8M]S6Xg4aR^GwovA&UN',
-        'crypt.cipher' => MCRYPT_RIJNDAEL_256,
-        'crypt.mode' => MCRYPT_MODE_CBC,
-        // Session
-        'session.options' => array(),
-        'session.handler' => null,
-        'session.flash_key' => 'slimflash',
-        'session.encrypt' => false,
-        // HTTP
-        'http.version' => '1.1'
-    );
-
-    public function testConstructorInjection()
+    public function testSetArray()
     {
-        $values = array("param" => "value");
-        $con = new Configuration(new HandlerTest);
-        $con->setArray($values);
+        $con = new ConfigurationHandler;
+        $con->setArray(array(
+            'foo' => 'bar'
+        ));
 
-        $this->assertSame($values['param'], $con['param']);
+        $this->assertEquals($con['foo'], 'bar');
     }
 
-    public function testDefaultValues()
+    public function testSetAndGet()
     {
-        $con = new Configuration();
+        $con = new ConfigurationHandler;
+        $con['foo'] = 'bar';
 
-        foreach ($this->defaults as $key => $value) {
-            $this->assertEquals($con[$key], $value);
-        }
+        $this->assertEquals($con['foo'], 'bar');
     }
 
     public function testKeys()
     {
-        $con = new Configuration();
-        $defaultKeys = array_keys($this->defaults);
-        $defaultKeys = ksort($defaultKeys);
-        $configKeys = $con->getKeys();
-        $configKeys = ksort($configKeys);
+        $con = new ConfigurationHandler;
+        $con->setArray(array(
+            'foo' => 'bar'
+        ));
+        $keys = $con->getKeys();
 
-        $this->assertEquals($defaultKeys, $configKeys);
+        $this->assertEquals($keys[0], 'foo');
     }
 
     public function  testWithNamespacedKey()
     {
-        $con = new Configuration();
+        $con = new ConfigurationHandler;
         $con['my.namespaced.keyname'] = 'My Value';
 
         $this->arrayHasKey($con, 'my');
@@ -107,7 +79,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testWithString()
     {
-        $con = new Configuration();
+        $con = new ConfigurationHandler;
         $con['keyname'] = 'My Value';
 
         $this->assertEquals('My Value', $con['keyname']);
@@ -115,11 +87,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testIsset()
     {
-        $con = new Configuration();
+        $con = new ConfigurationHandler;
         $con['param'] = 'value';
-        $con['service'] = function () {
-            return new Service();
-        };
 
         $this->assertTrue(isset($con['param']));
         $this->assertTrue(isset($con['service']));
@@ -128,11 +97,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
     public function testUnset()
     {
-        $con = new Configuration();
+        $con = new ConfigurationHandler;
         $con['param'] = 'value';
-        $con['service'] = function () {
-            return new Service();
-        };
 
         unset($con['param'], $con['service']);
         $this->assertFalse(isset($con['param']));

--- a/tests/ConfigurationHandlerTest.php
+++ b/tests/ConfigurationHandlerTest.php
@@ -91,7 +91,6 @@ class ConfigurationHandlerTest extends \PHPUnit_Framework_TestCase
         $con['param'] = 'value';
 
         $this->assertTrue(isset($con['param']));
-        $this->assertTrue(isset($con['service']));
         $this->assertFalse(isset($con['non_existent']));
     }
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -74,68 +74,33 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($values['param'], $con['param']);
     }
 
-    public function testDefaultValues()
+    public function testSetDefaultValues()
     {
-        $con = new Configuration();
+        $con = new Configuration(new HandlerTest);
 
         foreach ($this->defaults as $key => $value) {
             $this->assertEquals($con[$key], $value);
         }
     }
 
-    public function testKeys()
+    public function testGetDefaultValues()
     {
-        $con = new Configuration();
+        $con = new Configuration(new HandlerTest);
+        $defaults = $con->getDefaults();
+
+        foreach ($this->defaults as $key => $value) {
+            $this->assertEquals($defaults[$key], $value);
+        }
+    }
+
+    public function testCallHandlerMethod()
+    {
+        $con = new Configuration(new HandlerTest);
         $defaultKeys = array_keys($this->defaults);
         $defaultKeys = ksort($defaultKeys);
-        $configKeys = $con->getKeys();
+        $configKeys = $con->callHandlerMethod('getKeys');
         $configKeys = ksort($configKeys);
 
         $this->assertEquals($defaultKeys, $configKeys);
-    }
-
-    public function  testWithNamespacedKey()
-    {
-        $con = new Configuration();
-        $con['my.namespaced.keyname'] = 'My Value';
-
-        $this->arrayHasKey($con, 'my');
-        $this->arrayHasKey($con['my'], 'namespaced');
-        $this->arrayHasKey($con['my.namespaced'], 'keyname');
-        $this->assertEquals('My Value', $con['my.namespaced.keyname']);
-    }
-
-    public function testWithString()
-    {
-        $con = new Configuration();
-        $con['keyname'] = 'My Value';
-
-        $this->assertEquals('My Value', $con['keyname']);
-    }
-
-    public function testIsset()
-    {
-        $con = new Configuration();
-        $con['param'] = 'value';
-        $con['service'] = function () {
-            return new Service();
-        };
-
-        $this->assertTrue(isset($con['param']));
-        $this->assertTrue(isset($con['service']));
-        $this->assertFalse(isset($con['non_existent']));
-    }
-
-    public function testUnset()
-    {
-        $con = new Configuration();
-        $con['param'] = 'value';
-        $con['service'] = function () {
-            return new Service();
-        };
-
-        unset($con['param'], $con['service']);
-        $this->assertFalse(isset($con['param']));
-        $this->assertFalse(isset($con['service']));
     }
 }


### PR DESCRIPTION
This PR adds support for separate `ConfigurationHandler` classes to be used to manage the settings for Slim.

There is a default `ConfigurationHandler` which takes the previous work of nested keys and allows the handler to manage the keys and values.

Any `ConfigurationHandler`s will need to provide all settings as they currently are (which is `dot.nested.keys` as has always been with Slim), and also provide a `setArray()` method to allow values to be set from a PHP array. How the handler gets the values and does it's magic is completely up to the developer. Fancy using XML files to store configuration? Go ahead.

I have an interface prepared for each class here for when the interfaces branch is ready.
