### PR TITLE
Allow controller passing to notFound and error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - hhvm
 
 script: phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ language: php
 php:
   - 5.3
   - 5.4
+  - 5.5
 
 script: phpunit --coverage-text

--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Exception/Pass.php
+++ b/Slim/Exception/Pass.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Exception/Pass.php
+++ b/Slim/Exception/Pass.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Exception/Stop.php
+++ b/Slim/Exception/Stop.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Exception/Stop.php
+++ b/Slim/Exception/Stop.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Helper/Set.php
+++ b/Slim/Helper/Set.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Helper/Set.php
+++ b/Slim/Helper/Set.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -72,7 +72,7 @@ class Headers extends \Slim\Helper\Set
         foreach ($data as $key => $value) {
             $key = strtoupper($key);
             if (strpos($key, 'X_') === 0 || strpos($key, 'HTTP_') === 0 || in_array($key, static::$special)) {
-                if ($key === 'HTTP_CONTENT_TYPE' || $key === 'HTTP_CONTENT_LENGTH') {
+                if ($key === 'HTTP_CONTENT_LENGTH') {
                     continue;
                 }
                 $results[$key] = $value;

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -209,9 +209,10 @@ class Request
      * the value of the array key if requested; if the array key does not exist, NULL is returned.
      *
      * @param  string           $key
+     * @param  mixed            $default Default return value when key does not exist
      * @return array|mixed|null
      */
-    public function get($key = null)
+    public function get($key = null, $default = null)
     {
         if (!isset($this->env['slim.request.query_hash'])) {
             $output = array();
@@ -226,7 +227,7 @@ class Request
             if (isset($this->env['slim.request.query_hash'][$key])) {
                 return $this->env['slim.request.query_hash'][$key];
             } else {
-                return null;
+                return $default;
             }
         } else {
             return $this->env['slim.request.query_hash'];
@@ -240,10 +241,11 @@ class Request
      * the value of a hash key if requested; if the array key does not exist, NULL is returned.
      *
      * @param  string           $key
+     * @param  mixed            $default Default return value when key does not exist
      * @return array|mixed|null
      * @throws \RuntimeException If environment input is not available
      */
-    public function post($key = null)
+    public function post($key = null, $default = null)
     {
         if (!isset($this->env['slim.input'])) {
             throw new \RuntimeException('Missing slim.input in environment variables');
@@ -266,7 +268,7 @@ class Request
             if (isset($this->env['slim.request.form_hash'][$key])) {
                 return $this->env['slim.request.form_hash'][$key];
             } else {
-                return null;
+                return $default;
             }
         } else {
             return $this->env['slim.request.form_hash'];
@@ -276,31 +278,34 @@ class Request
     /**
      * Fetch PUT data (alias for \Slim\Http\Request::post)
      * @param  string           $key
+     * @param  mixed            $default Default return value when key does not exist
      * @return array|mixed|null
      */
-    public function put($key = null)
+    public function put($key = null, $default = null)
     {
-        return $this->post($key);
+        return $this->post($key, $default);
     }
 
     /**
      * Fetch PATCH data (alias for \Slim\Http\Request::post)
      * @param  string           $key
+     * @param  mixed            $default Default return value when key does not exist
      * @return array|mixed|null
      */
-    public function patch($key = null)
+    public function patch($key = null, $default = null)
     {
-        return $this->post($key);
+        return $this->post($key, $default);
     }
 
     /**
      * Fetch DELETE data (alias for \Slim\Http\Request::post)
      * @param  string           $key
+     * @param  mixed            $default Default return value when key does not exist
      * @return array|mixed|null
      */
-    public function delete($key = null)
+    public function delete($key = null, $default = null)
     {
-        return $this->post($key);
+        return $this->post($key, $default);
     }
 
     /**

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -113,6 +113,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
         415 => '415 Unsupported Media Type',
         416 => '416 Requested Range Not Satisfiable',
         417 => '417 Expectation Failed',
+        418 => '418 I\'m a teapot',
         422 => '422 Unprocessable Entity',
         423 => '423 Locked',
         //Server Error 5xx

--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -224,7 +224,7 @@ class Util
      */
     public static function encodeSecureCookie($value, $expires, $secret, $algorithm, $mode)
     {
-        $key = hash_hmac('sha1', $expires, $secret);
+        $key = hash_hmac('sha1', (string) $expires, $secret);
         $iv = self::getIv($expires, $secret);
         $secureString = base64_encode(
             self::encrypt(

--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Log.php
+++ b/Slim/Log.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Log.php
+++ b/Slim/Log.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/LogWriter.php
+++ b/Slim/LogWriter.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/LogWriter.php
+++ b/Slim/LogWriter.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware.php
+++ b/Slim/Middleware.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware.php
+++ b/Slim/Middleware.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware/ContentTypes.php
+++ b/Slim/Middleware/ContentTypes.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware/ContentTypes.php
+++ b/Slim/Middleware/ContentTypes.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware/Flash.php
+++ b/Slim/Middleware/Flash.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware/Flash.php
+++ b/Slim/Middleware/Flash.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware/MethodOverride.php
+++ b/Slim/Middleware/MethodOverride.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware/MethodOverride.php
+++ b/Slim/Middleware/MethodOverride.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware/PrettyExceptions.php
+++ b/Slim/Middleware/PrettyExceptions.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware/PrettyExceptions.php
+++ b/Slim/Middleware/PrettyExceptions.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware/SessionCookie.php
+++ b/Slim/Middleware/SessionCookie.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Middleware/SessionCookie.php
+++ b/Slim/Middleware/SessionCookie.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -184,7 +184,7 @@ class Route
             $callable = self::stringToCallable($callable);
         }
 
-        if (!is_callable($callable) || $callable === false) {
+        if (!is_callable($callable) && !is_array($callable) || $callable === false) {
             throw new \InvalidArgumentException('Route callable must be callable');
         }
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -143,7 +143,7 @@ class Route
      * @param string $callable
      * @return bool|array
      */
-    public static stringToCallable($callable)
+    public static function stringToCallable($callable)
     {
         $matches = array();
         if (preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -91,15 +91,22 @@ class Route
     protected $middleware = array();
 
     /**
+     * @var bool Whether or not this route should be matched in a case-sensitive manner
+     */
+    protected $caseSensitive;
+
+    /**
      * Constructor
      * @param string $pattern The URL pattern (e.g. "/books/:id")
      * @param mixed $callable Anything that returns TRUE for is_callable()
+     * @param bool $caseSensitive Whether or not this route should be matched in a case-sensitive manner
      */
-    public function __construct($pattern, $callable)
+    public function __construct($pattern, $callable, $caseSensitive = true)
     {
         $this->setPattern($pattern);
         $this->setCallable($callable);
         $this->setConditions(self::getDefaultConditions());
+        $this->caseSensitive = $caseSensitive;
     }
 
     /**
@@ -362,8 +369,14 @@ class Route
             $patternAsRegex .= '?';
         }
 
+        $regex = '#^' . $patternAsRegex . '$#';
+
+        if ($this->caseSensitive === false) {
+            $regex .= 'i';
+        }
+
         //Cache URL params' names and values if this route matches the current HTTP request
-        if (!preg_match('#^' . $patternAsRegex . '$#', $resourceUri, $paramValues)) {
+        if (!preg_match($regex, $resourceUri, $paramValues)) {
             return false;
         }
         foreach ($this->paramNames as $name) {

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -153,11 +153,13 @@ class Route
     public static function stringToCallable($callable)
     {
         $matches = array();
-        if (preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
-            return array($matches[1], $matches[2]);
+        if (preg_match('!^([^\:]+)\:{1,2}([[:alnum:]]+)$!', $callable, $matches)) {
+            $callable = array($matches[1], $matches[2]);
         } else {
-            return false;
+            $callable = false;
         }
+        
+        return $callable;
     }
 
     /**

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -92,8 +92,8 @@ class Route
 
     /**
      * Constructor
-     * @param string $pattern  The URL pattern (e.g. "/books/:id")
-     * @param mixed  $callable Anything that returns TRUE for is_callable()
+     * @param string $pattern The URL pattern (e.g. "/books/:id")
+     * @param mixed $callable Anything that returns TRUE for is_callable()
      */
     public function __construct($pattern, $callable)
     {
@@ -154,8 +154,8 @@ class Route
      */
     public function setCallable($callable)
     {
-        $matches = [];
-        if(is_string($callable) && preg_match('!^([^\:]+)\:\:(.+)$!', $callable, $matches)) {
+        $matches = array();
+        if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
             $callable = array(new $matches[1], $matches[2]);
         }
 
@@ -199,7 +199,7 @@ class Route
      */
     public function setName($name)
     {
-        $this->name = (string) $name;
+        $this->name = (string)$name;
     }
 
     /**
@@ -222,7 +222,7 @@ class Route
 
     /**
      * Get route parameter value
-     * @param  string                    $index     Name of URL parameter
+     * @param  string $index Name of URL parameter
      * @return string
      * @throws \InvalidArgumentException If route parameter does not exist at index
      */
@@ -237,8 +237,8 @@ class Route
 
     /**
      * Set route parameter value
-     * @param  string                    $index     Name of URL parameter
-     * @param  mixed                     $value     The new parameter value
+     * @param  string $index Name of URL parameter
+     * @param  mixed $value The new parameter value
      * @throws \InvalidArgumentException If route parameter does not exist at index
      */
     public function setParam($index, $value)
@@ -356,7 +356,7 @@ class Route
         $patternAsRegex = preg_replace_callback(
             '#:([\w]+)\+?#',
             array($this, 'matchesCallback'),
-            str_replace(')', ')?', (string) $this->pattern)
+            str_replace(')', ')?', (string)$this->pattern)
         );
         if (substr($this->pattern, -1) === '/') {
             $patternAsRegex .= '?';
@@ -368,7 +368,7 @@ class Route
         }
         foreach ($this->paramNames as $name) {
             if (isset($paramValues[$name])) {
-                if (isset($this->paramNamesPath[ $name ])) {
+                if (isset($this->paramNamesPath[$name])) {
                     $this->params[$name] = explode('/', urldecode($paramValues[$name]));
                 } else {
                     $this->params[$name] = urldecode($paramValues[$name]);
@@ -381,17 +381,17 @@ class Route
 
     /**
      * Convert a URL parameter (e.g. ":id", ":id+") into a regular expression
-     * @param  array    $m  URL parameters
+     * @param  array $m URL parameters
      * @return string       Regular expression for URL parameter
      */
     protected function matchesCallback($m)
     {
         $this->paramNames[] = $m[1];
-        if (isset($this->conditions[ $m[1] ])) {
-            return '(?P<' . $m[1] . '>' . $this->conditions[ $m[1] ] . ')';
+        if (isset($this->conditions[$m[1]])) {
+            return '(?P<' . $m[1] . '>' . $this->conditions[$m[1]] . ')';
         }
         if (substr($m[0], -1) === '+') {
-            $this->paramNamesPath[ $m[1] ] = 1;
+            $this->paramNamesPath[$m[1]] = 1;
 
             return '(?P<' . $m[1] . '>.+)';
         }
@@ -401,7 +401,7 @@ class Route
 
     /**
      * Set route name
-     * @param  string     $name The name of the route
+     * @param  string $name The name of the route
      * @return \Slim\Route
      */
     public function name($name)
@@ -413,7 +413,7 @@ class Route
 
     /**
      * Merge route conditions
-     * @param  array      $conditions Key-value array of URL parameter conditions
+     * @param  array $conditions Key-value array of URL parameter conditions
      * @return \Slim\Route
      */
     public function conditions(array $conditions)
@@ -439,6 +439,6 @@ class Route
         }
 
         $return = call_user_func_array($this->getCallable(), array_values($this->getParams()));
-        return ($return === false)? false : true;
+        return ($return === false) ? false : true;
     }
 }

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -166,6 +166,10 @@ class Route
      */
     public function getCallable()
     {
+        if (is_array($this->callable)) {
+            return array(new $this->callable[0], $this->callable[1]);
+        }
+
         return $this->callable;
     }
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -177,7 +177,7 @@ class Route
             $callable = self::stringToCallable($callable);
         }
 
-        if (!is_callable($callable) || $callable === false) {
+        if (!is_callable($callable) && !is_array($callable) || $callable === false) {
             throw new \InvalidArgumentException('Route callable must be callable');
         }
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -156,7 +156,7 @@ class Route
     {
         $matches = [];
         if(is_string($callable) && preg_match('!^([^\:]+)\:\:(.+)$!', $callable, $matches)) {
-            $callable = [new $matches[1], $matches[2]];
+            $callable = array(new $matches[1], $matches[2]);
         }
 
         if (!is_callable($callable)) {

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -137,6 +137,21 @@ class Route
     {
         $this->pattern = $pattern;
     }
+    
+    /**
+     * Parses controller string to an almost callable array
+     * @param string $callable
+     * @return bool|array
+     */
+    public static stringToCallable($callable)
+    {
+        $matches = array();
+        if (preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
+            return array($matches[1], $matches[2]);
+        } else {
+            return false;
+        }
+    }
 
     /**
      * Get route callable
@@ -154,12 +169,11 @@ class Route
      */
     public function setCallable($callable)
     {
-        $matches = array();
-        if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
-            $callable = array(new $matches[1], $matches[2]);
+        if (is_string($callable)) {
+            $callable = self::stringToCallable($callable);
         }
 
-        if (!is_callable($callable)) {
+        if (!is_callable($callable) || $callable === false) {
             throw new \InvalidArgumentException('Route callable must be callable');
         }
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -150,7 +150,7 @@ class Route
      * @param string $callable
      * @return bool|array
      */
-    public static stringToCallable($callable)
+    public static function stringToCallable($callable)
     {
         $matches = array();
         if (preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -144,6 +144,21 @@ class Route
     {
         $this->pattern = $pattern;
     }
+    
+    /**
+     * Parses controller string to an almost callable array
+     * @param string $callable
+     * @return bool|array
+     */
+    public static stringToCallable($callable)
+    {
+        $matches = array();
+        if (preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
+            return array($matches[1], $matches[2]);
+        } else {
+            return false;
+        }
+    }
 
     /**
      * Get route callable
@@ -161,12 +176,11 @@ class Route
      */
     public function setCallable($callable)
     {
-        $matches = array();
-        if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
-            $callable = array(new $matches[1], $matches[2]);
+        if (is_string($callable)) {
+            $callable = self::stringToCallable($callable);
         }
 
-        if (!is_callable($callable)) {
+        if (!is_callable($callable) || $callable === false) {
             throw new \InvalidArgumentException('Route callable must be callable');
         }
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -154,6 +154,11 @@ class Route
      */
     public function setCallable($callable)
     {
+        $matches = [];
+        if(is_string($callable) && preg_match('!^([^\:]+)\:\:(.+)$!', $callable, $matches)) {
+            $callable = [new $matches[1], $matches[2]];
+        }
+
         if (!is_callable($callable)) {
             throw new \InvalidArgumentException('Route callable must be callable');
         }

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -159,6 +159,10 @@ class Route
      */
     public function getCallable()
     {
+        if (is_array($this->callable)) {
+            return array(new $this->callable[0], $this->callable[1]);
+        }
+
         return $this->callable;
     }
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -636,7 +636,7 @@ class Slim
             $this->error = Route::stringToCallable($argument);
         }
         
-        if (!is_callable($this->error) && !is_array($this->error) {
+        if (!is_callable($this->error) && !is_array($this->error)) {
             //Invoke error handler
             $this->response->status(500);
             $this->response->body('');

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -638,7 +638,7 @@ class Slim
             $this->error = Route::stringToCallable($argument);
         }
         
-        if (!is_callable($this->error) && !is_array($this->error) {
+        if (!is_callable($this->error) && !is_array($this->error)) {
             //Invoke error handler
             $this->response->status(500);
             $this->response->body('');

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -744,7 +744,6 @@ class Slim
         if (!is_null($status)) {
             $this->response->status($status);
         }
-        $this->view->setTemplatesDirectory($this->config('templates.path'));
         $this->view->appendData($data);
         $this->view->display($template);
     }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE
@@ -54,7 +54,7 @@ class Slim
     /**
      * @const string
      */
-    const VERSION = '2.4.0';
+    const VERSION = '2.4.2';
 
     /**
      * @var \Slim\Helper\Set

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE
@@ -54,7 +54,7 @@ class Slim
     /**
      * @const string
      */
-    const VERSION = '2.3.5';
+    const VERSION = '2.4.0';
 
     /**
      * @var \Slim\Helper\Set

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -591,9 +591,11 @@ class Slim
             $this->notFound = $callable;
         } elseif (is_string($callable)) {
             $this->notFound = Route::stringToCallable($callable);
-        }
-        
-        if (!is_callable($this->notFound) && !is_array($this->notFound)) {
+            
+            if (!$this->error) {
+                throw new \Slim\Exception\Stop();
+            }
+        } else {
             ob_start();
             if (is_callable($this->notFound)) {
                 call_user_func($this->notFound);
@@ -636,10 +638,11 @@ class Slim
             $this->error = $argument;
         } elseif (is_string($argument)) {
             $this->error = Route::stringToCallable($argument);
-        }
-        
-        if (!is_callable($this->error) && !is_array($this->error)) {
-            //Invoke error handler
+            
+            if (!$this->error) {
+                throw new \Slim\Exception\Stop();
+            }
+        } else {
             $this->response->status(500);
             $this->response->body('');
             $this->response->write($this->callErrorHandler($argument));

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -591,7 +591,9 @@ class Slim
             $this->notFound = $callable;
         } elseif (is_string($callable)) {
             $this->notFound = Route::stringToCallable($callable);
-        } else {
+        }
+        
+        if (!is_callable($this->notFound) && !is_array($this->notFound)) {
             ob_start();
             if (is_callable($this->notFound)) {
                 call_user_func($this->notFound);

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -569,7 +569,7 @@ class Slim
      *
      * 1. When declaring the handler:
      *
-     * If the $callable parameter is not null and is callable, this
+     * If the $callable parameter is not null and is callable or string, this
      * method will register the callable to be invoked when no
      * routes match the current HTTP request. It WILL NOT invoke the callable.
      *
@@ -581,15 +581,20 @@ class Slim
      * whose body is the output of the Not Found handler.
      *
      * @param  mixed $callable Anything that returns true for is_callable()
+     * @throws \InvalidArgumentException When string $callable is not a valid controller
      */
     public function notFound ($callable = null)
     {
         if (is_callable($callable)) {
             $this->notFound = $callable;
+        } elseif (is_string($callable)) {
+            $this->notFound = Route::stringToCallable($callable);
         } else {
             ob_start();
             if (is_callable($this->notFound)) {
                 call_user_func($this->notFound);
+            } elseif (is_array($this->notFound)) {
+                call_user_func(array(new $this->notFound[0], $this->notFound[1]));
             } else {
                 call_user_func(array($this, 'defaultNotFound'));
             }
@@ -625,6 +630,8 @@ class Slim
         if (is_callable($argument)) {
             //Register error handler
             $this->error = $argument;
+        } elseif (is_string($argument)) {
+            $this->error = Route::stringToCallable($argument);
         } else {
             //Invoke error handler
             $this->response->status(500);
@@ -648,6 +655,8 @@ class Slim
         ob_start();
         if (is_callable($this->error)) {
             call_user_func_array($this->error, array($argument));
+        } elseif (is_array($this->error)) {
+            call_user_func(array(new $this->error[0], $this->error[1]));
         } else {
             call_user_func_array(array($this, 'defaultError'), array($argument));
         }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -634,7 +634,9 @@ class Slim
             $this->error = $argument;
         } elseif (is_string($argument)) {
             $this->error = Route::stringToCallable($argument);
-        } else {
+        }
+        
+        if (!is_callable($this->error) && !is_array($this->error) {
             //Invoke error handler
             $this->response->status(500);
             $this->response->body('');

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -40,9 +40,14 @@ if (!extension_loaded('mcrypt')) {
 
 /**
  * Slim
- * @package Slim
- * @author  Josh Lockhart
- * @since   1.0.0
+ * @package  Slim
+ * @author   Josh Lockhart
+ * @since    1.0.0
+ *
+ * @property $environment \Slim\Environment
+ * @property $response    \Slim\Http\Response
+ * @property $request     \Slim\Http\Request
+ * @property $router      \Slim\Router
  */
 class Slim
 {

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -44,10 +44,10 @@ if (!extension_loaded('mcrypt')) {
  * @author   Josh Lockhart
  * @since    1.0.0
  *
- * @property $environment \Slim\Environment
- * @property $response    \Slim\Http\Response
- * @property $request     \Slim\Http\Request
- * @property $router      \Slim\Router
+ * @property \Slim\Environment   $environment
+ * @property \Slim\Http\Response $response
+ * @property \Slim\Http\Request  $request
+ * @property \Slim\Router        $router
  */
 class Slim
 {

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -308,7 +308,9 @@ class Slim
             'cookies.cipher' => MCRYPT_RIJNDAEL_256,
             'cookies.cipher_mode' => MCRYPT_MODE_CBC,
             // HTTP
-            'http.version' => '1.1'
+            'http.version' => '1.1',
+            // Routing
+            'routes.case_sensitive' => true
         );
     }
 
@@ -434,7 +436,7 @@ class Slim
     {
         $pattern = array_shift($args);
         $callable = array_pop($args);
-        $route = new \Slim\Route($pattern, $callable);
+        $route = new \Slim\Route($pattern, $callable, $this->settings['routes.case_sensitive']);
         $this->router->map($route);
         if (count($args) > 0) {
             $route->setMiddleware($args);

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -571,7 +571,7 @@ class Slim
      *
      * 1. When declaring the handler:
      *
-     * If the $callable parameter is not null and is callable, this
+     * If the $callable parameter is not null and is callable or string, this
      * method will register the callable to be invoked when no
      * routes match the current HTTP request. It WILL NOT invoke the callable.
      *
@@ -583,15 +583,20 @@ class Slim
      * whose body is the output of the Not Found handler.
      *
      * @param  mixed $callable Anything that returns true for is_callable()
+     * @throws \InvalidArgumentException When string $callable is not a valid controller
      */
     public function notFound ($callable = null)
     {
         if (is_callable($callable)) {
             $this->notFound = $callable;
+        } elseif (is_string($callable)) {
+            $this->notFound = Route::stringToCallable($callable);
         } else {
             ob_start();
             if (is_callable($this->notFound)) {
                 call_user_func($this->notFound);
+            } elseif (is_array($this->notFound)) {
+                call_user_func(array(new $this->notFound[0], $this->notFound[1]));
             } else {
                 call_user_func(array($this, 'defaultNotFound'));
             }
@@ -627,6 +632,8 @@ class Slim
         if (is_callable($argument)) {
             //Register error handler
             $this->error = $argument;
+        } elseif (is_string($argument)) {
+            $this->error = Route::stringToCallable($argument);
         } else {
             //Invoke error handler
             $this->response->status(500);
@@ -650,6 +657,8 @@ class Slim
         ob_start();
         if (is_callable($this->error)) {
             call_user_func_array($this->error, array($argument));
+        } elseif (is_array($this->error)) {
+            call_user_func(array(new $this->error[0], $this->error[1]));
         } else {
             call_user_func_array(array($this, 'defaultError'), array($argument));
         }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -632,7 +632,9 @@ class Slim
             $this->error = $argument;
         } elseif (is_string($argument)) {
             $this->error = Route::stringToCallable($argument);
-        } else {
+        }
+        
+        if (!is_callable($this->error) && !is_array($this->error) {
             //Invoke error handler
             $this->response->status(500);
             $this->response->body('');

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -177,8 +177,11 @@ class Slim
         // Default view
         $this->container->singleton('view', function ($c) {
             $viewClass = $c['settings']['view'];
+            $templatesPath = $c['settings']['templates.path'];
 
-            return ($viewClass instanceOf \Slim\View) ? $viewClass : new $viewClass;
+            $view = ($viewClass instanceOf \Slim\View) ? $viewClass : new $viewClass;
+            $view->setTemplatesDirectory($templatesPath);
+            return $view;
         });
 
         // Default log writer

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -589,7 +589,9 @@ class Slim
             $this->notFound = $callable;
         } elseif (is_string($callable)) {
             $this->notFound = Route::stringToCallable($callable);
-        } else {
+        }
+        
+        if (!is_callable($this->notFound) && !is_array($this->notFound)) {
             ob_start();
             if (is_callable($this->notFound)) {
                 call_user_func($this->notFound);

--- a/Slim/View.php
+++ b/Slim/View.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/View.php
+++ b/Slim/View.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  * @package     Slim
  *
  * MIT LICENSE

--- a/Slim/View.php
+++ b/Slim/View.php
@@ -236,20 +236,23 @@ class View
      * This method echoes the rendered template to the current output buffer
      *
      * @param  string   $template   Pathname of template file relative to templates directory
+     * @param  array    $data       Any additonal data to be passed to the template.
      */
-    public function display($template)
+    public function display($template, $data = null)
     {
-        echo $this->fetch($template);
+        echo $this->fetch($template, $data);
     }
 
     /**
      * Return the contents of a rendered template file
-     * @var    string $template The template pathname, relative to the template base directory
-     * @return string           The rendered template
+     *
+     * @param    string $template   The template pathname, relative to the template base directory
+     * @param    array  $data       Any additonal data to be passed to the template.
+     * @return string               The rendered template
      */
-    public function fetch($template)
+    public function fetch($template, $data = null)
     {
-        return $this->render($template);
+        return $this->render($template, $data);
     }
 
     /**
@@ -257,17 +260,20 @@ class View
      *
      * NOTE: This method should be overridden by custom view subclasses
      *
-     * @var    string $template     The template pathname, relative to the template base directory
+     * @param  string $template     The template pathname, relative to the template base directory
+     * @param  array  $data         Any additonal data to be passed to the template.
      * @return string               The rendered template
      * @throws \RuntimeException    If resolved template pathname is not a valid file
      */
-    protected function render($template)
+    protected function render($template, $data = null)
     {
         $templatePathname = $this->getTemplatePathname($template);
         if (!is_file($templatePathname)) {
             throw new \RuntimeException("View cannot render `$template` because the template does not exist");
         }
-        extract($this->data->all());
+
+        $data = array_merge($this->data->all(), (array) $data);
+        extract($data);
         ob_start();
         require $templatePathname;
 

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,10 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
-        "ext-mcrypt": "*"
+        "php": ">=5.3.0"
+    },
+    "suggest": {
+        "ext-mcrypt": "Required for HTTP cookie encryption"
     },
     "autoload": {
         "psr-0": { "Slim": "." }

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -277,10 +277,8 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
      */
     public function testUnsetsContentTypeAndContentLength()
     {
-        $_SERVER['HTTP_CONTENT_TYPE'] = 'text/csv';
         $_SERVER['HTTP_CONTENT_LENGTH'] = 150;
         $env = \Slim\Environment::getInstance(true);
-        $this->assertFalse(isset($env['HTTP_CONTENT_TYPE']));
         $this->assertFalse(isset($env['HTTP_CONTENT_LENGTH']));
     }
 

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Helper/SetTest.php
+++ b/tests/Helper/SetTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Helper/SetTest.php
+++ b/tests/Helper/SetTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Http/CookiesTest.php
+++ b/tests/Http/CookiesTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Http/CookiesTest.php
+++ b/tests/Http/CookiesTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Http/HeadersTest.php
+++ b/tests/Http/HeadersTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Http/HeadersTest.php
+++ b/tests/Http/HeadersTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -531,6 +531,19 @@ class RequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test get content type with built-in server
+     */
+    public function testGetContentTypeWithBuiltInServer()
+    {
+        $env = \Slim\Environment::mock(array(
+            'slim.input' => '',
+            'HTTP_CONTENT_TYPE' => 'application/json; charset=ISO-8859-4'
+        ));
+        $req = new \Slim\Http\Request($env);
+        $this->assertEquals('application/json; charset=ISO-8859-4', $req->getContentType());
+    }
+
+    /**
      * Test get media type
      */
     public function testGetMediaTypeWhenExists()

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -221,6 +221,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(3, count($req->get()));
         $this->assertEquals('1', $req->get('one'));
         $this->assertNull($req->get('foo'));
+        $this->assertFalse($req->get('foo', false));
     }
 
     /**
@@ -236,6 +237,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(3, count($req->get()));
         $this->assertEquals('1', $req->get('one'));
         $this->assertNull($req->get('foo'));
+        $this->assertFalse($req->get('foo', false));
     }
 
     /**
@@ -253,6 +255,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($req->post()));
         $this->assertEquals('bar', $req->post('foo'));
         $this->assertNull($req->post('xyz'));
+        $this->assertFalse($req->post('xyz', false));
     }
 
     /**
@@ -271,6 +274,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2, count($req->post()));
         $this->assertEquals('bar', $req->post('foo'));
         $this->assertNull($req->post('xyz'));
+        $this->assertFalse($req->post('xyz', false));
     }
 
     /**
@@ -319,6 +323,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $req->put('foo'));
         $this->assertEquals('bar', $req->params('foo'));
         $this->assertNull($req->put('xyz'));
+        $this->assertFalse($req->put('xyz', false));
     }
 
     /**
@@ -337,6 +342,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $req->patch('foo'));
         $this->assertEquals('bar', $req->params('foo'));
         $this->assertNull($req->patch('xyz'));
+        $this->assertFalse($req->patch('xyz', false));
     }
 
     /**
@@ -355,6 +361,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $req->delete('foo'));
         $this->assertEquals('bar', $req->params('foo'));
         $this->assertNull($req->delete('xyz'));
+        $this->assertFalse($req->delete('xyz', false));
     }
 
     /**

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -508,6 +508,19 @@ class RequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test get content type for built-in PHP server
+     */
+    public function testGetContentTypeForBuiltInServer()
+    {
+        $env = \Slim\Environment::mock(array(
+            'slim.input' => '',
+            'HTTP_CONTENT_TYPE' => 'application/json; charset=ISO-8859-4'
+        ));
+        $req = new \Slim\Http\Request($env);
+        $this->assertEquals('application/json; charset=ISO-8859-4', $req->getContentType());
+    }
+
+    /**
      * Test get content type
      */
     public function testGetContentTypeWhenNotExists()

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Http/UtilTest.php
+++ b/tests/Http/UtilTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Http/UtilTest.php
+++ b/tests/Http/UtilTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/LogTest.php
+++ b/tests/LogTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/LogTest.php
+++ b/tests/LogTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/LogWriterTest.php
+++ b/tests/LogWriterTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/LogWriterTest.php
+++ b/tests/LogWriterTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Middleware/ContentTypesTest.php
+++ b/tests/Middleware/ContentTypesTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Middleware/ContentTypesTest.php
+++ b/tests/Middleware/ContentTypesTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Middleware/FlashTest.php
+++ b/tests/Middleware/FlashTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Middleware/FlashTest.php
+++ b/tests/Middleware/FlashTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Middleware/MethodOverrideTest.php
+++ b/tests/Middleware/MethodOverrideTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Middleware/MethodOverrideTest.php
+++ b/tests/Middleware/MethodOverrideTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Middleware/PrettyExceptionsTest.php
+++ b/tests/Middleware/PrettyExceptionsTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Middleware/PrettyExceptionsTest.php
+++ b/tests/Middleware/PrettyExceptionsTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/Middleware/SessionCookieTest.php
+++ b/tests/Middleware/SessionCookieTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/Middleware/SessionCookieTest.php
+++ b/tests/Middleware/SessionCookieTest.php
@@ -135,6 +135,7 @@ class SessionCookieTest extends PHPUnit_Framework_TestCase
 
         $logWriter->expects($this->once())
             ->method('write');
+        $oldLevel = error_reporting(E_ALL);
 
         $app = new \Slim\Slim(array(
             'log.writer' => $logWriter
@@ -149,6 +150,8 @@ class SessionCookieTest extends PHPUnit_Framework_TestCase
         $mw->setNextMiddleware($app);
         $mw->call();
         $this->assertEquals(array(), $_SESSION);
+
+        error_reporting($oldLevel);
     }
 
     /**

--- a/tests/Middleware/SessionCookieTest.php
+++ b/tests/Middleware/SessionCookieTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/MiddlewareTest.php
+++ b/tests/MiddlewareTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -69,11 +69,19 @@ class RouteTest extends PHPUnit_Framework_TestCase
 
     public function testGetCallableAsClass()
     {
-        $route = new \Slim\Route('/foo', '\Slim\Router::getCurrentRoute');
+        $route = new \Slim\Route('/foo', '\Slim\Router:getCurrentRoute');
 
         $callable = $route->getCallable();
         $this->assertInstanceOf('\Slim\Router', $callable[0]);
         $this->assertEquals('getCurrentRoute', $callable[1]);
+    }
+
+    public function testGetCallableAsStaticMethod()
+    {
+        $route = new \Slim\Route('/bar', '\Slim\Slim::getInstance');
+
+        $callable = $route->getCallable();
+        $this->assertEquals('\Slim\Slim::getInstance', $callable);
     }
 
     public function testSetCallable()

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -67,6 +67,15 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $this->assertSame($callable, $route->getCallable());
     }
 
+    public function testGetCallableAsClass()
+    {
+        $route = new \Slim\Route('/foo', '\Slim\Router::getCurrentRoute');
+
+        $callable = $route->getCallable();
+        $this->assertInstanceOf('\Slim\Router', $callable[0]);
+        $this->assertEquals('getCurrentRoute', $callable[1]);
+    }
+
     public function testSetCallable()
     {
         $callable = function () {

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -81,7 +81,8 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $route = new \Slim\Route('/bar', '\Slim\Slim::getInstance');
 
         $callable = $route->getCallable();
-        $this->assertEquals('\Slim\Slim::getInstance', $callable);
+        $this->assertInstanceOf('\Slim\Slim', $callable[0]);
+        $this->assertEquals('getInstance', $callable[1]);
     }
 
     public function testSetCallable()

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -272,6 +272,20 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array('year' => '2010', 'month' => '05', 'day' => '13'), $route3->getParams());
     }
 
+    public function testMatchesIsCaseSensitiveByDefault()
+    {
+        $route = new \Slim\Route('/case/sensitive', function () {});
+        $this->assertTrue($route->matches('/case/sensitive'));
+        $this->assertFalse($route->matches('/CaSe/SensItiVe'));
+    }
+
+    public function testMatchesCanBeCaseInsensitive()
+    {
+        $route = new \Slim\Route('/Case/Insensitive', function () {}, false);
+        $this->assertTrue($route->matches('/Case/Insensitive'));
+        $this->assertTrue($route->matches('/CaSe/iNSensItiVe'));
+    }
+
     public function testGetConditions()
     {
         $route = new \Slim\Route('/foo', function () {});

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -495,6 +495,22 @@ class SlimTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests if route will match in case-insensitive manner if configured to do so
+     */
+    public function testRouteMatchesInCaseInsensitiveMannerIfConfigured()
+    {
+        \Slim\Environment::mock(array(
+            'PATH_INFO' => '/BaR', // Does not match route case
+        ));
+        $s = new \Slim\Slim(array('routes.case_sensitive' => false));
+        $route = $s->get('/bar', function () { echo "xyz"; });
+        $s->call();
+        $this->assertEquals(200, $s->response()->status());
+        $this->assertEquals('xyz', $s->response()->body());
+        $this->assertEquals('/bar', $route->getPattern());
+    }
+
+    /**
      * Test if route contains URL encoded characters
      */
     public function testRouteWithUrlEncodedCharacters()

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -552,6 +552,16 @@ class SlimTest extends PHPUnit_Framework_TestCase
      ************************************************/
 
     /**
+     * Test template path is passed to view
+     */
+    public function testViewGetsTemplatesPath()
+    {
+        $path = dirname(__FILE__) . '/templates';
+        $s = new \Slim\Slim(array('templates.path' => $path));
+        $this->assertEquals($s->view->getTemplatesDirectory(), $path);
+    }
+
+    /**
      * Test render with template and data
      */
     public function testRenderTemplateWithData()

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -33,7 +33,7 @@
 //Mock custom view
 class CustomView extends \Slim\View
 {
-    public function render($template) { echo "Custom view"; }
+    public function render($template, $data = null) { echo "Custom view"; }
 }
 
 //Echo Logger

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.0
+ * @version     2.4.2
  *
  * MIT LICENSE
  *

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.3.5
+ * @version     2.4.0
  *
  * MIT LICENSE
  *

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -115,6 +115,21 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar'), $prop->getValue($view)->all());
     }
 
+    public function testLocalData()
+    {
+        $view = new \Slim\View();
+        $prop1 = new \ReflectionProperty($view, 'data');
+        $prop1->setAccessible(true);
+        $prop1->setValue($view, new \Slim\Helper\Set(array('foo' => 'bar')));
+
+        $prop2 = new \ReflectionProperty($view, 'templatesDirectory');
+        $prop2->setAccessible(true);
+        $prop2->setValue($view, dirname(__FILE__) . '/templates');
+
+        $output = $view->fetch('test.php', array('foo' => 'baz'));
+        $this->assertEquals('test output baz', $output);
+    }
+
     public function testAppendDataOverwrite()
     {
         $view = new \Slim\View();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,9 @@
 <?php
 set_include_path(dirname(__FILE__) . '/../' . PATH_SEPARATOR . get_include_path());
 
+// Set default timezone
+date_default_timezone_set('America/New_York');
+
 require_once 'Slim/Slim.php';
 
 // Register Slim's autoloader


### PR DESCRIPTION
This PR adds functionality to allow the user to pass a controller instead of a callable to `notFound` and `error` methods.

Adresses #741. Includes changes from #739.
