### PR TITLE
Fix sendfile headers

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -959,6 +959,10 @@ class App extends \Pimple
                 $data = stream_get_meta_data($fp);
 
                 foreach ($data['wrapper_data'] as $header) {
+                    if (strpos($header, ':') === false) {
+                        continue;
+                    }
+
                     list($k, $v) = explode(": ", $header, 2);
 
                     if ($k === "Content-Type") {


### PR DESCRIPTION
$data['wrapper_data'] also contains strings like 'HTTP/1.1 200 OK', which isn't a header.
