### PR TITLE
How to run Slim on Google App Engine/Cloud Platform

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -132,6 +132,31 @@ Ensure the `Web.config` and `index.php` files are in the same public-accessible 
         </system.webServer>
     </configuration>
 
+#### Google App Engine
+
+Two steps are required to successfully run your Slim application on Google App Engine. First, ensure the `app.yaml` file includes a default handler to `index.php`:
+
+    application: your-app-name
+    version: 1
+    runtime: php
+    api_version: 1
+    
+    handlers:
+    # ...
+    - url: /.*
+      script: public_html/index.php
+
+Next, edit your `index.php` file so Slim knows about the incoming URI:
+
+    $app = new Slim();
+    
+    // Google App Engine doesn't set $_SERVER['PATH_INFO']
+    $app->environment['PATH_INFO'] = $_SERVER['REQUEST_URI'];
+    
+    // ...
+    $app->run();
+
+   
 ## Documentation
 
 <http://docs.slimframework.com/>


### PR DESCRIPTION
Not only do you need a default script handler that points to your index.php file, but you will also need to manually populate the PATH_INFO attribute of Slim's Environment object. Additionally, App Engine doesn't set $_SERVER['SERVER_PORT'], which Slim doesn't use directly, but attempts to set to its Environment object. If you don't manually set SERVER_PORT on the $_SERVER object, GAE will fire a warning every time Slim loads up.
