### PR TITLE
Callable Resolver

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -24,7 +24,6 @@ use Pimple\ServiceProviderInterface;
  */
 class App extends \Pimple\Container
 {
-    use ResolveCallable;
     use MiddlewareAware;
 
     /**
@@ -162,6 +161,14 @@ class App extends \Pimple\Container
         $this['notAllowedHandler'] = function ($c) {
             return new Handlers\NotAllowed;
         };
+
+        /**
+         * This Pimple service MUST return a SHARED instance
+         * of \Slim\Interfaces\RouterInterface.
+         */
+        $this['resolver'] = function($c) {
+            return new Resolvers\DependencyResolver($c);
+        };
     }
 
     /********************************************************************************
@@ -261,7 +268,8 @@ class App extends \Pimple\Container
             throw new \InvalidArgumentException('Route pattern must be a string');
         }
 
-        $callable = $this->resolveCallable($callable);
+        $callable = $this['resolver']->build($callable);
+
         if ($callable instanceof \Closure) {
             $callable = $callable->bindTo($this);
         }

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Slim\Interfaces;
+
+interface CallableResolverInterface
+{
+    public function build($callable); 
+}

--- a/Slim/Resolvers/DependencyResolver.php
+++ b/Slim/Resolvers/DependencyResolver.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Slim\Resolvers;
+
+use Slim\Interfaces\CallableResolverInterface;
+
+class DependencyResolver implements CallableResolverInterface
+{
+    private $container;
+
+    public function __construct(\Pimple\Container $container)
+    {
+        $this->container = $container;
+    }
+
+    public function build($callable)
+    {
+        if (is_string($callable) && preg_match('!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!', $callable, $matches)) {
+
+            $class = $matches[1];
+            $method = $matches[2];
+
+            $container = $this->container;
+
+            $callable = function() use ($class, $method, $container) {
+                if (isset($container[$class])) {
+                    $obj = $container[$class];
+                } else {
+                    if (!class_exists($class)) {
+                        throw new \RuntimeException('Route callable class does not exist');
+                    }
+                    $obj = new $class;
+                }
+
+                if (!method_exists($obj, $method)) {
+                    throw new \RuntimeException('Route callable method does not exist');
+                }
+
+                return call_user_func_array(array($obj, $method), func_get_args());
+            };
+        }
+
+        return $callable;
+    }
+}


### PR DESCRIPTION
I moved the responsibility of creating the callable to a new dependency called a Callable Resolver. In the App constructor, I created a default Resolver that creates route callable methods the exact way they are created now. In addition, I created two more Resolvers. One by default will inject the Slim Pimple container into the constructor. The other will look for services inside of Pimple. For example, if you say "mycontroller:index", it will look for $app['mycontroller'] and call the index method on that controller. There is an interface to create your own Resolver.

To implement a resolver, you just change the $app['resolver'] class prior to adding routes.

I have some questions in this which I would like to discuss. For one, I made Pimple a dependency, but maybe it should be the Slim application itself. Also, I'm curious on naming. Third, I haven't written tests/doc for this but all current tests pass. I wanted to chat about this rough draft and nail it out
