### PR TITLE
Use DIRECTORY_SEPARATOR instead of / in test. 

### DIFF
--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -162,7 +162,8 @@ class ViewTest extends PHPUnit_Framework_TestCase
     public function testSetTemplatesDirectory()
     {
         $view = new \Slim\View();
-        $view->setTemplatesDirectory('templates/'); // <-- Should strip trailing slash
+        $directory = 'templates' . DIRECTORY_SEPARATOR;
+        $view->setTemplatesDirectory($directory); // <-- Should strip trailing slash
 
         $this->assertAttributeEquals('templates', 'templatesDirectory', $view);
     }


### PR DESCRIPTION
It looks like tests always fail in Windows. Failing line in [setTemplatesDirectory()](https://github.com/codeguy/Slim/blob/master/Slim/View.php#L207) is the following:

``` php
$this->templatesDirectory = rtrim($directory, DIRECTORY_SEPARATOR);
```

[ViewTest::testSetTemplatesDirectory()](https://github.com/codeguy/Slim/blob/master/tests/ViewTest.php#L165) has hardcoded "/" character which causes test to fail in Windows. Slim code itself is correct. Test is not portable.

``` php
$view->setTemplatesDirectory('templates/');
```

PR has not been tested with actual Windows machine. PR is against master because this test does not exist in develop anymore.
