### PR TITLE
Fix race condition in testExpiresAsString

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -724,7 +724,12 @@ class AppTest extends PHPUnit_Framework_TestCase
         $app['response']->finalize($app['request']);
 
         $this->assertNotNull($app['response']->getHeader('Expires'));
-        $this->assertEquals($expectedDate, $app['response']->getHeader('Expires'));
+        $this->assertEquals(
+          strtotime($expectedDate),
+          strtotime($app['response']->getHeader('Expires')),
+          '', // custom message
+          1 // delta
+        );
     }
 
     /**


### PR DESCRIPTION
Calling time functions twice in a row isn't guaranteed to get you the
same results.
