### PR TITLE
no need for is_array test

### DIFF
--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -142,11 +142,8 @@ class Headers extends Collection implements HeadersInterface
     public function add($key, $value)
     {
         $header = $this->get($key, true);
-        if (is_array($value)) {
-            $header = array_merge($header, $value);
-        } else {
-            $header[] = $value;
-        }
+        $header = array_merge($header, $value);
+            
         parent::set($this->normalizeKey($key), $header);
     }
 


### PR DESCRIPTION
set/parse always set values as array
get($key, true) always get an (maybe empty) array;

I still have a doubt about the (Collection) get method override. It passes E_STRICT but in this case the second parameter has a different meaning than the original $default value.
