### PR TITLE
FIX: slim.after is called too early

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -1043,6 +1043,8 @@ class App extends \Pimple
     {
         set_error_handler(array('\Slim\App', 'handleErrors'));
 
+        $this->applyHook('slim.before');
+
         // Invoke middleware and application stack
         try {
             $this['middleware'][0]->call();
@@ -1052,6 +1054,8 @@ class App extends \Pimple
 
         // Finalize and send response
         $this->finalize();
+
+        $this->applyHook('slim.after');
 
         restore_error_handler();
     }
@@ -1072,7 +1076,6 @@ class App extends \Pimple
     protected function dispatchRequest(\Slim\Http\Request $request, \Slim\Http\Response $response)
     {
         try {
-            $this->applyHook('slim.before');
             ob_start();
             $this->applyHook('slim.before.router');
             $dispatched = false;
@@ -1095,7 +1098,6 @@ class App extends \Pimple
             $this->applyHook('slim.after.router');
         } catch (\Slim\Exception\Stop $e) {}
         $response->write(ob_get_clean());
-        $this->applyHook('slim.after');
     }
 
     /**


### PR DESCRIPTION
FIX: slim.after is called too early (before response is sent to the client).
also move slim.before for enhanced symmetry
