### PR TITLE
Do not check content-type twice in sendFile() method

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -943,16 +943,12 @@ class App extends \Pimple
         } else {
             if (file_exists($file)) {
                 //Set Content-Type
-                if ($contentType) {
-                    $this['response']->getHeaders()->set("Content-Type", $contentType);
+                if (extension_loaded('fileinfo')) {
+                    $finfo = new \finfo(FILEINFO_MIME_TYPE);
+                    $type = $finfo->file($file);
+                    $this['response']->getHeaders()->set("Content-Type", $type);
                 } else {
-                    if (extension_loaded('fileinfo')) {
-                        $finfo = new \finfo(FILEINFO_MIME_TYPE);
-                        $type = $finfo->file($file);
-                        $this['response']->getHeaders()->set("Content-Type", $type);
-                    } else {
-                        $this['response']->getHeaders()->set("Content-Type", "application/octet-stream");
-                    }
+                    $this['response']->getHeaders()->set("Content-Type", "application/octet-stream");
                 }
 
                 //Set Content-Length
@@ -966,11 +962,7 @@ class App extends \Pimple
                     list($k, $v) = explode(": ", $header, 2);
 
                     if ($k === "Content-Type") {
-                        if ($contentType) {
-                            $this['response']->getHeaders()->set("Content-Type", $contentType);
-                        } else {
-                            $this['response']->getHeaders()->set("Content-Type", $v);
-                        }
+                        $this['response']->getHeaders()->set("Content-Type", $v);
                     } else if ($k === "Content-Length") {
                         $this['response']->getHeaders()->set("Content-Length", $v);
                     }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -499,6 +499,19 @@ class AppTest extends PHPUnit_Framework_TestCase
         $app->run();
     }
 
+    public function testStreamingAFileWithContentType()
+    {
+        $this->expectOutputString(file_get_contents(dirname(__DIR__) . "/composer.json"));
+
+        $app = $this->createApp();
+        $header = $app['response']->getHeaders();
+        $app->get('/bar', function() use ($app) {
+            $app->sendFile(dirname(__DIR__) . "/composer.json", 'application/json');
+        });
+        $app->run();
+        $this->assertEquals('application/json', $header->get('Content-Type'));
+    }
+
     public function testStreamingAProc()
     {
         $this->expectOutputString("FooBar\n");


### PR DESCRIPTION
The $contentType variable was being checked twice. I also added a test to make sure the content type is sent as expected.
