### PR TITLE
json can also just contain null or false.

### DIFF
--- a/Slim/Middleware/ContentTypes.php
+++ b/Slim/Middleware/ContentTypes.php
@@ -116,7 +116,7 @@ class ContentTypes extends \Slim\Middleware
     {
         if (function_exists('json_decode')) {
             $result = json_decode($input, true);
-            if ($result) {
+            if(json_last_error() === JSON_ERROR_NONE) {
                 return $result;
             }
         }


### PR DESCRIPTION
used json_last_error to check if json was decoded successfully.

Not sure if exceptions should be thrown however, I mean you should be able to use a HTTP DELETE for null values...
