### PR TITLE
Load Groups on Route Match

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -384,11 +384,7 @@ class App extends \Pimple
         $args = func_get_args();
         $pattern = array_shift($args);
         $callable = array_pop($args);
-        $this['router']->pushGroup($pattern, $args);
-        if (is_callable($callable)) {
-            call_user_func($callable);
-        }
-        $this['router']->popGroup();
+        $this['router']->addGroup($pattern, $callable, $args);
     }
 
     /**

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -49,9 +49,7 @@ interface RouterInterface
 
     public function map(RouteInterface $route);
 
-    public function pushGroup($group, $middleware = array());
-
-    public function popGroup();
+    public function addGroup($group, $callable, $middleware = array());
 
     public function urlFor($name, $params = array());
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -212,10 +212,10 @@ class Router implements RouterInterface
     {
         return array_push(
             $this->routeGroups, 
-            [$group => (object)[
+            array($group => (object)array(
                 'routes'        => $routes,
                 'middleware'    => $middleware
-            ]]
+            ))
         );
     }
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -214,6 +214,10 @@ class Router implements RouterInterface
      */
     public function addGroup($group, $routes, $middleware = array())
     {
+        if (strlen($this->currentBaseUri) > 0)
+        {
+            $group = $this->currentBaseUri.$group;
+        }
         return array_push(
             $this->routeGroups, 
             array($group => (object)array(

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -165,7 +165,7 @@ class Router implements RouterInterface
                         $routes($this->currentMiddleware);
                     }
                     
-                    return $this->getMatchedRoutes($httpMethod, $resourceUri, $reload);
+                    return $this->getMatchedRoutes($httpMethod, $resourceUri, $save);
                 }
             }
         }

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -78,7 +78,17 @@ class Router implements RouterInterface
      * @var array
      */
     protected $routeGroups;
-
+    
+    /**
+     * @var string Current Base URI
+     */
+    protected $currentBaseUri = '';
+    
+    /**
+     * @var array Current stack of middleware
+     */
+    protected $currentMiddleware;
+    
     /**
      * Constructor
      * @api
@@ -87,6 +97,7 @@ class Router implements RouterInterface
     {
         $this->routes = array();
         $this->routeGroups = array();
+        $this->currentMiddleware = array();
     }
 
     /**
@@ -130,21 +141,46 @@ class Router implements RouterInterface
     public function getMatchedRoutes($httpMethod, $resourceUri, $save = true)
     {
         $matchedRoutes = array();
+        
+        foreach ($this->routeGroups as $index => $grouproutes) {
+            foreach ($grouproutes as $uri => $group) {
+                
+                $groupSlashes = substr_count($uri, '/');
+                $resourceUriParts = explode('/', $resourceUri);
+                $resourceMatchUri = implode('/', array_slice($resourceUriParts, 0, $groupSlashes+1));
+                
+                if ($uri == $resourceMatchUri) {
+                    unset($this->routeGroups[$index]);
+                    
+                    $this->currentBaseUri = $uri;
+                    $routes = $group->routes;
+                    
+                    
+                    $this->currentMiddleware = array_merge(
+                        $this->currentMiddleware, 
+                        $group->middleware
+                    );
+                    
+                    if (is_callable($routes)) {
+                        $routes($this->currentMiddleware);
+                    }
+                    
+                    return $this->getMatchedRoutes($httpMethod, $resourceUri, $reload);
+                }
+            }
+        }
+        
         foreach ($this->routes as $route) {
             if (!$route->supportsHttpMethod($httpMethod) && !$route->supportsHttpMethod("ANY")) {
                 continue;
             }
-
+            
             if ($route->matches($resourceUri)) {
                 $matchedRoutes[] = $route;
             }
         }
-
-        if ($save === true) {
-            $this->matchedRoutes = $matchedRoutes;
-        }
-
-        return $matchedRoutes;
+        
+        return $this->matchedRoutes;
     }
 
     /**
@@ -157,33 +193,12 @@ class Router implements RouterInterface
      */
     public function map(RouteInterface $route)
     {
-        list($groupPattern, $groupMiddleware) = $this->processGroups();
-        $route->setPattern($groupPattern . $route->getPattern());
+        $route->setPattern($this->currentBaseUri . $route->getPattern());
         $this->routes[] = $route;
-        foreach ($groupMiddleware as $middleware) {
+
+        foreach ($this->currentMiddleware as $middleware) {
             $route->setMiddleware($middleware);
         }
-    }
-
-    /**
-     * Process route groups
-     *
-     * A helper method for processing the group's pattern and middleware.
-     *
-     * @return array An array with the elements: pattern, middlewareArr
-     */
-    protected function processGroups()
-    {
-        $pattern = "";
-        $middleware = array();
-        foreach ($this->routeGroups as $group) {
-            $k = key($group);
-            $pattern .= $k;
-            if (is_array($group[$k])) {
-                $middleware = array_merge($middleware, $group[$k]);
-            }
-        }
-        return array($pattern, $middleware);
     }
 
     /**
@@ -193,19 +208,15 @@ class Router implements RouterInterface
      * @return int                    The index of the new group
      * @api
      */
-    public function pushGroup($group, $middleware = array())
+    public function addGroup($group, $routes, $middleware = array())
     {
-        return array_push($this->routeGroups, array($group => $middleware));
-    }
-
-    /**
-     * Removes the last route group from the array
-     * @return bool True if successful, else False
-     * @api
-     */
-    public function popGroup()
-    {
-        return (array_pop($this->routeGroups) !== null);
+        return array_push(
+            $this->routeGroups, 
+            [$group => (object)[
+                'routes'        => $routes,
+                'middleware'    => $middleware
+            ]]
+        );
     }
 
     /**

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -180,7 +180,11 @@ class Router implements RouterInterface
             }
         }
         
-        return $this->matchedRoutes;
+        if ($save === true) {
+            $this->matchedRoutes = $matchedRoutes;
+        }
+        
+        return $matchedRoutes;
     }
 
     /**


### PR DESCRIPTION
This PR essentially loads the group once a match has been made on the base of the route. This allows loading separate views for a group as well as optimizing page load by loading only the callbacks necessary to fulfill the route.
