### PR TITLE
Matched routes should be saved so we can use getPattern() inside middleware hooks

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -1077,7 +1077,7 @@ class App extends \Pimple
             ob_start();
             $this->applyHook('slim.before.router');
             $dispatched = false;
-            $matchedRoutes = $this['router']->getMatchedRoutes($request->getMethod(), $request->getPathInfo(), false);
+            $matchedRoutes = $this['router']->getMatchedRoutes($request->getMethod(), $request->getPathInfo(), true);
             foreach ($matchedRoutes as $route) {
                 try {
                     $this->applyHook('slim.before.dispatch');


### PR DESCRIPTION
Save matched routes in dispatchRequest so you can use $router->getPattern() in various middleware
