### PR TITLE
Add missing semicolon to namespace declaration

### DIFF
--- a/Slim/Interfaces/SessionHandlerInterface.php
+++ b/Slim/Interfaces/SessionHandlerInterface.php
@@ -30,7 +30,7 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace Slim\Interfaces
+namespace Slim\Interfaces;
 
 /**
  * Session Handler Interface


### PR DESCRIPTION
Fix for missing semicolon issue #766
