### PR TITLE
Allow all valid characters in function names of getCallableAsClass

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -194,7 +194,7 @@ class Route implements RouteInterface
     public function setCallable($callable)
     {
         $matches = array();
-        if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
+        if (is_string($callable) && preg_match('!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!', $callable, $matches)) {
             $callable = array(new $matches[1], $matches[2]);
         }
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -76,6 +76,19 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('getCurrentRoute', $callable[1]);
     }
 
+    public function example_càllâble_wïth_wéird_chars()
+    {
+    }
+
+    public function testGetCallableWithOddCharsAsClass()
+    {
+        $route = new \Slim\Route('/foo', '\RouteTest:example_càllâble_wïth_wéird_chars');
+
+        $callable = $route->getCallable();
+        $this->assertInstanceOf('\RouteTest', $callable[0]);
+        $this->assertEquals('example_càllâble_wïth_wéird_chars', $callable[1]);
+    }
+
     public function testSetCallable()
     {
         $callable = function () {


### PR DESCRIPTION
This uses the [a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]\* regex as specified by https://php.net/manual/en/functions.user-defined.php
