### PR TITLE
Single middleware

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -121,6 +121,7 @@ class Route implements RouteInterface
      * @var array[Callable]
      */
     protected $middleware = array();
+	
 
     /**
      * Constructor
@@ -395,7 +396,7 @@ class Route implements RouteInterface
     public function setMiddleware($middleware)
     {
         if (is_array( $middleware )){
-			foreach ($middlware as $m) {
+			foreach ($middleware as $m) {
 				if (! $m instanceof \Slim\Middleware ) {
                     throw new \InvalidArgumentException('All Route middleware must be an instace of \Slim\Middleware');
                 }
@@ -432,42 +433,8 @@ class Route implements RouteInterface
             throw new \RuntimeException("Circular Middleware setup detected. Tried to queue the same Middleware instance ({$middleware_class}) twice.");
         }
 
-        $newMiddleware->setApplication(\Slim\Slim::getInstance());
         $newMiddleware->setNextMiddleware($this->middleware[0]);
         array_unshift($this->middleware, $newMiddleware);
-
-        return $this;
-    }
-
-    /**
-     * Set middleware
-     *
-     * This method allows middleware to be assigned to a specific Route.
-     * If the method argument `is_callable` (including callable arrays!),
-     * we directly append the argument to `$this->middleware`. Else, we
-     * assume the argument is an array of callables and merge the array
-     * with `$this->middleware`.  Each middleware is checked for is_callable()
-     * and an InvalidArgumentException is thrown immediately if it isn't.
-     *
-     * @param  Callable|array[Callable]
-     * @return \Slim\Route
-     * @throws \InvalidArgumentException If argument is not callable or not an array of callables.
-     * @api
-     */
-    public function setMiddleware($middleware)
-    {
-        if (is_callable($middleware)) {
-            $this->middleware[] = $middleware;
-        } elseif (is_array($middleware)) {
-            foreach ($middleware as $callable) {
-                if (!is_callable($callable)) {
-                    throw new \InvalidArgumentException('All Route middleware must be callable');
-                }
-            }
-            $this->middleware = array_merge($this->middleware, $middleware);
-        } else {
-            throw new \InvalidArgumentException('Route middleware must be callable or an array of callables');
-        }
 
         return $this;
     }
@@ -565,7 +532,7 @@ class Route implements RouteInterface
         return $this;
     }
 
-    /**
+     /**
      * Dispatch route
      *
      * This method invokes the route object's callable. If middleware is
@@ -573,14 +540,23 @@ class Route implements RouteInterface
      * the order specified.
      *
      * @return bool
-     * @api
      */
     public function dispatch()
     {
-        foreach ($this->middleware as $mw) {
-            call_user_func_array($mw, array($this));
-        }
+        //Invoke middleware and route stack
+        $this->middleware[0]->call();
+        return true;
+    }
 
+    /**
+     * Call
+     *
+     * This method implements the \Middleware 'call' method
+     *
+     * @return bool
+     */
+    public function call()
+    {
         $return = call_user_func_array($this->getCallable(), array_values($this->getParams()));
         return ($return === false) ? false : true;
     }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -49,6 +49,33 @@ class CustomMiddleware extends \Slim\Middleware
     }
 }
 
+//Mock middleware
+class CustomMiddlewarePre extends \Slim\Middleware
+{
+    public function call()
+    {
+        echo "foo";
+        $this->next->call();
+    }
+}
+class CustomMiddlewarePost extends \Slim\Middleware
+{
+    public function call()
+    {
+        $this->next->call();
+        echo "bar";
+    }
+}
+class CustomMiddlewarePrePost extends \Slim\Middleware
+{
+    public function call()
+    {
+        echo "Xfoo";
+        $this->next->call();
+        echo "Xbar";
+    }
+}
+
 class AppTest extends PHPUnit_Framework_TestCase
 {
     protected $app;
@@ -287,12 +314,12 @@ class AppTest extends PHPUnit_Framework_TestCase
      */
     public function testGetRoute()
     {
-        $mw1 = function () { echo "foo"; };
-        $mw2 = function () { echo "bar"; };
+        $mw1 = new CustomMiddlewarePre();
+        $mw2 = new RouteMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->get('/bar', $mw1, $mw2, $callable);
         $this->app->call();
-        $this->assertEquals('foobarxyz', (string)$this->app['response']->getBody());
+        $this->assertEquals('fooxyzbar', (string)$this->app['response']->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -306,12 +333,12 @@ class AppTest extends PHPUnit_Framework_TestCase
             'REQUEST_METHOD' => 'POST',
         ));
 
-        $mw1 = function () { echo "foo"; };
-        $mw2 = function () { echo "bar"; };
+        $mw1 = new CustomMiddlewarePre();
+        $mw2 = new RouteMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->post('/bar', $mw1, $mw2, $callable);
         $this->app->call();
-        $this->assertEquals('foobarxyz', (string)$this->app['response']->getBody());
+        $this->assertEquals('fooxyzbar', (string)$this->app['response']->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -325,12 +352,12 @@ class AppTest extends PHPUnit_Framework_TestCase
             'REQUEST_METHOD' => 'PUT'
         ));
 
