### PR TITLE
use php://input if body is null

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -127,10 +127,12 @@ class Request implements RequestInterface
         $this->env = $env;
         $this->headers = $headers;
         $this->cookies = $cookies;
-        $this->bodyRaw = new \GuzzleHttp\Stream\Stream(fopen('php://temp', 'r+'));
 
         if (is_string($body) === true) {
+            $this->bodyRaw = new \GuzzleHttp\Stream\Stream(fopen('php://temp', 'r+'));
             $this->bodyRaw->write($body);
+        } else {
+            $this->bodyRaw = new \GuzzleHttp\Stream\Stream(fopen('php://input', 'r'));
         }
         $this->bodyRaw->seek(0);
     }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -921,4 +921,23 @@ class RequestTest extends PHPUnit_Framework_TestCase
         ));
         $this->assertEquals('/foo/%23bar', $this->request->getPathInfo());
     }
+
+    /**
+     * Test request with body uses the php://temp writable stream
+     */
+    public function testRequestWithBodyUsesWritableStream()
+    {
+        $this->initializeRequest();
+        $this->assertTrue($this->request->getBody()->isWritable());
+    }
+
+    /**
+     * Test request without body uses the php://input read-only stream
+     */
+    public function testRequestWithoutBodyUsesReadOnlyStream()
+    {
+        $this->initializeRequest(array(), null);
+        $this->assertFalse($this->request->getBody()->isWritable());
+    }
+
 }


### PR DESCRIPTION
Use php://input if the body is null as [noted](https://github.com/codeguy/Slim/commit/1c4a990dc834728e1ad5f2d597071d9700504e7d#commitcomment-6083981) by @svemir. This was removed by mistake in the guzzle update pull request.

Some tests where added to make sure the read-only stream is used when the body is null.
