### PR TITLE
Ability to override error handler when extending \Slim\App

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -1042,7 +1042,7 @@ class App extends \Pimple
      */
     public function run()
     {
-        set_error_handler(array('\Slim\App', 'handleErrors'));
+        set_error_handler(array(get_called_class(), 'handleErrors'));
 
         // Invoke middleware and application stack
         try {


### PR DESCRIPTION
I do not like how Slim forces you to use ErrorExceptions, so I made this change to use late static binding when referencing the error handler so you can use your own if you extend \Slim\App.

Alternatively I could make a configuration option for the main \Slim\App class to just not set the error handler and back in `run()`.
