### PR TITLE
Error with virtual path in case a physical path is not a part of it.

### DIFF
--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -140,7 +140,11 @@ class Environment implements \ArrayAccess, \IteratorAggregate
             $env['SCRIPT_NAME'] = rtrim($physicalPath, '/'); // <-- Remove trailing slashes
 
             // Virtual path
-            $env['PATH_INFO'] = substr_replace($requestUri, '', 0, strlen($physicalPath)); // <-- Remove physical path
+            if (strpos($requestUri, $physicalPath) === 0) {
+                $env['PATH_INFO'] = substr($requestUri, strlen($physicalPath)); // <-- Remove physical path
+            } else {
+                $env['PATH_INFO'] = $requestUri; // <-- Physical path is not a part of request uri
+            }
             $env['PATH_INFO'] = str_replace('?' . $queryString, '', $env['PATH_INFO']); // <-- Remove query string
             $env['PATH_INFO'] = '/' . ltrim($env['PATH_INFO'], '/'); // <-- Ensure leading slash
 


### PR DESCRIPTION
Hi everyone!
I have problem with routing on my hosting where it is not possible to set "DocumentRoot" to 'public' subfolder (in my project 'index.php' placed in 'public' directory). I was created a '.htaccess' file with content:

```
DirectoryIndex /public/index.php
RewriteEngine On
RewriteCond %{REQUEST_FILENAME} -f
RewriteRule ^(.+) $1 [L]
RewriteCond %{DOCUMENT_ROOT}/public%{REQUEST_URI} -f
RewriteRule ^(.+) /public/$1 [L]
RewriteCond %{DOCUMENT_ROOT}/public/index.php -f
RewriteRule ^(.*) /public/index.php
```

And I see that all my routes was broken in $env['PATH_INFO'].
For example: 'ts' instead '/contacts'.
It happened because on line 143 in 'Slim/Environment.php':

```
$env['PATH_INFO'] = substr_replace($requestUri, '', 0, strlen($physicalPath)); // <-- Remove physical path
```

first seven symbols (strlen('/public')) was removed from $env['PATH_INFO'] but it does not contain '/public'.
And I was added a logic to check if physical path is a really part of $env['PATH_INFO']:

```
if (strpos($requestUri, $physicalPath) === 0) {
    $env['PATH_INFO'] = substr($requestUri, strlen($physicalPath)); // <-- Remove physical path
} else {
    $env['PATH_INFO'] = $requestUri; // <-- Physical path is not a part of request uri
}
```

P.S. Sorry for my bad English. :)
