### PR TITLE
Lazy-initialize class in \Slim\Route::setCallable()

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -163,7 +163,15 @@ class Route
     {
         $matches = array();
         if (is_string($callable) && preg_match('!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!', $callable, $matches)) {
-            $callable = array(new $matches[1], $matches[2]);
+            $class = $matches[1];
+            $method = $matches[2];
+            $callable = function() use ($class, $method) {
+                static $obj = null;
+                if ($obj === null) {
+                    $obj = new $class;
+                }
+                return call_user_func_array(array($obj, $method), func_get_args());
+            };
         }
 
         if (!is_callable($callable)) {

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -29,6 +29,28 @@
  * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
+
+class LazyInitializeTestClass {
+    public static $initialized = false;
+
+    public function __construct() {
+        self::$initialized = true;
+    }
+
+    public function foo() {
+    }
+}
+
+class FooTestClass {
+    public static $foo_invoked = false;
+    public static $foo_invoked_args = array();
+
+    public function foo() {
+        self::$foo_invoked = true;
+        self::$foo_invoked_args = func_get_args();
+    }
+}
+
 class RouteTest extends PHPUnit_Framework_TestCase
 {
     public function testGetPattern()
@@ -69,11 +91,26 @@ class RouteTest extends PHPUnit_Framework_TestCase
 
     public function testGetCallableAsClass()
     {
-        $route = new \Slim\Route('/foo', '\Slim\Router:getCurrentRoute');
+        FooTestClass::$foo_invoked = false;
+        FooTestClass::$foo_invoked_args = array();
+        $route = new \Slim\Route('/foo', '\FooTestClass:foo');
+        $route->setParams(array('bar' => '1234'));
 
-        $callable = $route->getCallable();
-        $this->assertInstanceOf('\Slim\Router', $callable[0]);
-        $this->assertEquals('getCurrentRoute', $callable[1]);
+        $this->assertFalse(FooTestClass::$foo_invoked);
+        $this->assertTrue($route->dispatch());
+        $this->assertTrue(FooTestClass::$foo_invoked);
+        $this->assertEquals(array('1234'), FooTestClass::$foo_invoked_args);
+    }
+
+    public function testGetCallableAsClassLazyInitialize()
+    {
+        LazyInitializeTestClass::$initialized = false;
+
+        $route = new \Slim\Route('/foo', '\LazyInitializeTestClass:foo');
+        $this->assertFalse(LazyInitializeTestClass::$initialized);
+
+        $route->dispatch();
+        $this->assertTrue(LazyInitializeTestClass::$initialized);
     }
 
 


### PR DESCRIPTION
You don't want to construct all kinds of objects when setting up your routes, so don't initialize those objects until
the route is actually dispatched. Add some basic caching so multiple route dispatches don't result in multiple class
instantiations.
