### PR TITLE
Fix resolving X-Forwarded-For header

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -576,10 +576,11 @@ class Request
      */
     public function getIp()
     {
-        if (isset($this->env['X_FORWARDED_FOR'])) {
-            return $this->env['X_FORWARDED_FOR'];
-        } elseif (isset($this->env['CLIENT_IP'])) {
-            return $this->env['CLIENT_IP'];
+        $keys = array('X_FORWARDED_FOR', 'HTTP_X_FORWARDED_FOR', 'CLIENT_IP', 'REMOTE_ADDR');
+        foreach ($keys as $key) {
+            if (isset($this->env[$key])) {
+                return $this->env[$key];
+            }
         }
 
         return $this->env['REMOTE_ADDR'];

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -853,41 +853,24 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     /**
      * Test get IP
+     *  @dataProvider dataTestIp
      */
-    public function testGetIp()
+    public function testGetIp(array $server, $expected)
     {
-        $env = \Slim\Environment::mock(array(
-            'REMOTE_ADDR' => '127.0.0.1'
-        ));
+        $env = \Slim\Environment::mock($server);
         $req = new \Slim\Http\Request($env);
-        $this->assertEquals('127.0.0.1', $req->getIp());
+        $this->assertEquals($expected, $req->getIp());
     }
 
-    /**
-     * Test get IP with proxy server and Client-Ip header
-     */
-    public function testGetIpWithClientIp()
+    public function dataTestIp()
     {
-        $env = \Slim\Environment::mock(array(
-            'REMOTE_ADDR' => '127.0.0.1',
-            'CLIENT_IP' => '127.0.0.2'
-        ));
-        $req = new \Slim\Http\Request($env);
-        $this->assertEquals('127.0.0.2', $req->getIp());
-    }
-
-    /**
-     * Test get IP with proxy server and X-Forwarded-For header
-     */
-    public function testGetIpWithForwardedFor()
-    {
-        $env = \Slim\Environment::mock(array(
-            'REMOTE_ADDR' => '127.0.0.1',
-            'CLIENT_IP' => '127.0.0.2',
-            'X_FORWARDED_FOR' => '127.0.0.3'
-        ));
-        $req = new \Slim\Http\Request($env);
-        $this->assertEquals('127.0.0.3', $req->getIp());
+        return array(
+                array(array('REMOTE_ADDR' => '127.0.0.1'), '127.0.0.1'),
+                array(array('REMOTE_ADDR' => '127.0.0.1', 'CLIENT_IP' => '127.0.0.2'), '127.0.0.2'),
+                array(array('REMOTE_ADDR' => '127.0.0.1', 'CLIENT_IP' => '127.0.0.2', 'X_FORWARDED_FOR' => '127.0.0.3'), '127.0.0.3'),
+                array(array('REMOTE_ADDR' => '127.0.0.1', 'CLIENT_IP' => '127.0.0.2', 'HTTP_X_FORWARDED_FOR' => '127.0.0.4'), '127.0.0.4'),
+                array(array('REMOTE_ADDR' => '127.0.0.1', 'CLIENT_IP' => '127.0.0.2', 'X_FORWARDED_FOR' => '127.0.0.3', 'HTTP_X_FORWARDED_FOR' => '127.0.0.4'), '127.0.0.3'),
+        );
     }
 
     /**


### PR DESCRIPTION
This fixes X-Forwarded-For resolving (HTTP_ prefix). This is fixed
on develop branch differently. However current behaviour renders
invalid results and IMHO this patch should merged and released
as 2.3.NEXT

The patch is backward compatible (prefers X_FORWARDED_FOR to HTTP_X_FORWARDED_FOR). Tests are included.
