### PR TITLE
Detect circular middleware stacks

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -1021,9 +1021,13 @@ class App extends \Pimple
      */
     public function add(\Slim\Middleware $newMiddleware)
     {
+        $middleware = $this['middleware'];
+        if(in_array($newMiddleware, $middleware)) {
+            $middleware_class = get_class($newMiddleware);
+            throw new \RuntimeException("Circular Middleware setup detected. Tried to queue the same Middleware instance ({$middleware_class}) twice.");
+        }
         $newMiddleware->setApplication($this);
         $newMiddleware->setNextMiddleware($this['middleware'][0]);
-        $middleware = $this['middleware'];
         array_unshift($middleware, $newMiddleware);
         $this['middleware'] = $middleware;
     }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1058,6 +1058,25 @@ class AppTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Hello', $this->app['response']->headers->get('X-Slim-Test'));
     }
 
+    /**
+     * Test exception when adding circular middleware queues
+     *
+     * This asserts that the same middleware can NOT be queued twice (usually by accident).
+     * 
+     * Circular middleware stack causes a troublesome to debug PHP Fatal error,
+     * mostly due to a quite opaque error message:
+     * 
+     * > Fatal error: Maximum function nesting level of '100' reached. aborting!
+     */
+    public function testFailureWhenAddingCircularMiddleware()
+    {
+        $this->setExpectedException('\RuntimeException');
+        $middleware = new CustomMiddleware();
+        $this->app->add($middleware);
+        $this->app->add($middleware);
+        $this->app->run();
+    }
+
     /************************************************
      * NOT FOUND HANDLING
      ************************************************/


### PR DESCRIPTION
This pull request aims to enhance Slim\App behavior when encountering circular middleware stacks. Instead of a PHP Fatal error, now an exception is thrown:

``` php
<?php
$middleware = new CustomMiddleware();
$app = new Slim\App;
$app->add($middleware);
$app->add($middleware);
$app->run(); // fatal error
```

Before:

> Fatal error: Maximum function nesting level of '100' reached. aborting! [...]

After:

> RuntimeException: Circular Middleware setup detected. Tried to queue the same Middleware instance (CustomMiddleware) twice.

The fatal error can be hard to debug mostly because of it's opaque error message. This usually happens by some accident in userland code and deserves a more comprehensible message IMMO.

Cheers!