-        $mw1 = function () { echo "foo"; };
-        $mw2 = function () { echo "bar"; };
+        $mw1 = new CustomMiddlewarePre();
+        $mw2 = new RouteMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->put('/bar', $mw1, $mw2, $callable);
         $this->app->call();
-        $this->assertEquals('foobarxyz', (string)$this->app['response']->getBody());
+        $this->assertEquals('fooxyzbar', (string)$this->app['response']->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -344,12 +371,12 @@ class AppTest extends PHPUnit_Framework_TestCase
             'REQUEST_METHOD' => 'PATCH'
         ));
 
-        $mw1 = function () { echo "foo"; };
-        $mw2 = function () { echo "bar"; };
+        $mw1 = new CustomMiddlewarePre();
+        $mw2 = new RouteMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->patch('/bar', $mw1, $mw2, $callable);
         $this->app->call();
-        $this->assertEquals('foobarxyz', (string)$this->app['response']->getBody());
+        $this->assertEquals('fooxyzbar', (string)$this->app['response']->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -363,12 +390,12 @@ class AppTest extends PHPUnit_Framework_TestCase
             'REQUEST_METHOD' => 'DELETE'
         ));
 
-        $mw1 = function () { echo "foo"; };
-        $mw2 = function () { echo "bar"; };
+        $mw1 = new CustomMiddlewarePre();
+        $mw2 = new RouteMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->delete('/bar', $mw1, $mw2, $callable);
         $this->app->call();
-        $this->assertEquals('foobarxyz', (string)$this->app['response']->getBody());
+        $this->assertEquals('fooxyzbar', (string)$this->app['response']->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -382,12 +409,12 @@ class AppTest extends PHPUnit_Framework_TestCase
             'REQUEST_METHOD' => 'OPTIONS'
         ));
 
-        $mw1 = function () { echo "foo"; };
-        $mw2 = function () { echo "bar"; };
+        $mw1 = new CustomMiddlewarePre();
+        $mw2 = new RouteMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->options('/bar', $mw1, $mw2, $callable);
         $this->app->call();
-        $this->assertEquals('foobarxyz', (string)$this->app['response']->getBody());
+        $this->assertEquals('fooxyzbar', (string)$this->app['response']->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -403,14 +430,14 @@ class AppTest extends PHPUnit_Framework_TestCase
             'REQUEST_URI' => '/foo/bar/baz'
         ));
 
-        $mw1 = function () { echo "foo"; };
-        $mw2 = function () { echo "bar"; };
+        $mw1 = new CustomMiddlewarePre();
+        $mw2 = new RouteMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $app->group('/bar', $mw1, function () use ($app, $mw2, $callable) {
             $app->get('/baz', $mw2, $callable);
         });
         $app->call();
-        $this->assertEquals('foobarxyz', (string)$app['response']->getBody());
+        $this->assertEquals('fooxyzbar', (string)$app['response']->getBody());
     }
 
     /*
@@ -418,8 +445,8 @@ class AppTest extends PHPUnit_Framework_TestCase
      */
     public function testAnyRoute()
     {
-        $mw1 = function () { echo "foo"; };
-        $mw2 = function () { echo "bar"; };
+        $mw1 = new CustomMiddlewarePre();
+        $mw2 = new RouteMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $methods = array('GET', 'POST', 'PUT', 'DELETE', 'OPTIONS');
 
@@ -429,7 +456,7 @@ class AppTest extends PHPUnit_Framework_TestCase
             ));
             $route = $this->app->any('/bar', $mw1, $mw2, $callable);
             $this->app->call();
-            $this->assertEquals('foobarxyz', (string)$this->app['response']->getBody());
+            $this->assertEquals('fooxyzbar', (string)$this->app['response']->getBody());
             $this->assertEquals('/bar', $route->getPattern());
             $this->assertSame($callable, $route->getCallable());
         }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -315,7 +315,7 @@ class AppTest extends PHPUnit_Framework_TestCase
     public function testGetRoute()
     {
         $mw1 = new CustomMiddlewarePre();
-        $mw2 = new RouteMiddlewarePost();
+        $mw2 = new CustomMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->get('/bar', $mw1, $mw2, $callable);
         $this->app->call();
@@ -334,7 +334,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         ));
 
         $mw1 = new CustomMiddlewarePre();
-        $mw2 = new RouteMiddlewarePost();
+        $mw2 = new CustomMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->post('/bar', $mw1, $mw2, $callable);
         $this->app->call();
@@ -353,7 +353,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         ));
 
         $mw1 = new CustomMiddlewarePre();
-        $mw2 = new RouteMiddlewarePost();
+        $mw2 = new CustomMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->put('/bar', $mw1, $mw2, $callable);
         $this->app->call();
@@ -372,7 +372,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         ));
 
         $mw1 = new CustomMiddlewarePre();
-        $mw2 = new RouteMiddlewarePost();
+        $mw2 = new CustomMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->patch('/bar', $mw1, $mw2, $callable);
         $this->app->call();
@@ -391,7 +391,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         ));
 
         $mw1 = new CustomMiddlewarePre();
