### PR TITLE
Non static Http classes, and other works

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -93,14 +93,14 @@ class App extends \Pimple
 
         // Environment
         $this['environment'] = $this->share(function ($c) {
-            return \Slim\Environment::createFromGlobals();
+            return \Slim\Environment($_SERVER);
         });
 
         // Request
         $this['request'] = $this->share(function ($c) {
             $environment = $c['environment'];
-            $headers = \Slim\Http\Headers::createFromEnvironment($environment);
-            $cookies = new \Slim\Collection(\Slim\Http\Cookies::extractFromHeaders($headers));
+            $headers = new \Slim\Http\Headers($environment);
+            $cookies = new \Slim\Http\Cookies($headers);
             if ($c['settings']['cookies.encrypt'] ===  true) {
                 $cookies->decrypt($c['crypt']);
             }
@@ -537,7 +537,7 @@ class App extends \Pimple
     public function lastModified($time)
     {
         if (is_integer($time)) {
-            $this['response']->headers->set('Last-Modified', gmdate('D, d M Y H:i:s T', $time));
+            $this['response']->getHeaders()->set('Last-Modified', gmdate('D, d M Y H:i:s T', $time));
             if ($time === strtotime($this['request']->getHeaders()->get('IF_MODIFIED_SINCE'))) {
                 $this->halt(304);
             }
@@ -575,7 +575,7 @@ class App extends \Pimple
         if ($type === 'weak') {
             $value = 'W/'.$value;
         }
-        $this['response']->headers->set('ETag', $value);
+        $this['response']->getHeaders()->set('ETag', $value);
 
         // Check conditional GET
         if ($etagsHeader = $this['request']->getHeaders()->get('IF_NONE_MATCH')) {
@@ -605,7 +605,7 @@ class App extends \Pimple
         if (is_string($time)) {
             $time = strtotime($time);
         }
-        $this['response']->headers->set('Expires', gmdate('D, d M Y H:i:s T', $time));
+        $this['response']->getHeaders()->set('Expires', gmdate('D, d M Y H:i:s T', $time));
     }
 
     /********************************************************************************
@@ -637,7 +637,7 @@ class App extends \Pimple
             'secure' => is_null($secure) ? $this->config('cookies.secure') : $secure,
             'httponly' => is_null($httponly) ? $this->config('cookies.httponly') : $httponly
         );
-        $this['response']->cookies->set($name, $settings);
+        $this['response']->getCookies()->set($name, $settings);
     }
 
     /**
@@ -681,7 +681,7 @@ class App extends \Pimple
             'secure' => is_null($secure) ? $this->config('cookies.secure') : $secure,
             'httponly' => is_null($httponly) ? $this->config('cookies.httponly') : $httponly
         );
-        $this['response']->cookies->remove($name, $settings);
+        $this['response']->getCookies()->remove($name, $settings);
     }
 
     /********************************************************************************
@@ -772,7 +772,7 @@ class App extends \Pimple
      */
     public function contentType($type)
     {
-        $this['response']->headers->set('Content-Type', $type);
+        $this['response']->getHeaders()->set('Content-Type', $type);
     }
 
     /**
@@ -928,20 +928,20 @@ class App extends \Pimple
             if (file_exists($file)) {
                 //Set Content-Type
                 if ($contentType) {
-                    $this['response']->headers->set("Content-Type", $contentType);
+                    $this['response']->getHeaders()->set("Content-Type", $contentType);
                 } else {
                     if (extension_loaded('fileinfo')) {
                         $finfo = new \finfo(FILEINFO_MIME_TYPE);
                         $type = $finfo->file($file);
-                        $this['response']->headers->set("Content-Type", $type);
+                        $this['response']->getHeaders()->set("Content-Type", $type);
                     } else {
-                        $this['response']->headers->set("Content-Type", "application/octet-stream");
+                        $this['response']->getHeaders()->set("Content-Type", "application/octet-stream");
                     }
                 }
 
                 //Set Content-Length
                 $stat = fstat($fp);
-                $this['response']->headers->set("Content-Length", $stat['size']);
+                $this['response']->getHeaders()->set("Content-Length", $stat['size']);
             } else {
                 //Set Content-Type and Content-Length
                 $data = stream_get_meta_data($fp);
@@ -951,12 +951,12 @@ class App extends \Pimple
 
                     if ($k === "Content-Type") {
                         if ($contentType) {
-                            $this['response']->headers->set("Content-Type", $contentType);
+                            $this['response']->getHeaders()->set("Content-Type", $contentType);
                         } else {
-                            $this['response']->headers->set("Content-Type", $v);
+                            $this['response']->getHeaders()->set("Content-Type", $v);
                         }
                     } else if ($k === "Content-Length") {
-                        $this['response']->headers->set("Content-Length", $v);
+                        $this['response']->getHeaders()->set("Content-Length", $v);
                     }
                 }
             }
@@ -976,7 +976,7 @@ class App extends \Pimple
     public function sendProcess($command, $contentType = "text/plain") {
         $ph = popen($command, 'r');
         $this['response']->stream($ph);
-        $this['response']->headers->set("Content-Type", $contentType);
+        $this['response']->getHeaders()->set("Content-Type", $contentType);
         $this->finalize();
     }
 
@@ -993,7 +993,7 @@ class App extends \Pimple
         if ($filename) {
             $h .= "filename='" . $filename . "'";
         }
-        $this['response']->headers->set("Content-Disposition", $h);
+        $this['response']->getHeaders()->set("Content-Disposition", $h);
     }
 
     /********************************************************************************
@@ -1111,9 +1111,9 @@ class App extends \Pimple
 
             // Encrypt and serialize cookies
             if ($this['settings']['cookies.encrypt']) {
-                $this['response']->cookies->encrypt($this['crypt']);
+                $this['response']->getCookies()->encrypt($this['crypt']);
             }
-            \Slim\Http\Cookies::serializeCookies($headers, $this['response']->cookies);
+            $this['response']->getCookies()->setHeaders($headers);
 
             //Send headers
             if (headers_sent() === false) {

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -93,7 +93,7 @@ class App extends \Pimple
 
         // Environment
         $this['environment'] = $this->share(function ($c) {
-            return \Slim\Environment($_SERVER);
+            return new \Slim\Environment($_SERVER);
         });
 
         // Request

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -110,7 +110,9 @@ class App extends \Pimple
 
         // Response
         $this['response'] = $this->share(function ($c) {
-            return new \Slim\Http\Response();
+            $headers = new \Slim\Http\Headers();
+            $cookies = new \Slim\Http\Cookies();
+            return new \Slim\Http\Response($headers, $cookies);
         });
 
         // Router

--- a/Slim/Collection.php
+++ b/Slim/Collection.php
@@ -32,24 +32,15 @@
  */
 namespace Slim;
 
-class Collection implements \Countable, \IteratorAggregate
+/**
+ * Collection
+ *
+ * @package Slim
+ * @author  Josh Lockhart
+ * @since   2.0.0
+ */
+class Collection extends \Pimple implements \Countable, \IteratorAggregate
 {
-    /**
-     * Key-value array of data
-     * @var array
-     */
-    protected $data = array();
-
-    /**
-     * Constructor
-     * @param array $items Pre-populate collection with this key-value array
-     * @api
-     */
-    public function __construct(array $items = array())
-    {
-        $this->replace($items);
-    }
-
     /**
      * Set data key to value
      * @param string $key   The data key
@@ -58,7 +49,7 @@ class Collection implements \Countable, \IteratorAggregate
      */
     public function set($key, $value)
     {
-        $this->data[$key] = $value;
+        $this->offsetSet($key, $value);
     }
 
     /**
@@ -70,8 +61,8 @@ class Collection implements \Countable, \IteratorAggregate
      */
     public function get($key, $default = null)
     {
-        if (isset($this->data[$key])) {
-            return $this->data[$key];
+        if ($this->offsetExists($key)) {
+            return $this->offsetGet($key);
         }
 
         return $default;
@@ -96,17 +87,7 @@ class Collection implements \Countable, \IteratorAggregate
      */
     public function all()
     {
-        return $this->data;
-    }
-
-    /**
-     * Fetch set data keys
-     * @return array This set's key-value data array keys
-     * @api
-     */
-    public function keys()
-    {
-        return array_keys($this->data);
+        return $this->values;
     }
 
     /**
@@ -117,7 +98,7 @@ class Collection implements \Countable, \IteratorAggregate
      */
     public function has($key)
     {
-        return array_key_exists($key, $this->data);
+        return $this->offsetExists($key);
     }
 
     /**
@@ -127,7 +108,7 @@ class Collection implements \Countable, \IteratorAggregate
      */
     public function remove($key)
     {
-        unset($this->data[$key]);
+        $this->offsetUnset($key);
     }
 
     /**
@@ -136,7 +117,7 @@ class Collection implements \Countable, \IteratorAggregate
      */
     public function clear()
     {
-        $this->data = array();
+        $this->values = array();
     }
 
     /**
@@ -146,8 +127,8 @@ class Collection implements \Countable, \IteratorAggregate
      */
     public function encrypt(\Slim\Crypt $crypt)
     {
-        foreach ($this as $elementName => $elementValue) {
-            $this->set($elementName, $crypt->encrypt($elementValue));
+        foreach ($this->values as $key => $value) {
+            $this->set($key, $crypt->encrypt($value));
         }
     }
 
@@ -158,8 +139,8 @@ class Collection implements \Countable, \IteratorAggregate
      */
     public function decrypt(\Slim\Crypt $crypt)
     {
-        foreach ($this as $elementName => $elementValue) {
-            $this->set($elementName, $crypt->decrypt($elementValue));
+        foreach ($this->values as $key => $value) {
+            $this->set($key, $crypt->decrypt($value));
         }
     }
 
@@ -170,7 +151,7 @@ class Collection implements \Countable, \IteratorAggregate
      */
     public function count()
     {
-        return count($this->data);
+        return count($this->values);
     }
 
     /**
@@ -180,6 +161,6 @@ class Collection implements \Countable, \IteratorAggregate
      */
     public function getIterator()
     {
-        return new \ArrayIterator($this->data);
+        return new \ArrayIterator($this->values);
     }
 }

--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -32,6 +32,8 @@
  */
 namespace Slim;
 
+use \Slim\Collection;
+
 /**
  * Environment
  *
@@ -44,40 +46,70 @@ namespace Slim;
  * @author  Josh Lockhart
  * @since   1.6.0
  */
-class Environment extends \Slim\Collection
+class Environment extends Collection
 {
     /**
-     * Create environment from globals
-     * @return \Slim\Environment
+     * Mock data for an Environment
+     * @var array
      */
-    public static function createFromGlobals()
+    public $mocked = array(
+        'SERVER_PROTOCOL'      => 'HTTP/1.1',
+        'REQUEST_METHOD'       => 'GET',
+        'SCRIPT_NAME'          => '',
+        'REQUEST_URI'          => '',
+        'QUERY_STRING'         => '',
+        'SERVER_NAME'          => 'localhost',
+        'SERVER_PORT'          => 80,
+        'HTTP_HOST'            => 'localhost',
+        'HTTP_ACCEPT'          => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'HTTP_ACCEPT_LANGUAGE' => 'en-US,en;q=0.8',
+        'HTTP_ACCEPT_CHARSET'  => 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
+        'HTTP_USER_AGENT'      => 'Slim Framework',
+        'REMOTE_ADDR'          => '127.0.0.1',
+        'REQUEST_TIME'         => ''
+    );
+
+    /**
+     * Constructor, will parse an array for environment information if present
+     * @param array $environment
+     */
+    public function __construct($environment = null)
     {
-        return new static($_SERVER);
+        if (!is_null($environment)) {
+            $this->parse($environment);
+        }
     }
 
     /**
-     * Create environment from mock data
-     * @return \Slim\Environment
+     * Parse environment array
+     *
+     * This method will parse an environment array and add the data to
+     * this collection
+     *
+     * @param  array  $environment
+     * @return void
      */
-    public static function mock(array $userData = array())
+    public function parse(array $environment)
     {
-        $data = array_merge(array(
-            'SERVER_PROTOCOL'      => 'HTTP/1.1',
-            'REQUEST_METHOD'       => 'GET',
-            'SCRIPT_NAME'          => '',
-            'REQUEST_URI'          => '',
-            'QUERY_STRING'         => '',
-            'SERVER_NAME'          => 'localhost',
-            'SERVER_PORT'          => 80,
-            'HTTP_HOST'            => 'localhost',
-            'HTTP_ACCEPT'          => 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-            'HTTP_ACCEPT_LANGUAGE' => 'en-US,en;q=0.8',
-            'HTTP_ACCEPT_CHARSET'  => 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
-            'HTTP_USER_AGENT'      => 'Slim Framework',
-            'REMOTE_ADDR'          => '127.0.0.1',
-            'REQUEST_TIME'         => time()
-        ), $userData);
+        foreach ($environment as $key => $value) {
+            $this->set($key, $value);
+        }
+    }
 
-        return new static($data);
+    /**
+     * Mock environment
+     *
+     * This method will parse a mock environment array and add the data to
+     * this collection
+     *
+     * @param  array  $environment
+     * @return void
+     */
+    public function mock(array $settings = array())
+    {
+        $this->mocked['REQUEST_TIME'] = time();
+        $settings = array_merge($this->mocked, $settings);
+
+        $this->parse($settings);
     }
 }

--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -32,6 +32,9 @@
  */
 namespace Slim\Http;
 
+use \Slim\Collection;
+use \Slim\Http\Headers;
+
 /**
  * Cookies
  *
@@ -50,7 +53,7 @@ namespace Slim\Http;
  * @author  Josh Lockhart
  * @since   2.3.0
  */
-class Cookies extends \Slim\Collection
+class Cookies extends Collection
 {
     /**
      * Default cookie settings
@@ -66,13 +69,14 @@ class Cookies extends \Slim\Collection
     );
 
     /**
-     * Extract cookies from HTTP headers
-     * @param  \Slim\Http\Headers $headers
-     * @return array
+     * Constructor, will parse headers for cookie information if present
+     * @param \Slim\Http\Headers $headers
      */
-    public static function extractFromHeaders(\Slim\Http\Headers $headers)
+    public function __construct(Headers $headers = null)
     {
-        return static::parseCookieHeader($headers->get('Cookie', ''));
+        if (!is_null($headers)) {
+            $this->values = $this->parseHeader($headers->get('Cookie', ''));
+        }
     }
 
     /**
@@ -93,11 +97,12 @@ class Cookies extends \Slim\Collection
     public function set($key, $value)
     {
         if (is_array($value)) {
-            $cookieSettings = array_replace($this->defaults, $value);
+            $settings = array_replace($this->defaults, $value);
         } else {
-            $cookieSettings = array_replace($this->defaults, array('value' => $value));
+            $settings = array_replace($this->defaults, array('value' => $value));
         }
-        parent::set($key, $cookieSettings);
+
+        parent::set($key, $settings);
     }
 
     /**
@@ -135,25 +140,15 @@ class Cookies extends \Slim\Collection
         }
     }
 
-    /********************************************************************************
-     * Static Methods
-     *******************************************************************************/
-
     /**
-     * Serialize cookies into HTTP response header
-     * @param  \Slim\Http\Headers $headers The Response headers
-     * @param  \Slim\Http\Cookies $cookies The Response cookies
-     * @param  array              $config  The Slim app settings
+     * Serialize this collection of cookies into a Headers object
+     * @param  Headers $headers
+     * @return void
      */
-    public static function serializeCookies(&$headers, \Slim\Http\Cookies $cookies)
+    public function setHeaders(Headers &$headers)
     {
-        foreach ($cookies as $name => $settings) {
-            if (is_string($settings['expires'])) {
-                $expires = strtotime($settings['expires']);
-            } else {
-                $expires = (int)$settings['expires'];
-            }
-            static::setCookieHeader($headers, $name, $settings);
+        foreach ($this->values as $name => $settings) {
+            $this->setHeader($headers, $name, $settings);
         }
     }
 
@@ -174,47 +169,52 @@ class Cookies extends \Slim\Collection
      * @param  string              $value
      * @return void
      */
-    public static function setCookieHeader(&$header, $name, $value)
+    public function setHeader(&$headers, $name, $value)
     {
-        //Build cookie header
+        $values = array();
+
         if (is_array($value)) {
-            $domain = '';
-            $path = '';
-            $expires = '';
-            $secure = '';
-            $httponly = '';
             if (isset($value['domain']) && $value['domain']) {
-                $domain = '; domain=' . $value['domain'];
+                $values[] = '; domain=' . $value['domain'];
             }
+
             if (isset($value['path']) && $value['path']) {
-                $path = '; path=' . $value['path'];
+                $values[] = '; path=' . $value['path'];
             }
+
             if (isset($value['expires'])) {
                 if (is_string($value['expires'])) {
                     $timestamp = strtotime($value['expires']);
                 } else {
                     $timestamp = (int) $value['expires'];
                 }
+
                 if ($timestamp !== 0) {
-                    $expires = '; expires=' . gmdate('D, d-M-Y H:i:s e', $timestamp);
+                    $values[] = '; expires=' . gmdate('D, d-M-Y H:i:s e', $timestamp);
                 }
             }
+
             if (isset($value['secure']) && $value['secure']) {
-                $secure = '; secure';
+                $values[] = '; secure';
             }
+
             if (isset($value['httponly']) && $value['httponly']) {
-                $httponly = '; HttpOnly';
+                $values[] = '; HttpOnly';
             }
-            $cookie = sprintf('%s=%s%s', urlencode($name), urlencode((string) $value['value']), $domain . $path . $expires . $secure . $httponly);
-        } else {
-            $cookie = sprintf('%s=%s', urlencode($name), urlencode((string) $value));
+
+            $value = (string)$value['value'];
         }
 
-        //Set cookie header
-        if (!isset($header['Set-Cookie']) || $header['Set-Cookie'] === '') {
-            $header['Set-Cookie'] = $cookie;
+        $cookie = sprintf(
+            '%s=%s',
+            urlencode($name),
+            urlencode((string) $value) . implode('', $values)
+        );
+
+        if (!$headers->has('Set-Cookie') || $headers->get('Set-Cookie') === '') {
+            $headers->set('Set-Cookie', $cookie);
         } else {
-            $header['Set-Cookie'] = implode("\n", array($header['Set-Cookie'], $cookie));
+            $headers->set('Set-Cookie', implode("\n", array($headers->get('Set-Cookie'), $cookie)));
         }
     }
 
@@ -231,58 +231,58 @@ class Cookies extends \Slim\Collection
      * first argument; this method directly modifies this object instead of
      * returning a value.
      *
-     * @param  array  $header
-     * @param  string $name
-     * @param  array  $value
+     * @param  \Slim\Http\Headers  $headers
+     * @param  string              $name
+     * @param  array               $value
      */
-    public static function deleteCookieHeader(&$header, $name, $value = array())
+    public function deleteHeader(Headers &$headers, $name, $value = array())
     {
-        //Remove affected cookies from current response header
-        $cookiesOld = array();
-        $cookiesNew = array();
-        if (isset($header['Set-Cookie'])) {
-            $cookiesOld = explode("\n", $header['Set-Cookie']);
-        }
-        foreach ($cookiesOld as $c) {
+        $crumbs = ($headers->has('Set-Cookie') ? explode("\n", $headers->get('Set-Cookie')) : array());
+        $cookies = array();
+
+        foreach ($crumbs as $crumb) {
             if (isset($value['domain']) && $value['domain']) {
                 $regex = sprintf('@%s=.*domain=%s@', urlencode($name), preg_quote($value['domain']));
             } else {
                 $regex = sprintf('@%s=@', urlencode($name));
             }
-            if (preg_match($regex, $c) === 0) {
-                $cookiesNew[] = $c;
+
+            if (preg_match($regex, $crumb) === 0) {
+                $cookies[] = $crumb;
             }
         }
-        if ($cookiesNew) {
-            $header['Set-Cookie'] = implode("\n", $cookiesNew);
+
+        if (!empty($cookies)) {
+            $headers->set('Set-Cookie', implode("\n", $cookies));
         } else {
-            unset($header['Set-Cookie']);
+            $headers->remove('Set-Cookie');
         }
 
-        //Set invalidating cookie to clear client-side cookie
-        static::setCookieHeader($header, $name, array_merge(array('value' => '', 'path' => null, 'domain' => null, 'expires' => time() - 100), $value));
+        $this->setHeader($headers, $name, array_merge(array('value' => '', 'path' => null, 'domain' => null, 'expires' => time() - 100), $value));
     }
 
     /**
      * Parse cookie header
      *
      * This method will parse the HTTP request's `Cookie` header
-     * and extract cookies into an associative array.
+     * and extract cookies into this collection.
      *
-     * @param  string
-     * @return array
+     * @param  string $header
+     * @return void
      */
-    public static function parseCookieHeader($header)
+    public function parseHeader($header)
     {
-        $cookies = array();
         $header = rtrim($header, "\r\n");
-        $headerPieces = preg_split('@\s*[;,]\s*@', $header);
+        $pieces = preg_split('@\s*[;,]\s*@', $header);
+        $cookies = array();
 
-        foreach ($headerPieces as $c) {
-            $cParts = explode('=', $c);
-            if (count($cParts) === 2) {
-                $key = urldecode($cParts[0]);
-                $value = urldecode($cParts[1]);
+        foreach ($pieces as $cookie) {
+            $cookie = explode('=', $cookie);
+
+            if (count($cookie) === 2) {
+                $key = urldecode($cookie[0]);
+                $value = urldecode($cookie[1]);
+
                 if (!isset($cookies[$key])) {
                     $cookies[$key] = $value;
                 }

--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -33,21 +33,23 @@
 namespace Slim\Http;
 
 use \Slim\Collection;
+use \Slim\Crypt;
 use \Slim\Http\Headers;
 
 /**
  * Cookies
  *
- * This class manages a collection of HTTP response cookies. Each
- * \Slim\Http\Response instance will contain a \Slim\Http\Cookies instance.
+ * This class manages a collection of HTTP cookies. Each
+ * \Slim\Http\Request and \Slim\Http\Response instance will contain a
+ * \Slim\Http\Cookies instance.
  *
- * This class also has several static helper methods used to parse
- * HTTP request `Cookie` headers and to serialize cookie data into
- * HTTP response headers.
+ * This class has several helper methods used to parse
+ * HTTP `Cookie` headers and to serialize cookie data into
+ * HTTP headers.
  *
  * Like many other Slim application objects, \Slim\Http\Cookies extends
  * \Slim\Container so you have access to a simple and common interface
- * to manipulate HTTP response cookies.
+ * to manipulate HTTP cookies.
  *
  * @package Slim
  * @author  Josh Lockhart
@@ -132,7 +134,7 @@ class Cookies extends Collection
      * @param \Slim\Crypt $crypt
      * @api
      */
-    public function encrypt(\Slim\Crypt $crypt)
+    public function encrypt(Crypt $crypt)
     {
         foreach ($this as $name => $settings) {
             $settings['value'] = $crypt->encrypt($settings['value']);

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -32,6 +32,10 @@
  */
 namespace Slim\Http;
 
+use \Slim\Environment;
+use \Slim\Http\Headers;
+use \Slim\Http\Cookies;
+
 /**
  * Slim HTTP Request
  *
@@ -114,7 +118,7 @@ class Request
      * Constructor
      * @api
      */
-    public function __construct(\Slim\Environment $env, \Slim\Http\Headers $headers, \Slim\Collection $cookies, $body = null)
+    public function __construct(Environment $env, Headers $headers, Cookies $cookies, $body = null)
     {
         $this->env = $env;
         $this->headers = $headers;

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -83,14 +83,14 @@ class Request
      * @var \Slim\Http\Headers
      * @api
      */
-    public $headers;
+    protected $headers;
 
     /**
      * Request cookies
      * @var \Slim\Collection
      * @api
      */
-    public $cookies;
+    protected $cookies;
 
     /**
      * Request query parameters

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -32,6 +32,9 @@
  */
 namespace Slim\Http;
 
+use \Slim\Http\Headers;
+use \Slim\Http\Cookies;
+
 /**
  * Response
  *
@@ -160,20 +163,22 @@ class Response
 
     /**
      * Constructor
-     * @param string                   $body    The HTTP response body
-     * @param int                      $status  The HTTP response status
-     * @param \Slim\Http\Headers|array $headers The HTTP response headers
+     * @param \Slim\Http\Headers $headers The HTTP response headers
+     * @param \Slim\Http\Cookies $cookies The HTTP response cookies
+     * @param string             $body    The HTTP response body
+     * @param int                $status  The HTTP response status
      * @api
      */
-    public function __construct($body = '', $status = 200, $headers = array())
+    public function __construct(Headers $headers, Cookies $cookies, $body = '', $status = 200)
     {
-        $this->setStatus($status);
-        $this->headers = new \Slim\Http\Headers();
-        $headers = array_merge(array('Content-Type' => 'text/html'), $headers);
-        $this->headers->replace($headers);
-        $this->cookies = new \Slim\Http\Cookies();
+        $this->headers = $headers;
+        if (!$this->headers->has('Content-Type')) {
+            $this->headers->set('Content-Type', 'text/html');
+        }
+        $this->cookies = $cookies;
         $this->isStream = false;
         $this->write($body, true);
+        $this->setStatus($status);
     }
 
     /**

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -60,14 +60,14 @@ class Response
      * @var \Slim\Http\Headers
      * @api
      */
-    public $headers;
+    protected $headers;
 
     /**
      * Response cookies
      * @var \Slim\Http\Cookies
      * @api
      */
-    public $cookies;
+    protected $cookies;
 
     /**
      * Response body
@@ -168,7 +168,8 @@ class Response
     public function __construct($body = '', $status = 200, $headers = array())
     {
         $this->setStatus($status);
-        $this->headers = new \Slim\Http\Headers(array('Content-Type' => 'text/html'));
+        $this->headers = new \Slim\Http\Headers();
+        $headers = array_merge(array('Content-Type' => 'text/html'), $headers);
         $this->headers->replace($headers);
         $this->cookies = new \Slim\Http\Cookies();
         $this->isStream = false;
@@ -213,6 +214,24 @@ class Response
     public function setBody($content)
     {
         $this->write($content, true);
+    }
+
+    /**
+     * Get HTTP headers
+     * @return \Slim\Http\Headers
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * Get HTTP cookies
+     * @return \Slim\Collection
+     */
+    public function getCookies()
+    {
+        return $this->cookies;
     }
 
     /**
@@ -306,7 +325,7 @@ class Response
      * @param int    $status The redirect HTTP status code
      * @api
      */
-    public function redirect ($url, $status = 302)
+    public function redirect($url, $status = 302)
     {
         $this->setStatus($status);
         $this->headers->set('Location', $url);

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -38,14 +38,14 @@ class CollectionTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->bag = new \Slim\Collection();
-        $this->property = new \ReflectionProperty($this->bag, 'data');
+        $this->property = new \ReflectionProperty($this->bag, 'values');
         $this->property->setAccessible(true);
     }
 
     public function testInitializeWithData()
     {
         $bag = new \Slim\Collection(array('foo' => 'bar'));
-        $bagProperty = new \ReflectionProperty($bag, 'data');
+        $bagProperty = new \ReflectionProperty($bag, 'values');
         $bagProperty->setAccessible(true);
 
         $this->assertEquals(array('foo' => 'bar'), $bagProperty->getValue($bag));

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -55,7 +55,7 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
      */
     public function testEnvironmentFromGlobals()
     {
-        $env = \Slim\Environment::createFromGlobals();
+        $env = new \Slim\Environment($_SERVER);
 
         $this->assertInstanceOf('\Slim\Environment', $env);
         $this->assertEquals($env->all(), $_SERVER);
@@ -66,7 +66,8 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
      */
     public function testEnvironmentFromMockData()
     {
-        $env = \Slim\Environment::mock(array(
+        $env = new \Slim\Environment();
+        $env->mock(array(
             'SCRIPT_NAME' => '/foo/bar/index.php',
             'REQUEST_URI' => '/foo/bar?abc=123'
         ));

--- a/tests/Http/CookiesTest.php
+++ b/tests/Http/CookiesTest.php
@@ -33,16 +33,19 @@ class CookiesTest extends PHPUnit_Framework_TestCase
 {
     public function testCreateFromHeaders()
     {
-        $headers = new \Slim\Http\Headers(array('HTTP_COOKIE' => 'foo=bar;abc=123'));
-        $cookies = new \Slim\Collection(\Slim\Http\Cookies::extractFromHeaders($headers));
+        $environment = new \Slim\Environment(array('HTTP_COOKIE' => 'foo=bar;abc=123'));
+        $headers = new \Slim\Http\Headers($environment);
+        $cookies = new \Slim\Http\Cookies($headers);
+
         $this->assertEquals('bar', $cookies->get('foo'));
         $this->assertEquals('123', $cookies->get('abc'));
     }
 
     public function testSetWithStringValue()
     {
-        $c = new \Slim\Http\Cookies();
-        $c->set('foo', 'bar');
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->set('foo', 'bar');
+
         $this->assertAttributeEquals(
             array(
                 'foo' => array(
@@ -54,16 +57,16 @@ class CookiesTest extends PHPUnit_Framework_TestCase
                     'httponly' => false
                 )
             ),
-            'data',
-            $c
+            'values',
+            $cookies
         );
     }
 
     public function testSetWithArrayValue()
     {
         $now = time();
-        $c = new \Slim\Http\Cookies();
-        $c->set('foo', array(
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->set('foo', array(
             'value' => 'bar',
             'expires' => $now + 86400,
             'domain' => '.example.com',
@@ -82,18 +85,18 @@ class CookiesTest extends PHPUnit_Framework_TestCase
                     'httponly' => true
                 )
             ),
-            'data',
-            $c
+            'values',
+            $cookies
         );
     }
 
     public function testRemove()
     {
-        $c = new \Slim\Http\Cookies();
-        $c->remove('foo');
-        $prop = new \ReflectionProperty($c, 'data');
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->remove('foo');
+        $prop = new \ReflectionProperty($cookies, 'values');
         $prop->setAccessible(true);
-        $cValue = $prop->getValue($c);
+        $cValue = $prop->getValue($cookies);
         $this->assertEquals('', $cValue['foo']['value']);
         $this->assertLessThan(time(), $cValue['foo']['expires']);
     }
@@ -102,18 +105,21 @@ class CookiesTest extends PHPUnit_Framework_TestCase
     {
         $name = 'foo';
         $value = 'bar';
-        $header = array();
-        \Slim\Http\Cookies::setCookieHeader($header, $name, $value);
-        $this->assertEquals('foo=bar', $header['Set-Cookie']);
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->setHeader($headers, $name, $value);
+        $this->assertEquals('foo=bar', $headers->get('Set-Cookie'));
     }
 
     public function testSetCookieHeaderWithNameAndValueWhenCookieAlreadySet()
     {
         $name = 'foo';
         $value = 'bar';
-        $header = array('Set-Cookie' => 'one=two');
-        \Slim\Http\Cookies::setCookieHeader($header, $name, $value);
-        $this->assertEquals("one=two\nfoo=bar", $header['Set-Cookie']);
+        $headers = new \Slim\Http\Headers();
+        $headers->set('Set-Cookie', 'one=two');
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->setHeader($headers, $name, $value);
+        $this->assertEquals("one=two\nfoo=bar", $headers->get('Set-Cookie'));
     }
 
     public function testSetCookieHeaderWithNameAndValueAndDomain()
@@ -121,12 +127,13 @@ class CookiesTest extends PHPUnit_Framework_TestCase
         $name = 'foo';
         $value = 'bar';
         $domain = 'foo.com';
-        $header = array();
-        \Slim\Http\Cookies::setCookieHeader($header, $name, array(
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->setHeader($headers, $name, array(
             'value' => $value,
             'domain' => $domain
         ));
-        $this->assertEquals('foo=bar; domain=foo.com', $header['Set-Cookie']);
+        $this->assertEquals('foo=bar; domain=foo.com', $headers->get('Set-Cookie'));
     }
 
     public function testSetCookieHeaderWithNameAndValueAndDomainAndPath()
@@ -135,13 +142,14 @@ class CookiesTest extends PHPUnit_Framework_TestCase
         $value = 'bar';
         $domain = 'foo.com';
         $path = '/foo';
-        $header = array();
-        \Slim\Http\Cookies::setCookieHeader($header, $name, array(
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->setHeader($headers, $name, array(
             'value' => $value,
             'domain' => $domain,
             'path' => $path
         ));
-        $this->assertEquals('foo=bar; domain=foo.com; path=/foo', $header['Set-Cookie']);
+        $this->assertEquals('foo=bar; domain=foo.com; path=/foo', $headers->get('Set-Cookie'));
     }
 
     public function testSetCookieHeaderWithNameAndValueAndDomainAndPathAndExpiresAsString()
@@ -152,14 +160,15 @@ class CookiesTest extends PHPUnit_Framework_TestCase
         $path = '/foo';
         $expires = '2 days';
         $expiresFormat = gmdate('D, d-M-Y H:i:s e', strtotime($expires));
-        $header = array();
-        \Slim\Http\Cookies::setCookieHeader($header, $name, array(
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->setHeader($headers, $name, array(
             'value' => $value,
             'domain' => $domain,
             'path' => '/foo',
             'expires' => $expires
         ));
-        $this->assertEquals('foo=bar; domain=foo.com; path=/foo; expires=' . $expiresFormat, $header['Set-Cookie']);
+        $this->assertEquals('foo=bar; domain=foo.com; path=/foo; expires=' . $expiresFormat, $headers->get('Set-Cookie'));
     }
 
     public function testSetCookieHeaderWithNameAndValueAndDomainAndPathAndExpiresAsInteger()
@@ -170,14 +179,15 @@ class CookiesTest extends PHPUnit_Framework_TestCase
         $path = '/foo';
         $expires = strtotime('2 days');
         $expiresFormat = gmdate('D, d-M-Y H:i:s e', $expires);
-        $header = array();
-        \Slim\Http\Cookies::setCookieHeader($header, $name, array(
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->setHeader($headers, $name, array(
             'value' => $value,
             'domain' => $domain,
             'path' => '/foo',
             'expires' => $expires
         ));
-        $this->assertEquals('foo=bar; domain=foo.com; path=/foo; expires=' . $expiresFormat, $header['Set-Cookie']);
+        $this->assertEquals('foo=bar; domain=foo.com; path=/foo; expires=' . $expiresFormat, $headers->get('Set-Cookie'));
     }
 
     public function testSetCookieHeaderWithNameAndValueAndDomainAndPathAndExpiresAsZero()
@@ -187,14 +197,15 @@ class CookiesTest extends PHPUnit_Framework_TestCase
         $domain = 'foo.com';
         $path = '/foo';
         $expires = 0;
-        $header = array();
-        \Slim\Http\Cookies::setCookieHeader($header, $name, array(
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->setHeader($headers, $name, array(
             'value' => $value,
             'domain' => $domain,
             'path' => '/foo',
             'expires' => $expires
         ));
-        $this->assertEquals('foo=bar; domain=foo.com; path=/foo', $header['Set-Cookie']);
+        $this->assertEquals('foo=bar; domain=foo.com; path=/foo', $headers->get('Set-Cookie'));
     }
 
     public function testSetCookieHeaderWithNameAndValueAndDomainAndPathAndExpiresAndSecure()
@@ -206,15 +217,16 @@ class CookiesTest extends PHPUnit_Framework_TestCase
         $expires = strtotime('2 days');
         $expiresFormat = gmdate('D, d-M-Y H:i:s e', $expires);
         $secure = true;
-        $header = array();
-        \Slim\Http\Cookies::setCookieHeader($header, $name, array(
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->setHeader($headers, $name, array(
             'value' => $value,
             'domain' => $domain,
             'path' => '/foo',
             'expires' => $expires,
             'secure' => $secure
         ));
-        $this->assertEquals('foo=bar; domain=foo.com; path=/foo; expires=' . $expiresFormat . '; secure', $header['Set-Cookie']);
+        $this->assertEquals('foo=bar; domain=foo.com; path=/foo; expires=' . $expiresFormat . '; secure', $headers->get('Set-Cookie'));
     }
 
     public function testSetCookieHeaderWithNameAndValueAndDomainAndPathAndExpiresAndSecureAndHttpOnly()
@@ -227,8 +239,9 @@ class CookiesTest extends PHPUnit_Framework_TestCase
         $expiresFormat = gmdate('D, d-M-Y H:i:s e', $expires);
         $secure = true;
         $httpOnly = true;
-        $header = array();
-        \Slim\Http\Cookies::setCookieHeader($header, $name, array(
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->setHeader($headers, $name, array(
             'value' => $value,
             'domain' => $domain,
             'path' => '/foo',
@@ -236,39 +249,47 @@ class CookiesTest extends PHPUnit_Framework_TestCase
             'secure' => $secure,
             'httponly' => $httpOnly
         ));
-        $this->assertEquals('foo=bar; domain=foo.com; path=/foo; expires=' . $expiresFormat . '; secure; HttpOnly', $header['Set-Cookie']);
+        $this->assertEquals('foo=bar; domain=foo.com; path=/foo; expires=' . $expiresFormat . '; secure; HttpOnly', $headers->get('Set-Cookie'));
     }
 
     public function testDeleteCookieHeaderWithSurvivingCookie()
     {
-        $header = array('Set-Cookie' => "foo=bar\none=two");
-        \Slim\Http\Cookies::deleteCookieHeader($header, 'foo');
-        $this->assertEquals(1, preg_match("@^one=two\nfoo=; expires=@", $header['Set-Cookie']));
+        $headers = new \Slim\Http\Headers();
+        $headers->replace(array('Set-Cookie' => "foo=bar\none=two"));
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->deleteHeader($headers, 'foo');
+        $this->assertEquals(1, preg_match("@^one=two\nfoo=; expires=@", $headers->get('Set-Cookie')));
     }
 
     public function testDeleteCookieHeaderWithoutSurvivingCookie()
     {
-        $header = array('Set-Cookie' => "foo=bar");
-        \Slim\Http\Cookies::deleteCookieHeader($header, 'foo');
-        $this->assertEquals(1, preg_match("@foo=; expires=@", $header['Set-Cookie']));
+        $headers = new \Slim\Http\Headers();
+        $headers->replace(array('Set-Cookie' => "foo=bar"));
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->deleteHeader($headers, 'foo');
+        $this->assertEquals(1, preg_match("@foo=; expires=@", $headers->get('Set-Cookie')));
     }
 
     public function testDeleteCookieHeaderWithMatchingDomain()
     {
-        $header = array('Set-Cookie' => "foo=bar; domain=foo.com");
-        \Slim\Http\Cookies::deleteCookieHeader($header, 'foo', array(
+        $headers = new \Slim\Http\Headers();
+        $headers->replace(array('Set-Cookie' => "foo=bar; domain=foo.com"));
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->deleteHeader($headers, 'foo', array(
             'domain' => 'foo.com'
         ));
-        $this->assertEquals(1, preg_match("@foo=; domain=foo.com; expires=@", $header['Set-Cookie']));
+        $this->assertEquals(1, preg_match("@foo=; domain=foo.com; expires=@", $headers->get('Set-Cookie')));
     }
 
     public function testDeleteCookieHeaderWithoutMatchingDomain()
     {
-        $header = array('Set-Cookie' => "foo=bar; domain=foo.com");
-        \Slim\Http\Cookies::deleteCookieHeader($header, 'foo', array(
+        $headers = new \Slim\Http\Headers();
+        $headers->replace(array('Set-Cookie' => "foo=bar; domain=foo.com"));
+        $cookies = new \Slim\Http\Cookies();
+        $cookies->deleteHeader($headers, 'foo', array(
             'domain' => 'bar.com'
         ));
-        $this->assertEquals(1, preg_match("@foo=bar; domain=foo\.com\nfoo=; domain=bar\.com@", $header['Set-Cookie']));
+        $this->assertEquals(1, preg_match("@foo=bar; domain=foo\.com\nfoo=; domain=bar\.com@", $headers->get('Set-Cookie')));
     }
 
     /**
@@ -277,7 +298,8 @@ class CookiesTest extends PHPUnit_Framework_TestCase
     public function testParsesCookieHeader()
     {
         $header = 'foo=bar; one=two; colors=blue';
-        $result = \Slim\Http\Cookies::parseCookieHeader($header);
+        $cookies = new \Slim\Http\Cookies();
+        $result = $cookies->parseHeader($header);
         $this->assertEquals(3, count($result));
         $this->assertEquals('bar', $result['foo']);
         $this->assertEquals('two', $result['one']);
@@ -287,7 +309,8 @@ class CookiesTest extends PHPUnit_Framework_TestCase
     public function testParsesCookieHeaderWithCommaSeparator()
     {
         $header = 'foo=bar, one=two, colors=blue';
-        $result = \Slim\Http\Cookies::parseCookieHeader($header);
+        $cookies = new \Slim\Http\Cookies();
+        $result = $cookies->parseHeader($header);
         $this->assertEquals(3, count($result));
         $this->assertEquals('bar', $result['foo']);
         $this->assertEquals('two', $result['one']);
@@ -297,7 +320,8 @@ class CookiesTest extends PHPUnit_Framework_TestCase
     public function testPrefersLeftmostCookieWhenManyCookiesWithSameName()
     {
         $header = 'foo=bar; foo=beer';
-        $result = \Slim\Http\Cookies::parseCookieHeader($header);
+        $cookies = new \Slim\Http\Cookies();
+        $result = $cookies->parseHeader($header);
         $this->assertEquals('bar', $result['foo']);
     }
 }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -39,7 +39,8 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     protected function initializeRequest(array $serverData = array(), $body = 'abc=123&foo=bar')
     {
-        $this->environment = \Slim\Environment::mock(array_merge(array(
+        $this->environment = new \Slim\Environment();
+        $this->environment->mock(array_merge(array(
             'SERVER_PROTOCOL'      => 'HTTP/1.1',
             'REQUEST_METHOD'       => 'GET',
             'SCRIPT_NAME'          => '/foo/index.php',
@@ -55,8 +56,8 @@ class RequestTest extends PHPUnit_Framework_TestCase
             'REMOTE_ADDR'          => '127.0.0.1',
             'REQUEST_TIME'         => time()
         ), $serverData));
-        $this->headers = \Slim\Http\Headers::createFromEnvironment($this->environment);
-        $this->cookies = new \Slim\Collection(\Slim\Http\Cookies::extractFromHeaders($this->headers));
+        $this->headers = new \Slim\Http\Headers($this->environment);
+        $this->cookies = new \Slim\Http\Cookies($this->headers);
         $this->request = new \Slim\Http\Request($this->environment, $this->headers, $this->cookies, $body);
     }
 

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -34,7 +34,9 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 {
     public function testConstructWithoutArgs()
     {
-        $res = new \Slim\Http\Response();
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies);
 
         $this->assertAttributeEquals(200, 'status', $res);
         $this->assertAttributeEquals('', 'body', $res);
@@ -42,7 +44,9 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testConstructWithArgs()
     {
-        $res = new \Slim\Http\Response('Foo', 201);
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies, 'Foo', 201);
 
         $this->assertAttributeEquals(201, 'status', $res);
         $this->assertAttributeEquals('Foo', 'body', $res);
@@ -50,14 +54,18 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testGetStatus()
     {
-        $res = new \Slim\Http\Response();
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies);
 
         $this->assertEquals(200, $res->getStatus());
     }
 
     public function testSetStatus()
     {
-        $res = new \Slim\Http\Response();
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies);
         $res->setStatus(301);
 
         $this->assertAttributeEquals(301, 'status', $res);
@@ -65,7 +73,9 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testGetBody()
     {
-        $res = new \Slim\Http\Response();
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies);
         $property = new \ReflectionProperty($res, 'body');
         $property->setAccessible(true);
         $property->setValue($res, 'foo');
@@ -75,7 +85,9 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testSetBody()
     {
-        $res = new \Slim\Http\Response('bar');
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies, 'bar');
         $res->setBody('foo'); // <-- Should replace body
 
         $this->assertAttributeEquals('foo', 'body', $res);
@@ -83,7 +95,9 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testWrite()
     {
-        $res = new \Slim\Http\Response();
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies);
         $property = new \ReflectionProperty($res, 'body');
         $property->setAccessible(true);
         $property->setValue($res, 'foo');
@@ -94,14 +108,18 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testLength()
     {
-        $res = new \Slim\Http\Response('foo'); // <-- Sets body and length
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies, 'foo'); // <-- Sets body and length
 
         $this->assertEquals(3, $res->getLength());
     }
 
     public function testFinalize()
     {
-        $res = new \Slim\Http\Response();
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies);
         $resFinal = $res->finalize();
 
         $this->assertTrue(is_array($resFinal));
@@ -113,7 +131,9 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testFinalizeWithEmptyBody()
     {
-        $res = new \Slim\Http\Response('Foo', 304);
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies, 'Foo', 304);
         $resFinal = $res->finalize();
 
         $this->assertEquals('', $resFinal[2]);
@@ -121,7 +141,9 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testRedirect()
     {
-        $res = new \Slim\Http\Response();
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $res = new \Slim\Http\Response($headers, $cookies);
         $res->redirect('/foo');
 
         $pStatus = new \ReflectionProperty($res, 'status');
@@ -133,8 +155,10 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testIsEmpty()
     {
-        $r1 = new \Slim\Http\Response();
-        $r2 = new \Slim\Http\Response();
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $r1 = new \Slim\Http\Response($headers, $cookies);
+        $r2 = new \Slim\Http\Response($headers, $cookies);
         $r1->setStatus(404);
         $r2->setStatus(201);
         $this->assertFalse($r1->isEmpty());
@@ -143,8 +167,11 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testIsClientError()
     {
-        $r1 = new \Slim\Http\Response();
-        $r2 = new \Slim\Http\Response();
+        $headers1 = new \Slim\Http\Headers();
+        $headers2 = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $r1 = new \Slim\Http\Response($headers1, $cookies);
+        $r2 = new \Slim\Http\Response($headers2, $cookies);
         $r1->setStatus(404);
         $r2->setStatus(500);
         $this->assertTrue($r1->isClientError());
@@ -153,8 +180,11 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testIsForbidden()
     {
-        $r1 = new \Slim\Http\Response();
-        $r2 = new \Slim\Http\Response();
+        $headers1 = new \Slim\Http\Headers();
+        $headers2 = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $r1 = new \Slim\Http\Response($headers1, $cookies);
+        $r2 = new \Slim\Http\Response($headers2, $cookies);
         $r1->setStatus(403);
         $r2->setStatus(500);
         $this->assertTrue($r1->isForbidden());
@@ -163,8 +193,11 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testIsInformational()
     {
-        $r1 = new \Slim\Http\Response();
-        $r2 = new \Slim\Http\Response();
+        $headers1 = new \Slim\Http\Headers();
+        $headers2 = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $r1 = new \Slim\Http\Response($headers1, $cookies);
+        $r2 = new \Slim\Http\Response($headers2, $cookies);
         $r1->setStatus(100);
         $r2->setStatus(200);
         $this->assertTrue($r1->isInformational());
@@ -173,8 +206,11 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testIsNotFound()
     {
-        $r1 = new \Slim\Http\Response();
-        $r2 = new \Slim\Http\Response();
+        $headers1 = new \Slim\Http\Headers();
+        $headers2 = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $r1 = new \Slim\Http\Response($headers1, $cookies);
+        $r2 = new \Slim\Http\Response($headers2, $cookies);
         $r1->setStatus(404);
         $r2->setStatus(200);
         $this->assertTrue($r1->isNotFound());
@@ -183,8 +219,11 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testIsOk()
     {
-        $r1 = new \Slim\Http\Response();
-        $r2 = new \Slim\Http\Response();
+        $headers1 = new \Slim\Http\Headers();
+        $headers2 = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $r1 = new \Slim\Http\Response($headers1, $cookies);
+        $r2 = new \Slim\Http\Response($headers2, $cookies);
         $r1->setStatus(200);
         $r2->setStatus(201);
         $this->assertTrue($r1->isOk());
@@ -193,9 +232,13 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testIsSuccessful()
     {
-        $r1 = new \Slim\Http\Response();
-        $r2 = new \Slim\Http\Response();
-        $r3 = new \Slim\Http\Response();
+        $headers1 = new \Slim\Http\Headers();
+        $headers2 = new \Slim\Http\Headers();
+        $headers3 = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $r1 = new \Slim\Http\Response($headers1, $cookies);
+        $r2 = new \Slim\Http\Response($headers2, $cookies);
+        $r3 = new \Slim\Http\Response($headers3, $cookies);
         $r1->setStatus(200);
         $r2->setStatus(201);
         $r3->setStatus(302);
@@ -206,8 +249,11 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testIsRedirect()
     {
-        $r1 = new \Slim\Http\Response();
-        $r2 = new \Slim\Http\Response();
+        $headers1 = new \Slim\Http\Headers();
+        $headers2 = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $r1 = new \Slim\Http\Response($headers1, $cookies);
+        $r2 = new \Slim\Http\Response($headers2, $cookies);
         $r1->setStatus(307);
         $r2->setStatus(304);
         $this->assertTrue($r1->isRedirect());
@@ -216,9 +262,13 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testIsRedirection()
     {
-        $r1 = new \Slim\Http\Response();
-        $r2 = new \Slim\Http\Response();
-        $r3 = new \Slim\Http\Response();
+        $headers1 = new \Slim\Http\Headers();
+        $headers2 = new \Slim\Http\Headers();
+        $headers3 = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $r1 = new \Slim\Http\Response($headers1, $cookies);
+        $r2 = new \Slim\Http\Response($headers2, $cookies);
+        $r3 = new \Slim\Http\Response($headers3, $cookies);
         $r1->setStatus(307);
         $r2->setStatus(304);
         $r3->setStatus(200);
@@ -229,8 +279,11 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
     public function testIsServerError()
     {
-        $r1 = new \Slim\Http\Response();
-        $r2 = new \Slim\Http\Response();
+        $headers1 = new \Slim\Http\Headers();
+        $headers2 = new \Slim\Http\Headers();
+        $cookies = new \Slim\Http\Cookies();
+        $r1 = new \Slim\Http\Response($headers1, $cookies);
+        $r2 = new \Slim\Http\Response($headers2, $cookies);
         $r1->setStatus(500);
         $r2->setStatus(400);
         $this->assertTrue($r1->isServerError());

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -128,7 +128,7 @@ class ResponseTest extends PHPUnit_Framework_TestCase
         $pStatus->setAccessible(true);
 
         $this->assertEquals(302, $pStatus->getValue($res));
-        $this->assertEquals('/foo', $res->headers->get('Location'));
+        $this->assertEquals('/foo', $res->getHeaders()->get('Location'));
     }
 
     public function testIsEmpty()

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -35,7 +35,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->view = new \Slim\View(dirname(__FILE__) . '/templates');
-        $this->property = new \ReflectionProperty($this->view, 'data');
+        $this->property = new \ReflectionProperty($this->view, 'values');
         $this->property->setAccessible(true);
     }
 


### PR DESCRIPTION
@codeguy I know the rule is to do single feature or implementation changes in separate branches, sorry for having three separate changes in one here.

I wanted to get the Http classes to be instantiated objects rather than rely on static methods as I tried to explain in my email. They seem to lend themselves more to that pattern IMO. Anyway, I got it working ok, so let me know if you think we could go this route here.

Also, as we discussed, I have the Collection extending Pimple now, more work could be done in the future to use more array syntax throughout (maybe?), currently works fine.

Also also, I've protected the Headers and Cookies instances in the Request and Response classes.

All unit tests pass, and after xmas, I will take a thorough look through to see if there is full code coverage with these changes.
