### PR TITLE
Allow passing array of methods to Slim\Route::via() and Slim\Route::appendHttpMethods()

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -326,6 +326,9 @@ class Route implements RouteInterface
     public function appendHttpMethods()
     {
         $args = func_get_args();
+        if(count($args) && is_array($args[0])){
+            $args = $args[0];
+        }
         $this->methods = array_merge($this->methods, $args);
     }
 
@@ -337,6 +340,9 @@ class Route implements RouteInterface
     public function via()
     {
         $args = func_get_args();
+        if(count($args) && is_array($args[0])){
+            $args = $args[0];
+        }
         $this->methods = array_merge($this->methods, $args);
 
         return $this;

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -476,12 +476,30 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $this->assertAttributeEquals(array('GET', 'POST', 'PUT'), 'methods', $route);
     }
 
+    public function testAppendArrayOfHttpMethods()
+    {
+        $arrayOfMethods = array('GET','POST','PUT');
+        $route = new \Slim\Route('/foo', function () {});
+        $route->appendHttpMethods($arrayOfMethods);
+
+        $this->assertAttributeEquals($arrayOfMethods,'methods',$route);
+    }
+
     public function testAppendHttpMethodsWithVia()
     {
         $route = new \Slim\Route('/foo', function () {});
         $route->via('PUT');
 
         $this->assertAttributeContains('PUT', 'methods', $route);
+    }
+
+    public function testAppendArrayOfHttpMethodsWithVia()
+    {
+        $arrayOfMethods = array('GET','POST','PUT');
+        $route = new \Slim\Route('/foo', function () {});
+        $route->via($arrayOfMethods);
+
+        $this->assertAttributeEquals($arrayOfMethods,'methods',$route);
     }
 
     public function testSupportsHttpMethod()


### PR DESCRIPTION
Tests included

Example:

``` php
<?php
$route = new Slim\Route('/foo',function() {});
$route->via( array(
   'GET',
   'POST'
));
```
