### PR TITLE
don't explode headers

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -529,8 +529,7 @@ class Response implements ResponseInterface
             }
 
             foreach ($this->headers as $name => $value) {
-                $hValues = explode("\n", $value);
-                foreach ($hValues as $hVal) {
+                foreach ($value as $hVal) {
                     header("$name: $hVal", false);
                 }
             }


### PR DESCRIPTION
The headers value already contains an array and doesn't need to be exploded. This is preventing Slim from working properly as explode is receiving an array instead of a string.
