### PR TITLE
Explicit flow control for better static analysis

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -736,6 +736,7 @@ class App extends \Pimple
      * The thrown exception will be caught in application's `call()` method
      * and the response will be sent as is to the HTTP client.
      *
+     * @return \Exception
      * @throws \Slim\Exception\Stop
      * @api
      */
@@ -755,6 +756,7 @@ class App extends \Pimple
      *
      * @param  int    $status  The HTTP response status
      * @param  string $message The HTTP response body
+     * @throws \Exception
      * @api
      */
     public function halt($status, $message = '')
@@ -762,7 +764,7 @@ class App extends \Pimple
         $this->cleanBuffer();
         $this['response']->setStatus($status);
         $this['response']->write($message, true);
-        $this->stop();
+        throw $this->stop();
     }
 
     /**
@@ -772,6 +774,7 @@ class App extends \Pimple
      * the router's current iteration to stop and continue to the subsequent route if available.
      * If no subsequent matching routes are found, a 404 response will be sent to the client.
      *
+     * @return \Exception
      * @throws \Slim\Exception\Pass
      * @api
      */


### PR DESCRIPTION
## Why?

The motivation for this is to explicitly tell static analysis tools that `App::stop` (and friends) won't return flow control.
## What changed?

_No code change was required_. Only signature (aka docblocks) changes were added. All we need is those functions to explicit declare that they `@return \Exception`

> to be fair a `throw` was required to satisfy `App::halt`'s signature
> although it's guaranteed it will not be used as `App::stop` won't return flow control
## What's the benefit of this?

``` php
$app->get('/some/route', function () use ($app) {
  if (someCondition()) {
      throw $app->halt(404); // <-- explicit flow control
  }
  $app->render('some/page');
});
```

Although it's completely possible to write client code like the example shown here, static analysis tools will complain about `App::halt` not returning `Exception`.
