### PR TITLE
Slim View extract fix; removed possibility to include arbitrary file

### DIFF
--- a/Slim/View.php
+++ b/Slim/View.php
@@ -273,7 +273,7 @@ class View
         }
 
         $data = array_merge($this->data->all(), (array) $data);
-        extract($data);
+        extract($data, EXTR_SKIP);
         ob_start();
         require $templatePathname;
 


### PR DESCRIPTION
Here is method `render` of class `\Slim\View`:

```
    protected function render($template, $data = null)
    {
        $templatePathname = $this->getTemplatePathname($template);
        if (!is_file($templatePathname)) {
            throw new \RuntimeException("View cannot render `$template` because the template does not exist");
        }

        $data = array_merge($this->data->all(), (array) $data);
        extract($data);
        ob_start();
        require $templatePathname;

        return ob_get_clean();
    }

```

Pay attention to `extract`. If you pass variable `templatePathname` to template, it will overwrite path to template and arbitrary file may be included. Such behaviour if default for `extract`.

How to reproduce:

```
public function testAction() {
    $this->getApp()->render('test.php', array('templatePathname', '/etc/passwd'));
}
```
