### PR TITLE
always merge settings if 1st parameter is an array

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -335,16 +335,16 @@ class Slim
      */
     public function config($name, $value = null)
     {
-        if (func_num_args() === 1) {
-            if (is_array($name)) {
-                $this->settings = array_merge($this->settings, $name);
-            } else {
-                return isset($this->settings[$name]) ? $this->settings[$name] : null;
-            }
+        $c = $this->container;
+
+        if (is_array($name)) {
+            $c['settings'] = array_merge($c['settings'], $name);
+        } elseif (func_num_args() === 1) {
+            return isset($c['settings'][$name]) ? $c['settings'][$name] : null;
         } else {
-            $settings = $this->settings;
+            $settings = $c['settings'];
             $settings[$name] = $value;
-            $this->settings = $settings;
+            $c['settings'] = $settings;
         }
     }
 

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -338,7 +338,11 @@ class Slim
         $c = $this->container;
 
         if (is_array($name)) {
-            $c['settings'] = array_merge($c['settings'], $name);
+            if (true === $value) {
+                $c['settings'] = array_merge_recursive($c['settings'], $name);
+            } else {
+                $c['settings'] = array_merge($c['settings'], $name);
+            }
         } elseif (func_num_args() === 1) {
             return isset($c['settings'][$name]) ? $c['settings'][$name] : null;
         } else {

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -222,7 +222,8 @@ class SlimTest extends PHPUnit_Framework_TestCase
                 ),
             )
         );
-
+        
+        // Test recursive batch behaviour
         $s->config($override, true);
 
         $expected =  array(
@@ -234,6 +235,12 @@ class SlimTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals($expected, $s->config('my_module'));
+
+        // Test default batch behaviour
+        $s = new \Slim\Slim($config);
+        $s->config($override);
+
+        $this->assertNotEquals($expected, $s->config('my_module'));
     }
 
     /************************************************

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -199,6 +199,43 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($s->config('debug'));
     }
 
+    /**
+     * Test set settings recursively
+     */
+    public function testSetSettingsRecursively()
+    {
+        $config = array(
+            'my_module' => array(
+                'paths'  => array(
+                    './my_module/path/1',
+                ),
+            )
+        );
+
+        $s = new \Slim\Slim($config);
+
+        $override = array(
+            'my_module' => array(
+                'paths'  => array(
+                    './my_module/path/2',
+                    './my_module/path/3',
+                ),
+            )
+        );
+
+        $s->config($override, true);
+
+        $expected =  array(
+            'paths'  => array(
+                './my_module/path/1',
+                './my_module/path/2',
+                './my_module/path/3',
+            ),
+        );
+
+        $this->assertEquals($expected, $s->config('my_module'));
+    }
+
     /************************************************
      * MODES
      ************************************************/


### PR DESCRIPTION
- avoids accidental assignments when $name in an array and num parameters > 1 
- avoids usage of magic methods
