### PR TITLE
clean buffer after exception in route

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1344,6 +1344,7 @@ class Slim
                 throw $e;
             } else {
                 try {
+                    $this->response()->write(ob_get_clean());
                     $this->error($e);
                 } catch (\Slim\Exception\Stop $e) {
                     // Do nothing


### PR DESCRIPTION
The output buffer doesn't seem to be cleaned after an error in a route.
This makes the `$this->response->body('');` in the error method to be useless as the route output will be sent to the browser anyway.

``` php
$app = new Slim\Slim(array('debug'=>false));
$app->get('/', function() {
    echo 'foo';
    throw new \Exception();
});
$app->error(function() {
    echo 'bar';
});
$app->run();
```

The expected output would be `bar` as the response body is supposed the be cleaned, but the actual output is `foobar` instead.

This PR cleans the buffer before calling the error method.
