### PR TITLE
Allow multiple arguments for applyHook

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -856,11 +856,11 @@ class App extends \Pimple
 
     /**
      * Invoke hook
-     * @param  string $name    The hook name
-     * @param  mixed  $hookArg (Optional) Argument for hooked functions
+     * @param  string $name The hook name
+     * @param  mixed  ...   (Optional) Argument(s) for hooked functions, can specify multiple arguments
      * @api
      */
-    public function applyHook($name, $hookArg = null)
+    public function applyHook($name)
     {
         if (!isset($this->hooks[$name])) {
             $this->hooks[$name] = array(array());
@@ -870,10 +870,15 @@ class App extends \Pimple
             if (count($this->hooks[$name]) > 1) {
                 ksort($this->hooks[$name]);
             }
+
+            $args = func_get_args();
+            array_shift($args);
+            var_dump($args);
+
             foreach ($this->hooks[$name] as $priority) {
                 if (!empty($priority)) {
                     foreach ($priority as $callable) {
-                        call_user_func($callable, $hookArg);
+                        call_user_func_array($callable, $args);
                     }
                 }
             }


### PR DESCRIPTION
Not using variadic due to PHP5.6+ only.
