### PR TITLE
add \Slim\Router\::getRouteParam

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -69,12 +69,37 @@ class Router
     protected $routeGroups;
 
     /**
+     * @var array Lookup hash of all params route get
+     */
+    protected $routeParams;
+
+    /**
      * Constructor
      */
     public function __construct()
     {
         $this->routes = array();
         $this->routeGroups = array();
+        $this->routeParams = array();
+    }
+
+    /**
+     * Get any matched route params
+     *
+     * @param   string|null     $name   the param name in the route pattern, if null, return all the matched route param as array, return null if the $key doesn't exist
+     * @return  string|array
+     */
+    public function getRouteParam($key = false)
+    {
+        if ($key === false) {
+            return $this->routeParams;
+        }
+
+        if (array_key_exists($key, $this->routeParams)) {
+            return $this->routeParams["$key"];
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -112,6 +137,7 @@ class Router
 
                 if ($route->matches($resourceUri)) {
                     $this->matchedRoutes[] = $route;
+                    $this->routeParams = array_merge($this->routeParams, $route->getParams());
                 }
             }
         }


### PR DESCRIPTION
Since now the Route Param can only(?) be accessed by the param of the Route Callback function.
It may be a little bit difficult to get the Route Param in the Route Middleware now, I think there should be another way to do the trick like other thing.
This patch offers another way to get Route Param, with this, we can get route param like the following code

``` php
$app->get('/:param1/:param2', function (/*optional, add as you want*/) use ($app) {
    $param1 = $app->router->getRouteParam("param1");
    $param2 = $app->router->getRouteParam("param2");
});
```
