### PR TITLE
Slim instance as parameter in controller constructor

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -99,9 +99,9 @@ class Route
      * Constructor
      * @param string $pattern The URL pattern (e.g. "/books/:id")
      * @param mixed $callable Anything that returns TRUE for is_callable()
-     * @param \Slim\Slim $application
+     * @param \Slim\Slim|null $application The primary Slim application instance
      */
-    public function __construct($pattern, $callable, $application)
+    public function __construct($pattern, $callable, $application = null)
     {
         $this->setApplication($application);
         $this->setPattern($pattern);
@@ -140,13 +140,26 @@ class Route
      * Set application
      *
      * This method injects the primary Slim application instance into
-     * this middleware.
+     * this class.
      *
      * @param  \Slim\Slim $application
      */
     public function setApplication($application)
     {
         $this->app = $application;
+    }
+
+    /**
+     * Get application
+     *
+     * This method retrieves the application previously injected
+     * into this class.
+     *
+     * @return \Slim\Slim
+     */
+    public function getApplication()
+    {
+        return $this->app;
     }
 
     /**

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -51,6 +51,11 @@ class Route
     protected $callable;
 
     /**
+     * @var \Slim\Slim Reference to the primary application instance
+     */
+    protected $app;
+
+    /**
      * @var array Conditions for this route's URL parameters
      */
     protected $conditions = array();
@@ -94,9 +99,11 @@ class Route
      * Constructor
      * @param string $pattern The URL pattern (e.g. "/books/:id")
      * @param mixed $callable Anything that returns TRUE for is_callable()
+     * @param \Slim\Slim $application
      */
-    public function __construct($pattern, $callable)
+    public function __construct($pattern, $callable, $application)
     {
+        $this->setApplication($application);
         $this->setPattern($pattern);
         $this->setCallable($callable);
         $this->setConditions(self::getDefaultConditions());
@@ -130,6 +137,19 @@ class Route
     }
 
     /**
+     * Set application
+     *
+     * This method injects the primary Slim application instance into
+     * this middleware.
+     *
+     * @param  \Slim\Slim $application
+     */
+    public function setApplication($application)
+    {
+        $this->app = $application;
+    }
+
+    /**
      * Set route pattern
      * @param  string $pattern
      */
@@ -156,7 +176,7 @@ class Route
     {
         $matches = array();
         if (is_string($callable) && preg_match('!^([^\:]+)\:([[:alnum:]]+)$!', $callable, $matches)) {
-            $callable = array(new $matches[1], $matches[2]);
+            $callable = array(new $matches[1]($this->app), $matches[2]);
         }
 
         if (!is_callable($callable)) {

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -434,7 +434,7 @@ class Slim
     {
         $pattern = array_shift($args);
         $callable = array_pop($args);
-        $route = new \Slim\Route($pattern, $callable);
+        $route = new \Slim\Route($pattern, $callable, $this);
         $this->router->map($route);
         if (count($args) > 0) {
             $route->setMiddleware($args);

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -76,6 +76,18 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('getCurrentRoute', $callable[1]);
     }
 
+    public function testGetCallableAsClassPassingApp()
+    {   
+        $app = new \Slim\Slim();
+        $route = new \Slim\Route('/foo', '\Slim\Router:getCurrentRoute', $app);
+
+        $callable = $route->getCallable();
+        $application = $route->getApplication();
+        $this->assertInstanceOf('\Slim\Router', $callable[0]);
+        $this->assertEquals('getCurrentRoute', $callable[1]);
+        $this->assertInstanceOf('\Slim\Slim', $application);
+    }
+
     public function testGetCallableAsStaticMethod()
     {
         $route = new \Slim\Route('/bar', '\Slim\Slim::getInstance');

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -78,8 +78,8 @@ class RouteTest extends PHPUnit_Framework_TestCase
 
     public function testGetCallableAsClassPassingApp()
     {   
-        $app = new \Slim\Slim();
-        $route = new \Slim\Route('/foo', '\Slim\Router:getCurrentRoute', $app);
+        $s = new \Slim\Slim();
+        $route = new \Slim\Route('/foo', '\Slim\Router:getCurrentRoute', $s);
 
         $callable = $route->getCallable();
         $application = $route->getApplication();

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -77,7 +77,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
     }
 
     public function testGetCallableAsClassPassingApp()
-    {   
+    {
         $s = new \Slim\Slim();
         $route = new \Slim\Route('/foo', '\Slim\Router:getCurrentRoute', $s);
 


### PR DESCRIPTION
This PR addresses issue #748 by passing the \Slim\Slim application object to the controller constructor.

Just add something like the following to your controller class and \Slim\Slim object will be available within your controllers.

``` php
/**
 * Constructor
 * @param \Slim\Slim $application The Slim application
 */
public function __construct(\Slim\Slim $application)
{
    $this->app = $application;
}
```
