### PR TITLE
Lazy-initialize class in \Slim\Route::setCallable()

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -195,7 +195,15 @@ class Route implements RouteInterface
     {
         $matches = array();
         if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
-            $callable = array(new $matches[1], $matches[2]);
+            $class = $matches[1];
+            $method = $matches[2];
+            $callable = function() use ($class, $method) {
+                static $obj = null;
+                if ($obj === null) {
+                    $obj = new $class;
+                }
+                return $obj->$method();
+            };
         }
 
         if (!is_callable($callable)) {

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -202,7 +202,7 @@ class Route implements RouteInterface
                 if ($obj === null) {
                     $obj = new $class;
                 }
-                return $obj->$method();
+                return call_user_func_array(array($obj, $method), func_get_args());
             };
         }
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -29,6 +29,18 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
+class LazyInitializeTestClass {
+    public static $initialized = false;
+
+    public function __construct() {
+        self::$initialized = true;
+    }
+
+    public function foo() {
+    }
+}
+
 class RouteTest extends PHPUnit_Framework_TestCase
 {
     public function testGetPattern()
@@ -72,8 +84,20 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $route = new \Slim\Route('/foo', '\Slim\Router:getCurrentRoute');
 
         $callable = $route->getCallable();
-        $this->assertInstanceOf('\Slim\Router', $callable[0]);
-        $this->assertEquals('getCurrentRoute', $callable[1]);
+        // FIXME: use a different method, dispatch route and check if it was called?
+        //$this->assertInstanceOf('\Slim\Router', $callable[0]);
+        //$this->assertEquals('getCurrentRoute', $callable[1]);
+    }
+
+    public function testGetCallableAsClassLazyInitialize()
+    {
+        LazyInitializeTestClass::$initialized = false;
+
+        $route = new \Slim\Route('/foo', '\LazyInitializeTestClass:foo');
+        $this->assertFalse(LazyInitializeTestClass::$initialized);
+
+        $route->dispatch();
+        $this->assertTrue(LazyInitializeTestClass::$initialized);
     }
 
     public function testSetCallable()

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -43,9 +43,11 @@ class LazyInitializeTestClass {
 
 class FooTestClass {
     public static $foo_invoked = false;
+    public static $foo_invoked_args = array();
 
     public function foo() {
         self::$foo_invoked = true;
+        self::$foo_invoked_args = func_get_args();
     }
 }
 
@@ -90,11 +92,14 @@ class RouteTest extends PHPUnit_Framework_TestCase
     public function testGetCallableAsClass()
     {
         FooTestClass::$foo_invoked = false;
+        FooTestClass::$foo_invoked_args = array();
         $route = new \Slim\Route('/foo', '\FooTestClass:foo');
+        $route->setParams(array('bar' => '1234'));
 
         $this->assertFalse(FooTestClass::$foo_invoked);
         $this->assertTrue($route->dispatch());
         $this->assertTrue(FooTestClass::$foo_invoked);
+        $this->assertEquals(array('1234'), FooTestClass::$foo_invoked_args);
     }
 
     public function testGetCallableAsClassLazyInitialize()

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -41,6 +41,14 @@ class LazyInitializeTestClass {
     }
 }
 
+class FooTestClass {
+    public static $foo_invoked = false;
+
+    public function foo() {
+        self::$foo_invoked = true;
+    }
+}
+
 class RouteTest extends PHPUnit_Framework_TestCase
 {
     public function testGetPattern()
@@ -81,12 +89,12 @@ class RouteTest extends PHPUnit_Framework_TestCase
 
     public function testGetCallableAsClass()
     {
-        $route = new \Slim\Route('/foo', '\Slim\Router:getCurrentRoute');
+        FooTestClass::$foo_invoked = false;
+        $route = new \Slim\Route('/foo', '\FooTestClass:foo');
 
-        $callable = $route->getCallable();
-        // FIXME: use a different method, dispatch route and check if it was called?
-        //$this->assertInstanceOf('\Slim\Router', $callable[0]);
-        //$this->assertEquals('getCurrentRoute', $callable[1]);
+        $this->assertFalse(FooTestClass::$foo_invoked);
+        $this->assertTrue($route->dispatch());
+        $this->assertTrue(FooTestClass::$foo_invoked);
     }
 
     public function testGetCallableAsClassLazyInitialize()


### PR DESCRIPTION
You don't want to construct all kinds of objects when setting up your routes, so don't initialize those objects until
the route is actually dispatched. Add some basic caching so multiple route dispatches don't result in multiple class
instantiations.

Note: I had to comment out RouteTest::testGetCallableAsClass(), as the callable is now a lambda function instead of an array. WDYT is the best way to solve this? (I think that the test was depending on an implementation detail and should just test whether the set callable is invoked when the route gets dispatched)
