### PR TITLE
Fix unit test on Windows

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -511,13 +511,13 @@ class AppTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('application/json', $app['response']->getHeader('Content-Type'));
     }
 
-    public function testStreamingAProc()
+    public function testStreamingAProcess()
     {
         $this->expectOutputString("FooBar\n");
 
         $app = $this->createApp();
         $app->get('/bar', function() use ($app) {
-            $app->sendProcess("echo 'FooBar'");
+            $app->sendProcess("echo FooBar");
         });
         $app->run();
     }


### PR DESCRIPTION
Windows's echo doesn't remove the enclosing quotes.

Also renamed the test for clarity and consistency with 828613e068b169c2cdc8844fd98a6f3a960fc4a3
