### PR TITLE
augment `via` to also accept an array of verbs as 1st argument

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -299,7 +299,7 @@ class Route
     {
         $args = func_get_args();
         if (is_array($args[0])){
-            $args = $args[0]
+            $args = $args[0];
         }
         $this->methods = array_merge($this->methods, $args);
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -298,6 +298,9 @@ class Route
     public function via()
     {
         $args = func_get_args();
+        if (is_array($args[0])){
+            $args = $args[0]
+        }
         $this->methods = array_merge($this->methods, $args);
 
         return $this;


### PR DESCRIPTION
I found it impossible to pass an arbitrary number of HTTP verbs stored in an array to `via` as `call_user_func_array` won't accept it as callable like:

``` php
$verbs = array('GET', 'POST'); //this is actually sourced from a JSON file somewhere else
call_user_func_array($app->map('/foo', $handler_fn)->via, $verbs);
```

I patched it the way you can see in the PR. The additional way of using `via` would now be like:

``` php
$verbs = array('GET', 'POST');
$app->map('/foo', $handler_fn)->via($verbs);
```

I do think this is a valuable addition (as generating routing from configuration files is something I'd need to do on a regular basis), yet I am far from being a PHP pro so I am not too sure about coding style et. al. If you like the idea but think this should be handled differently, feel free to discard the PR and implement the feature in a more fitting fashion.

Thanks!

P.S.: Sorry for not targeting `codeguy:develop`, I must have somehow missed the dropdown where to change that. Seems impossible to change that afterwards.
