### PR TITLE
Allow passing controllers to error and notFound

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -144,6 +144,23 @@ class Route
     {
         $this->pattern = $pattern;
     }
+    
+    /**
+     * Parses controller string to an almost callable array
+     * @param string $callable
+     * @return bool|array
+     */
+    public static function stringToCallable($callable)
+    {
+        $matches = array();
+        if (preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
+            $callable = array($matches[1], $matches[2]);
+        } else {
+            $callable = false;
+        }
+        
+        return $callable;
+    }
 
     /**
      * Get route callable
@@ -151,6 +168,9 @@ class Route
      */
     public function getCallable()
     {
+        if (is_array($this->callable)) {
+            $this->callable = array(new $this->callable[0], $this->callable[1]);
+        }
         return $this->callable;
     }
 
@@ -161,12 +181,11 @@ class Route
      */
     public function setCallable($callable)
     {
-        $matches = array();
-        if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
-            $callable = array(new $matches[1], $matches[2]);
+        if (is_string($callable) && !is_callable($callable)) {
+            $callable = self::stringToCallable($callable);
         }
 
-        if (!is_callable($callable)) {
+        if (!is_callable($callable) && !is_array($callable) || $callable === false) {
             throw new \InvalidArgumentException('Route callable must be callable');
         }
 

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -598,10 +598,10 @@ class Slim
             $this->notFound = $callable;
         } else {
             ob_start();
-            if (is_callable($this->notFound)) {
-                call_user_func($this->notFound);
-            } else if (is_array($this->notFound)) {
+            if (is_array($this->notFound)) {
                 call_user_func(array(new $this->notFound[0], $this->notFound[1]));
+            } else if (is_callable($this->notFound)) {
+                call_user_func($this->notFound);
             } else {
                 call_user_func(array($this, 'defaultNotFound'));
             }
@@ -666,10 +666,11 @@ class Slim
     protected function callErrorHandler($argument = null)
     {
         ob_start();
-        if (is_callable($this->error)) {
-            call_user_func_array($this->error, array($argument));
-        } else if (is_array($this->error)) {
+        
+        if (is_array($this->error)) {
             call_user_func_array(array(new $this->error[0], $this->error[1]), array($argument));
+        } else if (is_callable($this->error)) {
+            call_user_func_array($this->error, array($argument));
         } else {
             call_user_func_array(array($this, 'defaultError'), array($argument));
         }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -588,10 +588,20 @@ class Slim
     {
         if (is_callable($callable)) {
             $this->notFound = $callable;
+        } else if (is_string($callable)) {
+            $callable = Route::stringToCallable($callable);
+            
+            if (!$callable) {
+                throw new \Slim\Exception\Stop();
+            }
+            
+            $this->notFound = $callable;
         } else {
             ob_start();
             if (is_callable($this->notFound)) {
                 call_user_func($this->notFound);
+            } else if (is_array($this->notFound)) {
+                call_user_func(array(new $this->notFound[0], $this->notFound[1]));
             } else {
                 call_user_func(array($this, 'defaultNotFound'));
             }
@@ -627,6 +637,14 @@ class Slim
         if (is_callable($argument)) {
             //Register error handler
             $this->error = $argument;
+        } else if (is_string($argument)) {
+            $argument = Route::stringToCallable($argument);
+            
+            if (!$argument) {
+                throw new \Slim\Exception\Stop();
+            }
+            
+            $this->error = $argument;
         } else {
             //Invoke error handler
             $this->response->status(500);
@@ -650,6 +668,8 @@ class Slim
         ob_start();
         if (is_callable($this->error)) {
             call_user_func_array($this->error, array($argument));
+        } else if (is_array($this->error)) {
+            call_user_func_array(array(new $this->error[0], $this->error[1]), array($argument));
         } else {
             call_user_func_array(array($this, 'defaultError'), array($argument));
         }

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -1413,6 +1413,13 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $errCallback = function () { echo "404"; };
         $s->error($errCallback);
         $this->assertSame($errCallback, PHPUnit_Framework_Assert::readAttribute($s, 'error'));
+        
+        $s = new \Slim\Slim();
+        $s->error('\Slim\Slim:error');
+        $error = PHPUnit_Framework_Assert::readAttribute($s, 'error');
+
+        $this->assertEquals('\Slim\Slim', $error[0]);
+        $this->assertEquals('error', $error[1]);
     }
 
     /**
@@ -1433,6 +1440,13 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $notFoundCallback = function () { echo "404"; };
         $s->notFound($notFoundCallback);
         $this->assertSame($notFoundCallback, PHPUnit_Framework_Assert::readAttribute($s, 'notFound'));
+        
+        $s = new \Slim\Slim();
+        $s->notFound('\Slim\Slim:notFound');
+        $error = PHPUnit_Framework_Assert::readAttribute($s, 'notFound');
+
+        $this->assertEquals('\Slim\Slim', $error[0]);
+        $this->assertEquals('notFound', $error[1]);
     }
 
     /**
@@ -1443,6 +1457,15 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s = new \Slim\Slim();
         $notFoundCallback = 'foo';
         $s->notFound($notFoundCallback);
+    }
+    
+    public function testErrorHandlerWithController() {
+        $s = new \Slim\Slim();
+        $s->error('\Slim\Slim:error');
+        $error = PHPUnit_Framework_Assert::readAttribute($s, 'error');
+
+        $this->assertEquals('\Slim\Slim', $error[0]);
+        $this->assertEquals('error', $error[1]);
     }
 
     /************************************************

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -1415,11 +1415,23 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $this->assertSame($errCallback, PHPUnit_Framework_Assert::readAttribute($s, 'error'));
         
         $s = new \Slim\Slim();
-        $s->error('\Slim\Slim:error');
+        $s->error('\Slim\Slim:defaultError');
         $error = PHPUnit_Framework_Assert::readAttribute($s, 'error');
 
         $this->assertEquals('\Slim\Slim', $error[0]);
-        $this->assertEquals('error', $error[1]);
+        $this->assertEquals('defaultError', $error[1]);
+        $exceptionThrown = false;
+        try {
+            $s->error();
+        } catch (\Slim\Exception\Stop $e) {
+            $exceptionThrown = true;
+        }
+        
+        $this->assertEquals(true, $exceptionThrown);
+        $this->assertNotEquals(
+            false,
+            strpos($s->response->body(), '<title>Error</title>')
+        );
     }
 
     /**
@@ -1442,11 +1454,23 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $this->assertSame($notFoundCallback, PHPUnit_Framework_Assert::readAttribute($s, 'notFound'));
         
         $s = new \Slim\Slim();
-        $s->notFound('\Slim\Slim:notFound');
+        $s->notFound('\Slim\Slim:defaultNotFound');
         $error = PHPUnit_Framework_Assert::readAttribute($s, 'notFound');
 
         $this->assertEquals('\Slim\Slim', $error[0]);
-        $this->assertEquals('notFound', $error[1]);
+        $this->assertEquals('defaultNotFound', $error[1]);
+        $exceptionThrown = false;
+        try {
+            $s->notFound();
+        } catch (\Slim\Exception\Stop $e) {
+            $exceptionThrown = true;
+        }
+        
+        $this->assertEquals(true, $exceptionThrown);
+        $this->assertNotEquals(
+            false,
+            strpos($s->response->body(), '<title>404 Page Not Found</title>')
+        );
     }
 
     /**
@@ -1457,15 +1481,6 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s = new \Slim\Slim();
         $notFoundCallback = 'foo';
         $s->notFound($notFoundCallback);
-    }
-    
-    public function testErrorHandlerWithController() {
-        $s = new \Slim\Slim();
-        $s->error('\Slim\Slim:error');
-        $error = PHPUnit_Framework_Assert::readAttribute($s, 'error');
-
-        $this->assertEquals('\Slim\Slim', $error[0]);
-        $this->assertEquals('error', $error[1]);
     }
 
     /************************************************


### PR DESCRIPTION
This PR adds functionality to allow the user to pass a controller instead of a callable to notFound and error methods.

Adresses #741.
