### PR TITLE
Only instantiate the controller class if the route is requested

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -182,6 +182,11 @@ class Route implements RouteInterface
      */
     public function getCallable()
     {
+        //Instantiate class constructor
+        if(is_array($this->callable)) {
+            $this->callable = array(new $this->callable[0], $this->callable[1]);
+        }
+
         return $this->callable;
     }
 
@@ -195,7 +200,7 @@ class Route implements RouteInterface
     {
         $matches = array();
         if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
-            $callable = array(new $matches[1], $matches[2]);
+            $callable = array($matches[1], $matches[2]);
         }
 
         if (!is_callable($callable)) {


### PR DESCRIPTION
Not sure if this is a document error or a bug but according to the [2.40 release notes](https://github.com/codeguy/Slim/releases/tag/2.4.0) the app will instantiate the controller class when the route is requested.

This is not the case, presently the class is instantiated even if the route is not requested. 
e.g. 
$app->get('/hello/:name', '\Hello:sayHello');
$app->get('/bye/:name', '\GoodBye:sayBye');

If you request `/hello/Josh`, the constructor of both `\Hello` and `\GoodBye` will be triggered. 

To get around this issue I've just moved the instantiation of the class from `setCallable` to `getCallable`
