### PR TITLE
Route contexts

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -277,6 +277,11 @@ class App extends \Pimple
         $pattern = array_shift($args);
         $callable = array_pop($args);
         $route = new \Slim\Route($pattern, $callable, $this['settings']['routes.case_sensitive']);
+
+        $obj = $this['settings']['routes.context'];
+        $context = (is_null($obj)) ? $this : $obj;
+        $route->setContext($context);
+
         $this['router']->map($route);
         if (count($args) > 0) {
             $route->setMiddleware($args);

--- a/Slim/Configuration.php
+++ b/Slim/Configuration.php
@@ -82,7 +82,8 @@ class Configuration implements ConfigurationInterface, \IteratorAggregate
         // HTTP
         'http.version' => '1.1',
         // Routing
-        'routes.case_sensitive' => true
+        'routes.case_sensitive' => true,
+        'routes.context' => null
     );
 
     /**

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -75,6 +75,11 @@ class Route implements RouteInterface
     protected $callable;
 
     /**
+     * @var mixed The routes context
+     */
+    protected $context;
+
+    /**
      * Conditions for this route's URL parameters
      * @var array
      */
@@ -213,6 +218,24 @@ class Route implements RouteInterface
         }
 
         $this->callable = $callable;
+    }
+
+    /**
+     * Get route context
+     * @return mixed
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+
+    /**
+     * Set route context
+     * @param mixed $context
+     */
+    public function setContext($context)
+    {
+        $this->context = $context;
     }
 
     /**
@@ -519,7 +542,14 @@ class Route implements RouteInterface
             call_user_func_array($mw, array($this));
         }
 
-        $return = call_user_func_array($this->getCallable(), array_values($this->getParams()));
+        $callable = $this->getCallable();
+        $context = $this->getContext();
+
+        if (method_exists('Closure','bindTo') && is_object($context)) {
+            $callable = \Closure::bind($callable, $context);
+        }
+
+        $return = call_user_func_array($callable, array_values($this->getParams()));
         return ($return === false) ? false : true;
     }
 }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -484,6 +484,32 @@ class AppTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('jo hnsmi th', (string)$this->app['response']->getBody());
     }
 
+    /**
+     * Test that the app will set itself as a default context on routes
+     */
+
+    public function testAppDefaultContext()
+    {
+        $s = new \Slim\App();
+        $route = $s->get('/foo', function(){});
+        $this->assertEquals($s, $route->getContext());
+    }
+
+    /**
+     * Test Setting an alternate context in the apps settings
+     */
+
+    public function testAppContextSetting()
+    {
+        $context = new StdClass;
+        $s = new \Slim\App(array(
+            "routes.context" => $context
+        ));
+
+        $route = $s->get('/foo', function(){});
+        $this->assertEquals($context, $route->getContext());
+    }
+
     /************************************************
      * File Streaming
      ************************************************/

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -142,6 +142,16 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $route = new \Slim\Route('/foo', 'doesNotExist'); // <-- Called inside __construct()
     }
 
+    public function testGetAndSetContext()
+    {
+        $context = array("foo" => "bar");
+        $route = new \Slim\Route('/foo', function(){});
+
+        $this->assertNull($route->getContext());
+        $route->setContext($context);
+        $this->assertEquals($context, $route->getContext());
+    }
+
     public function testGetParams()
     {
         $route = new \Slim\Route('/hello/:first/:last', function () {});


### PR DESCRIPTION
Added the ability to bind contexts to routes. By default if no context is set the slim app object will be used allowing you to run things like `$this->render();` in your routes without pulling the `$app` variable into scope.

This PR also adds a `Slim` setting 'routes.context' which can be used to set a default context object for all routes (instead of the Slim app object).

On the route object you have two new methods `getContext()` and `setContext(object)` which can be used to get and set the routes personal context.
