### PR TITLE
Allow underscores in method names for controllers

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -155,7 +155,7 @@ class Route
     public function setCallable($callable)
     {
         $matches = array();
-        if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
+        if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]_]+)$!', $callable, $matches)) {
             $callable = array(new $matches[1], $matches[2]);
         }
 


### PR DESCRIPTION
This adds an underscore to the regex used to compose the $callable variable to match cases where the method name contains an underscore.
