### PR TITLE
Implement addHeader and addHeaders

### DIFF
--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -98,7 +98,7 @@ class Headers extends Collection implements HeadersInterface
                     continue;
                 }
 
-                parent::set($this->normalizeKey($key), $value);
+                parent::set($this->normalizeKey($key), array($value));
             }
         }
     }
@@ -112,7 +112,7 @@ class Headers extends Collection implements HeadersInterface
      */
     public function set($key, $value)
     {
-        parent::set($this->normalizeKey($key), $value);
+        parent::set($this->normalizeKey($key), array($value));
     }
 
     /**
@@ -123,9 +123,31 @@ class Headers extends Collection implements HeadersInterface
      * @return mixed           The data value, or the default value
      * @api
      */
-    public function get($key, $default = null)
+    public function get($key, $asArray = false)
     {
-        return parent::get($this->normalizeKey($key), $default);
+        if ($asArray) {
+            return parent::get($this->normalizeKey($key), array());
+        } else {
+            return implode(', ', parent::get($this->normalizeKey($key), array()));
+        }
+    }
+
+    /**
+     * Add data to key
+     *
+     * @param string $key   The data key
+     * @param mixed  $value The data value
+     * @api
+     */
+    public function add($key, $value)
+    {
+        $header = $this->get($key, true);
+        if (is_array($value)) {
+            $header = array_merge($header, $value);
+        } else {
+            $header[] = $value;
+        }
+        parent::set($this->normalizeKey($key), $header);
     }
 
     /**

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -164,10 +164,10 @@ class Request implements RequestInterface
     {
         // Get actual request method
         $method = $this->env->get('REQUEST_METHOD');
-        $methodOverride = $this->headers->get('HTTP_X_HTTP_METHOD_OVERRIDE', false);
+        $methodOverride = $this->headers->get('HTTP_X_HTTP_METHOD_OVERRIDE');
 
         // Detect method override (by HTTP header or POST parameter)
-        if ($methodOverride !== false) {
+        if (!empty($methodOverride)) {
             $method = strtoupper($methodOverride);
         } else if ($method === static::METHOD_POST) {
             $customMethod = $this->post(static::METHOD_OVERRIDE, false);
@@ -286,14 +286,29 @@ class Request implements RequestInterface
         $this->headers->replace($headers);
     }
 
+    /**
+     * Add a header value
+     *
+     * @param string $name
+     * @param string $value
+     * @api
+     */
     public function addHeader($name, $value)
     {
-        // TODO
+        $this->headers->add($name, $value);
     }
 
+    /**
+     * Add multiple header values
+     *
+     * @param array $headers
+     * @api
+     */
     public function addHeaders(array $headers)
     {
-        // TODO
+        foreach ($headers as $name => $value) {
+            $this->headers->add($name, $value);
+        }
     }
 
     /**
@@ -669,7 +684,7 @@ class Request implements RequestInterface
      */
     public function isFormData()
     {
-        return (is_null($this->getContentType()) && $this->getOriginalMethod() === static::METHOD_POST) || in_array($this->getMediaType(), self::$formDataMediaTypes);
+        return (empty($this->getContentType()) && $this->getOriginalMethod() === static::METHOD_POST) || in_array($this->getMediaType(), self::$formDataMediaTypes);
     }
 
     /**

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -684,7 +684,7 @@ class Request implements RequestInterface
      */
     public function isFormData()
     {
-        return (empty($this->getContentType()) && $this->getOriginalMethod() === static::METHOD_POST) || in_array($this->getMediaType(), self::$formDataMediaTypes);
+        return ($this->getContentType() == '' && $this->getOriginalMethod() === static::METHOD_POST) || in_array($this->getMediaType(), self::$formDataMediaTypes);
     }
 
     /**

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -296,14 +296,29 @@ class Response implements ResponseInterface
         $this->headers->replace($headers);
     }
 
+    /**
+     * Add a header value
+     *
+     * @param string $name
+     * @param string $value
+     * @api
+     */
     public function addHeader($name, $value)
     {
-        // TODO
+        $this->headers->add($name, $value);
     }
 
