### PR TITLE
add getParam for router, now we can get Route Param anywhere

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -80,6 +80,12 @@ class Router implements RouterInterface
     protected $routeGroups;
 
     /**
+     * all params of the matched route
+     * @var array
+     */
+    protected $routeParams;
+
+    /**
      * Constructor
      * @api
      */
@@ -87,6 +93,26 @@ class Router implements RouterInterface
     {
         $this->routes = array();
         $this->routeGroups = array();
+        $this->routeParams = array();
+    }
+
+    /**
+     * Get any matched route params
+     *
+     * @param   string|null     $name   the param name in the route pattern, if null, return all the matched route param as array, return null if the $key doesn't exist
+     * @return  string|array
+     */
+    public function getParam($key = false)
+    {
+        if ($key === false) {
+            return $this->routeParams;
+        }
+
+        if (array_key_exists($key, $this->routeParams)) {
+            return $this->routeParams["$key"];
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -142,6 +168,7 @@ class Router implements RouterInterface
 
         if ($save === true) {
             $this->matchedRoutes = $matchedRoutes;
+            $this->routeParams = array_merge($this->routeParams, $route->getParams());
         }
 
         return $matchedRoutes;


### PR DESCRIPTION
I can't using Route Param IN the Route Middleware Since now I can only(?) access Route Param via the Route Callback Parameters.
This patch fixed this problem.
e.g.

``` php
$app->get('/:param1/:param2', function (/*now it's optional*/) use ($app) {
    $param1 = $app->router->getParam('param1');
    $param2 = $app->router->getParam('param2');
    $allparam = $app->router->getParam();
});
```
