### PR TITLE
Route contexts

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -51,6 +51,11 @@ class Route
     protected $callable;
 
     /**
+     * @var object The routes context
+     */
+    protected $context;
+
+    /**
      * @var array Conditions for this route's URL parameters
      */
     protected $conditions = array();
@@ -179,6 +184,24 @@ class Route
         }
 
         $this->callable = $callable;
+    }
+
+    /**
+     * Get route context
+     * @return object
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * Set route context
+     * @param object $context
+     */
+    public function setContext(object $context)
+    {
+        $this->context = $context;
     }
 
     /**

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -51,7 +51,7 @@ class Route
     protected $callable;
 
     /**
-     * @var object The routes context
+     * @var mixed The routes context
      */
     protected $context;
 
@@ -188,7 +188,7 @@ class Route
 
     /**
      * Get route context
-     * @return object
+     * @return mixed
      */
     public function getContext()
     {
@@ -197,9 +197,9 @@ class Route
 
     /**
      * Set route context
-     * @param object $context
+     * @param mixed $context
      */
-    public function setContext(object $context)
+    public function setContext($context)
     {
         $this->context = $context;
     }
@@ -482,7 +482,14 @@ class Route
             call_user_func_array($mw, array($this));
         }
 
-        $return = call_user_func_array($this->getCallable(), array_values($this->getParams()));
+        $callable = $this->getCallable();
+        $context = $this->getContext();
+
+        if (method_exists('Closure','bindTo') && is_object($context)) {
+          $callable = \Closure::bind($callable, $context);
+        }
+
+        $return = call_user_func_array($callable, array_values($this->getParams()));
         return ($return === false) ? false : true;
     }
 }

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -310,7 +310,8 @@ class Slim
             // HTTP
             'http.version' => '1.1',
             // Routing
-            'routes.case_sensitive' => true
+            'routes.case_sensitive' => true,
+            'routes.context' => null
         );
     }
 
@@ -441,6 +442,11 @@ class Slim
         $pattern = array_shift($args);
         $callable = array_pop($args);
         $route = new \Slim\Route($pattern, $callable, $this->settings['routes.case_sensitive']);
+
+        $obj = $this->settings['routes.context'];
+        $context = (is_null($obj)) ? $this : $obj;
+        $route->setContext($context); 
+
         $this->router->map($route);
         if (count($args) > 0) {
             $route->setMiddleware($args);

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -150,6 +150,16 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $route = new \Slim\Route('/foo', 'doesNotExist'); // <-- Called inside __construct()
     }
 
+    public function testGetAndSetContext()
+    {
+      $context = array("foo" => "bar");
+      $route = new \Slim\Route('/foo', function(){});
+
+      $this->assertNull($route->getContext());
+      $route->setContext($context);
+      $this->assertEquals($context, $route->getContext());
+    }
+
     public function testGetParams()
     {
         $route = new \Slim\Route('/hello/:first/:last', function () {});

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -576,6 +576,16 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($s, $route->getContext());
     }
 
+    public function testAppContextSetting()
+    {
+      $context = new StdClass;
+      $s = new \Slim\Slim(array(
+        "routes.context" => $context
+      ));
+      $route = $s->get('/foo', function(){});
+      $this->assertEquals($context, $route->getContext());
+    }
+
     /************************************************
      * VIEW
      ************************************************/

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -222,7 +222,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
                 ),
             )
         );
-        
+
         // Test recursive batch behaviour
         $s->config($override, true);
 
@@ -567,6 +567,13 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s->get('/bar/:one/:two', function ($one, $two) { echo $one . $two; });
         $s->call();
         $this->assertEquals('jo hnsmi th', $s->response()->body());
+    }
+
+    public function testAppDefaultContext()
+    {
+        $s = new \Slim\Slim();
+        $route = $s->get('/foo', function(){});
+        $this->assertEquals($s, $route->getContext());
     }
 
     /************************************************
@@ -1237,7 +1244,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
      *
      * This asserts that the same middleware can NOT be queued twice (usually by accident).
      * Circular middleware stack causes a troublesome to debug PHP Fatal error:
-     * 
+     *
      * > Fatal error: Maximum function nesting level of '100' reached. aborting!
      */
     public function testFailureWhenAddingCircularMiddleware()


### PR DESCRIPTION
Added the ability to bind contexts to routes. By default if no context is set the slim app object will be used allowing you to run things like `$this->render();` in your routes without pulling the `$app` variable into scope.

This PR also adds a `Slim` setting 'routes.context' which can be used to set a default context object for all routes (instead of the Slim app object).

On the route object you have two new methods `getContext()` and `setContext(object)` which can be used to get and set the routes personal context.
