### PR TITLE
Prevent fatal error if callable does not exist in Route->setCallable

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -202,7 +202,13 @@ class Route implements RouteInterface
             $callable = function() use ($class, $method) {
                 static $obj = null;
                 if ($obj === null) {
+                    if(!class_exists($class)) {
+                        throw new \InvalidArgumentException('Route callable class does not exist');
+                    }
                     $obj = new $class;
+                }
+                if(!method_exists($obj, $method)) {
+                    throw new \InvalidArgumentException('Route callable method does not exist');
                 }
                 return call_user_func_array(array($obj, $method), func_get_args());
             };


### PR DESCRIPTION
Add class and method checks to setCallable to avoid fatal errors when callable does not exist.
