### PR TITLE
Include redirected items when parsing headers.

### DIFF
--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -93,7 +93,7 @@ class Headers extends Collection implements HeadersInterface
         foreach ($environment as $key => $value) {
             $key = strtoupper($key);
 
-            if (strpos($key, 'HTTP_') === 0 || in_array($key, $this->special)) {
+            if (strpos($key, 'HTTP_') === 0 || strpos($key, 'REDIRECT_') === 0 || in_array($key, $this->special)) {
                 if ($key === 'HTTP_CONTENT_TYPE' || $key === 'HTTP_CONTENT_LENGTH') {
                     continue;
                 }

--- a/tests/Http/HeadersTest.php
+++ b/tests/Http/HeadersTest.php
@@ -122,4 +122,16 @@ class HeadersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('text/csv', $headers->get('HTTP_CONTENT_TYPE'));
         $this->assertEquals(10, $headers->get('HTTP_CONTENT_LENGTH'));
     }
+
+    public function testCapturesRedirectedHeaders()
+    {
+        $env = new \Slim\Environment();
+        $env->mock(array(
+            'REDIRECT_HTTP_AUTHORIZATION' => 'Basic cm9vdDp0MDBy',
+            'REDIRECT_HTTP_FOO' => "bar"
+        ));
+        $headers = new \Slim\Http\Headers($env);
+        $this->assertEquals('Basic cm9vdDp0MDBy', $headers->get('Redirect-Http-Authorization'));
+        $this->assertEquals('bar', $headers->get('Redirect-Http-Foo'));
+    }
 }


### PR DESCRIPTION
Undocumented Apache [annoyance](http://goo.gl/tRKHba). In some cases when using mod_rewrite _REDIRECT__ prefix is added to the headers.  This happens for example when using workaround to make HTTP Basic Authentication work together with FastCGI.

`RewriteRule .* - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]`

Currently Slim does not include these items when parsing the headers. Only way to access them is through _$_SERVER_ superglobal.
