### PR TITLE
Slim View extract fix; removed possibility to include arbitrary file

### DIFF
--- a/Slim/View.php
+++ b/Slim/View.php
@@ -134,7 +134,7 @@ class View extends Collection implements ViewInterface
 
         // Render template with view variables into a temporary output buffer
         $this->replace($data);
-        extract($this->all());
+        extract($this->all(), EXTR_SKIP);
         ob_start();
         require $templatePathname;
 


### PR DESCRIPTION
Here is method `render` of class `\Slim\View`:

```
    protected function render($template, array $data = array())
    {
        // Resolve and verify template file
        $templatePathname = $this->templateDirectory . DIRECTORY_SEPARATOR . ltrim($template, DIRECTORY_SEPARATOR);
        if (!is_file($templatePathname)) {
            throw new \RuntimeException("Cannot render template `$templatePathname` because the template does not exist. Make sure your view's template directory is correct.");
        }

        // Render template with view variables into a temporary output buffer
        $this->replace($data);
        extract($this->all());
        ob_start();
        require $templatePathname;

        // Return temporary output buffer content, destroy output buffer
        return ob_get_clean();
    }

```

Pay attention to `extract`. If you pass variable `templatePathname` to template, it will overwrite path to template and arbitrary file may be included. Such behaviour if default for `extract`.

How to reproduce:

```
public function testAction() {
    $this->getApp()->render('test.php', array('templatePathname' => '/etc/passwd'));
}
```
