### PR TITLE
Automatic json_encode when header is set

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -202,7 +202,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     public function setBody($content)
     {
         if($this->headers->get('Content-Type') == 'application/json'){
-	        $content = (is_string($content)) ?: json_encode($content);
+	        $content = (is_string($content)) ?: json_encode($content); 
     	} 
         $this->write($content, true);
     }

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -201,6 +201,9 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
 
     public function setBody($content)
     {
+        if($this->headers->get('Content-Type') == 'application/json'){
+	        $content = (is_string($content)) ?: json_encode($content);
+    	} 
         $this->write($content, true);
     }
 


### PR DESCRIPTION
I mainly use Slim for backend api calls and find that I have to constantly json_encode my data. This would allow for automatic encoding if the header is set. I'm open for better ways for comparison. I figured checking for a string was the best performance wise.

Example use (very basic):

```
$app->response->headers->set('Content-Type', 'application/json');
$result = array("key" => "value");
$app->response->setBody($result);
```
