### PR TITLE
Patch 840

### DIFF
--- a/Slim/Log.php
+++ b/Slim/Log.php
@@ -306,8 +306,8 @@ class Log
         if (!isset(self::$levels[$level])) {
             throw new \InvalidArgumentException('Invalid log level supplied to function');
         } else if ($this->enabled && $this->writer && $level <= $this->level) {
-            $message = (string)$object;
-            if (count($context) > 0) {
+            $message = $object;
+            if ($context) {
                 if (isset($context['exception']) && $context['exception'] instanceof \Exception) {
                     $message .= ' - ' . $context['exception'];
                     unset($context['exception']);

--- a/Slim/Log.php
+++ b/Slim/Log.php
@@ -85,7 +85,7 @@ class Log
     );
 
     /**
-     * @var mixed
+     * @var mixed|\Slim\LogWriter
      */
     protected $writer;
 
@@ -101,7 +101,7 @@ class Log
 
     /**
      * Constructor
-     * @param  mixed $writer
+     * @param  mixed|\Slim\LogWriter $writer
      */
     public function __construct($writer)
     {

--- a/Slim/LogWriter.php
+++ b/Slim/LogWriter.php
@@ -35,8 +35,10 @@ namespace Slim;
 /**
  * Log Writer
  *
- * This class is used by Slim_Log to write log messages to a valid, writable
+ * This class is used by \Slim\Log to write log messages to a valid, writable
  * resource handle (e.g. a file or STDERR).
+ *
+ * @see \Slim\Log
  *
  * @package Slim
  * @author  Josh Lockhart

--- a/Slim/LogWriter.php
+++ b/Slim/LogWriter.php
@@ -66,10 +66,11 @@ class LogWriter
      * Write message
      * @param  mixed     $message
      * @param  int       $level
-     * @return int|bool
+     * @return int|bool  number of bytes written, or FALSE on error
+     * @see fwrite
      */
     public function write($message, $level = null)
     {
-        return fwrite($this->resource, (string) $message . PHP_EOL);
+        return fwrite($this->resource, (isset($level) ? "[$level]: " : '') . $message . PHP_EOL);
     }
 }

--- a/tests/LogWriterTest.php
+++ b/tests/LogWriterTest.php
@@ -34,10 +34,11 @@ class LogWriterTest extends PHPUnit_Framework_TestCase
 {
     public function testInstantiation()
     {
-        $this->expectOutputString('Hello!' . PHP_EOL);
+        $this->expectOutputString('Hello!' . PHP_EOL . '[22]: Hello!' . PHP_EOL);
         $handle = fopen('php://output', 'w');
         $fw = new \Slim\LogWriter($handle);
-        $this->assertTrue($fw->write('Hello!') > 0); //<-- Returns number of bytes written if successful
+        $this->assertGreaterThan(0, $fw->write('Hello!'));
+        $this->assertGreaterThan(0, $fw->write('Hello!', 22));
     }
 
     public function testInstantiationWithNonResource()


### PR DESCRIPTION
see #840

this fixes additional  minor issues like additional docblock comments and an unused variable in `LogWriter::write()`.