+    /**
+     * Add multiple header values
+     *
+     * @param array $headers
+     * @api
+     */
     public function addHeaders(array $headers)
     {
-        // TODO
+        foreach ($headers as $name => $value) {
+            $this->headers->add($name, $value);
+        }
     }
 
     /**

--- a/tests/Http/HeadersTest.php
+++ b/tests/Http/HeadersTest.php
@@ -63,8 +63,16 @@ class HeadersTest extends PHPUnit_Framework_TestCase
 
     public function testGet()
     {
-        $this->property->setValue($this->headers, array('Content-Length' => 100));
+        $this->property->setValue($this->headers, array('Content-Length' => array(100)));
         $this->assertEquals(100, $this->headers->get('CONTENT_LENGTH'));
+    }
+
+    public function testAdd()
+    {
+        $this->headers->set('foo', 'foo');
+        $this->headers->add('foo', 'bar');
+        $this->assertEquals(array('Foo'=>array('foo', 'bar')), $this->property->getValue($this->headers));
+        $this->assertEquals('foo, bar', $this->headers->get('foo'));
     }
 
     public function testHas()

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -413,7 +413,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
             'REQUEST_METHOD' => 'POST',
             'CONTENT_LENGTH' => 0
         ), '');
-        $this->assertNull($this->request->getContentType());
+        $this->assertEquals('', $this->request->getContentType());
     }
 
     /**
@@ -530,7 +530,33 @@ class RequestTest extends PHPUnit_Framework_TestCase
             'REQUEST_METHOD' => 'POST',
             'CONTENT_TYPE' => 'application/json',
         ), '');
-        $this->assertEquals(0, $this->request->getContentLength());
+        $this->assertEquals('', $this->request->getContentLength());
+    }
+
+    /**
+     * Test add header
+     */
+    public function testAddHeader()
+    {
+        $this->initializeRequest(array(
+            'HTTP_HOST' => 'slimframework.com',
+            'SERVER_NAME' => 'example.com'
+        ));
+        $this->request->addHeader('Foo', 'Bar');
+        $this->assertEquals('Bar', $this->request->getHeader('Foo'));
+    }
+
+    /**
+     * Test add header
+     */
+    public function testAddHeaders()
+    {
+        $this->initializeRequest(array(
+            'HTTP_HOST' => 'slimframework.com',
+            'SERVER_NAME' => 'example.com'
+        ));
+        $this->request->addHeaders(array('Foo' => array('Foo', 'Bar')));
+        $this->assertEquals('Foo, Bar', $this->request->getHeader('Foo'));
     }
 
     /**
@@ -781,8 +807,8 @@ class RequestTest extends PHPUnit_Framework_TestCase
      */
     public function testGetReferrerWhenNotExists()
     {
-        $this->assertNull($this->request->getReferrer());
-        $this->assertNull($this->request->getReferer());
+        $this->assertEquals('', $this->request->getReferrer());
+        $this->assertEquals('', $this->request->getReferer());
     }
 
     /**
@@ -805,7 +831,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
             'HTTP_USER_AGENT' => 'ua-string'
         ));
         $this->headers->remove('HTTP_USER_AGENT');
-        $this->assertNull($this->request->getUserAgent());
+        $this->assertEquals('', $this->request->getUserAgent());
     }
 
     /**

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -149,7 +149,10 @@ class ResponseTest extends PHPUnit_Framework_TestCase
         );
         $this->headersProperty->getValue($this->response)->replace($headers);
 
-        $this->assertSame($headers, $this->response->getHeaders());
+        $this->assertSame(array(
+            'Content-Type' => array('application/json'),
+            'X-Foo' => array('Bar')
+        ), $this->response->getHeaders());
     }
 
     public function testHasHeader()
@@ -188,6 +191,22 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('X-Foo', $this->headersProperty->getValue($this->response)->all());
         $this->assertArrayHasKey('X-Test', $this->headersProperty->getValue($this->response)->all());
+    }
+
+    public function testAddHeader()
+    {
+        $this->response->setHeader('X-Foo', 'Bar');
+        $this->response->addHeader('X-Foo', 'Foo');
+        $this->assertArrayHasKey('X-Foo', $this->headersProperty->getValue($this->response)->all());
+        $this->assertEquals('Bar, Foo', $this->headersProperty->getValue($this->response)->get('X-Foo'));
+    }
+
+    public function testAddHeaders()
+    {
+        $this->response->setHeader('X-Foo', 'Bar');
+        $this->response->addHeaders(array('X-Foo' => array('Foo', '123')));
+        $this->assertArrayHasKey('X-Foo', $this->headersProperty->getValue($this->response)->all());
+        $this->assertEquals('Bar, Foo, 123', $this->headersProperty->getValue($this->response)->get('X-Foo'));
     }
 
     public function testRemoveHeader()


### PR DESCRIPTION
Implement the addHeader and AddHeaders in the Http\Request and Http\Response classes.

According to the proposed FIG http message interface, the Http\Header class now uses arrays to store the headers and returns a string on getHeader() if the $asArray parameter is false or not set.
