### PR TITLE
Each route gets a canonical name by default, i.e. a number.

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -98,6 +98,11 @@ class Slim
         'slim.after' => array(array())
     );
 
+    /**
+     * @var integer Counts the number of available routes. 
+     */
+    private $routeCount = 0;
+
     /********************************************************************************
     * PSR-0 Autoloader
     *
@@ -441,6 +446,8 @@ class Slim
         $pattern = array_shift($args);
         $callable = array_pop($args);
         $route = new \Slim\Route($pattern, $callable, $this->settings['routes.case_sensitive']);
+        $this->routeCount++;
+        $route->setName((string)$this->routeCount);
         $this->router->map($route);
         if (count($args) > 0) {
             $route->setMiddleware($args);


### PR DESCRIPTION
By this, it is possible to programmatically list all available routes.
Example:
$routes = $app->router()->getNamedRoutes();

For course, routes can still labeled with custom names, i.e. the canonical names can be overridden.
