### PR TITLE
Don't start a session when finalize() is called.

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -1185,14 +1185,17 @@ class App extends \Pimple
         if (!$this->responded) {
             $this->responded = true;
 
-            // Save flash messages to session
-            $this['flash']->save();
+            // Finalise session if it has been used
+            if (isset($_SESSION)) {
+                // Save flash messages to session
+                $this['flash']->save();
 
-            // Encrypt, save, close session
-            if ($this->config('session.encrypt') === true) {
-                $this['session']->encrypt($this['crypt']);
+                // Encrypt, save, close session
+                if ($this->config('session.encrypt') === true) {
+                    $this['session']->encrypt($this['crypt']);
+                }
+                $this['session']->save();
             }
-            $this['session']->save();
 
             //Fetch status, header, and body
             list($status, $headers, $body) = $this['response']->finalize();


### PR DESCRIPTION
If the session hasn't already been started, then there is no need to start one in finalize() which is what happens when the flash or session objects are retrieved from Pimple.

Note: I've tested for the existence of $_SESSION for compatibility with PHP 5.3. For PHP 5.4+, it would be neater to use session_status().