-        $mw2 = new RouteMiddlewarePost();
+        $mw2 = new CustomMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->delete('/bar', $mw1, $mw2, $callable);
         $this->app->call();
@@ -410,7 +410,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         ));
 
         $mw1 = new CustomMiddlewarePre();
-        $mw2 = new RouteMiddlewarePost();
+        $mw2 = new CustomMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $route = $this->app->options('/bar', $mw1, $mw2, $callable);
         $this->app->call();
@@ -431,7 +431,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         ));
 
         $mw1 = new CustomMiddlewarePre();
-        $mw2 = new RouteMiddlewarePost();
+        $mw2 = new CustomMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $app->group('/bar', $mw1, function () use ($app, $mw2, $callable) {
             $app->get('/baz', $mw2, $callable);
@@ -446,7 +446,7 @@ class AppTest extends PHPUnit_Framework_TestCase
     public function testAnyRoute()
     {
         $mw1 = new CustomMiddlewarePre();
-        $mw2 = new RouteMiddlewarePost();
+        $mw2 = new CustomMiddlewarePost();
         $callable = function () { echo "xyz"; };
         $methods = array('GET', 'POST', 'PUT', 'DELETE', 'OPTIONS');
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -593,7 +593,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
 		$mw1 = new RouteMiddleware1();
         $mw2 = new RouteMiddleware2();
         $route->setMiddleware($mw2);
-        $route->setMiddleware($mw1)
+        $route->setMiddleware($mw1);
         $route->matches('/hello/josh'); //<-- Extracts params from resource URI
         $route->dispatch();
     }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -51,6 +51,24 @@ class FooTestClass {
     }
 }
 
+//Mock middleware
+class RouteMiddleware1 extends \Slim\Middleware
+{
+    public function call()
+    {
+        echo "First! ";
+        $this->next->call();
+    }
+}
+class RouteMiddleware2 extends \Slim\Middleware
+{
+    public function call()
+    {
+        echo "Second! ";
+        $this->next->call();
+    }
+}
+
 class RouteTest extends PHPUnit_Framework_TestCase
 {
     public function testGetPattern()
@@ -428,9 +446,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
     public function testSetMiddleware()
     {
         $route = new \Slim\Route('/foo', function () {});
-        $mw = function () {
-            echo 'Foo';
-        };
+        $mw = new RouteMiddleware1();
         $route->setMiddleware($mw);
 
         $this->assertAttributeContains($mw, 'middleware', $route);
@@ -439,12 +455,8 @@ class RouteTest extends PHPUnit_Framework_TestCase
     public function testSetMiddlewareMultipleTimes()
     {
         $route = new \Slim\Route('/foo', function () {});
-        $mw1 = function () {
-            echo 'Foo';
-        };
-        $mw2 = function () {
-            echo 'Bar';
-        };
+        $mw1 = new RouteMiddleware1();
+        $mw2 = new RouteMiddleware2();
         $route->setMiddleware($mw1);
         $route->setMiddleware($mw2);
 
@@ -455,12 +467,8 @@ class RouteTest extends PHPUnit_Framework_TestCase
     public function testSetMiddlewareWithArray()
     {
         $route = new \Slim\Route('/foo', function () {});
-        $mw1 = function () {
-            echo 'Foo';
-        };
-        $mw2 = function () {
-            echo 'Bar';
-        };
+        $mw1 = new RouteMiddleware1();
+        $mw2 = new RouteMiddleware2();
         $route->setMiddleware(array($mw1, $mw2));
 
         $this->assertAttributeContains($mw1, 'middleware', $route);
@@ -582,28 +590,11 @@ class RouteTest extends PHPUnit_Framework_TestCase
     {
         $this->expectOutputString('First! Second! Hello josh');
         $route = new \Slim\Route('/hello/:name', function ($name) { echo "Hello $name"; });
-        $route->setMiddleware(function () {
-            echo "First! ";
-        });
-        $route->setMiddleware(function () {
-            echo "Second! ";
-        });
+		$mw1 = new RouteMiddleware1();
+        $mw2 = new RouteMiddleware2();
+        $route->setMiddleware($mw2);
+        $route->setMiddleware($mw1)
         $route->matches('/hello/josh'); //<-- Extracts params from resource URI
-        $route->dispatch();
-    }
-
-    /**
-     * Test middleware with arguments
-     */
-    public function testRouteMiddlwareArguments()
-    {
-        $this->expectOutputString('foobar');
-        $route = new \Slim\Route('/foo', function () { echo "bar"; });
-        $route->setName('foo');
-        $route->setMiddleware(function ($route) {
-            echo $route->getName();
-        });
-        $route->matches('/foo'); //<-- Extracts params from resource URI
         $route->dispatch();
     }
 }


### PR DESCRIPTION
Proposal to use a single type of "middleware", instead of having application middleware and route middleware.
This commit changes Route.php to use \Slim\Middleware instead of just a callable.
This of course implies that "route middleware" now implements the rack protocol.

(http://help.slimframework.com/discussions/suggestions/581-enhancing-route-mdidleware)
