### PR TITLE
Remove framework dependencies on deprecated methods

### DIFF
--- a/Slim/Helper/Set.php
+++ b/Slim/Helper/Set.php
@@ -140,6 +140,16 @@ class Set implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
+     * Add value as Closure with key
+     * @param string $key
+     * @param mixed $value
+     */
+    public function keep($key, \Closure $value)
+    {
+        $this->set($key, $this->protect($value));
+    }
+    
+    /**
      * Property Overloading
      */
 

--- a/Slim/Middleware/PrettyExceptions.php
+++ b/Slim/Middleware/PrettyExceptions.php
@@ -71,8 +71,8 @@ class PrettyExceptions extends \Slim\Middleware
             $env['slim.log'] = $log;
             $env['slim.log']->error($e);
             $this->app->contentType('text/html');
-            $this->app->response()->status(500);
-            $this->app->response()->body($this->renderBody($env, $e));
+            $this->app->response()->setStatus(500);
+            $this->app->response()->setBody($this->renderBody($env, $e));
         }
     }
 

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -633,8 +633,8 @@ class Slim
             $this->error = $argument;
         } else {
             //Invoke error handler
-            $this->response->status(500);
-            $this->response->body('');
+            $this->response->setStatus(500);
+            $this->response->setBody('');
             $this->response->write($this->callErrorHandler($argument));
             $this->stop();
         }
@@ -719,13 +719,13 @@ class Slim
     public function view($viewClass = null)
     {
         if (!is_null($viewClass)) {
-            $existingData = is_null($this->view) ? array() : $this->view->getData();
+            $existingData = is_null($this->view) ? array() : $this->view->all();
             if ($viewClass instanceOf \Slim\View) {
                 $this->view = $viewClass;
             } else {
                 $this->view = new $viewClass();
             }
-            $this->view->appendData($existingData);
+            $this->view->replace($existingData);
             $this->view->setTemplatesDirectory($this->config('templates.path'));
         }
 
@@ -751,9 +751,9 @@ class Slim
     public function render($template, $data = array(), $status = null)
     {
         if (!is_null($status)) {
-            $this->response->status($status);
+            $this->response->setStatus($status);
         }
-        $this->view->appendData($data);
+        $this->view->replace($data);
         $this->view->display($template);
     }
 
@@ -1032,8 +1032,8 @@ class Slim
     public function halt($status, $message = '')
     {
         $this->cleanBuffer();
-        $this->response->status($status);
-        $this->response->body($message);
+        $this->response->setStatus($status);
+        $this->response->setBody($message);
         $this->stop();
     }
 
@@ -1313,7 +1313,7 @@ class Slim
     {
         try {
             if (isset($this->environment['slim.flash'])) {
-                $this->view()->setData('flash', $this->environment['slim.flash']);
+                $this->view()->set('flash', $this->environment['slim.flash']);
             }
             $this->applyHook('slim.before');
             ob_start();

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -442,17 +442,17 @@ class RequestTest extends PHPUnit_Framework_TestCase
             'HTTP_ACCEPT_ENCODING' => 'gzip'
         ));
         $req = new \Slim\Http\Request($env);
-        $headers = $req->headers();
+        $headers = $req->headers;
         $this->assertInstanceOf('\Slim\Http\Headers', $headers);
-        $this->assertEquals('gzip', $req->headers('HTTP_ACCEPT_ENCODING'));
-        $this->assertEquals('gzip', $req->headers('HTTP-ACCEPT-ENCODING'));
-        $this->assertEquals('gzip', $req->headers('http_accept_encoding'));
-        $this->assertEquals('gzip', $req->headers('http-accept-encoding'));
-        $this->assertEquals('gzip', $req->headers('ACCEPT_ENCODING'));
-        $this->assertEquals('gzip', $req->headers('ACCEPT-ENCODING'));
-        $this->assertEquals('gzip', $req->headers('accept_encoding'));
-        $this->assertEquals('gzip', $req->headers('accept-encoding'));
-        $this->assertNull($req->headers('foo'));
+        $this->assertEquals('gzip', $req->headers->get('HTTP_ACCEPT_ENCODING'));
+        $this->assertEquals('gzip', $req->headers->get('HTTP-ACCEPT-ENCODING'));
+        $this->assertEquals('gzip', $req->headers->get('http_accept_encoding'));
+        $this->assertEquals('gzip', $req->headers->get('http-accept-encoding'));
+        $this->assertEquals('gzip', $req->headers->get('ACCEPT_ENCODING'));
+        $this->assertEquals('gzip', $req->headers->get('ACCEPT-ENCODING'));
+        $this->assertEquals('gzip', $req->headers->get('accept_encoding'));
+        $this->assertEquals('gzip', $req->headers->get('accept-encoding'));
+        $this->assertNull($req->headers->get('foo'));
     }
 
     /**
@@ -466,9 +466,9 @@ class RequestTest extends PHPUnit_Framework_TestCase
         ));
         //fwrite(fopen('php://stdout', 'w'), print_r($env, true));
         $req = new \Slim\Http\Request($env);
-        $this->assertEquals('PUT', $req->headers('X_HTTP_METHOD_OVERRIDE'));
-        $this->assertNull($req->headers('X_METHOD_OVERRIDE')); //<-- Ensures `HTTP_` is not removed if not prefix
-        $this->assertEquals('application/json', $req->headers('HTTP_CONTENT_TYPE')); //<-- Ensures `HTTP_` is removed if prefix
+        $this->assertEquals('PUT', $req->headers->get('X_HTTP_METHOD_OVERRIDE'));
+        $this->assertNull($req->headers->get('X_METHOD_OVERRIDE')); //<-- Ensures `HTTP_` is not removed if not prefix
+        $this->assertEquals('application/json', $req->headers->get('HTTP_CONTENT_TYPE')); //<-- Ensures `HTTP_` is removed if prefix
     }
 
     /**

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -69,7 +69,7 @@ class ResponseTest extends PHPUnit_Framework_TestCase
     public function testStatusGetOld()
     {
         $res = new \Slim\Http\Response('', 201);
-        $this->assertEquals(201, $res->status());
+        $this->assertEquals(201, $res->getStatus());
     }
 
     /**
@@ -80,7 +80,7 @@ class ResponseTest extends PHPUnit_Framework_TestCase
         $res = new \Slim\Http\Response();
         $prop = new \ReflectionProperty($res, 'status');
         $prop->setAccessible(true);
-        $res->status(301);
+        $res->setStatus(301);
 
         $this->assertEquals(301, $prop->getValue($res));
     }

--- a/tests/Middleware/PrettyExceptionsTest.php
+++ b/tests/Middleware/PrettyExceptionsTest.php
@@ -49,8 +49,8 @@ class PrettyExceptionsTest extends PHPUnit_Framework_TestCase
         $mw->setApplication($app);
         $mw->setNextMiddleware($app);
         $mw->call();
-        $this->assertEquals(200, $app->response()->status());
-        $this->assertEquals('Success', $app->response()->body());
+        $this->assertEquals(200, $app->response()->getStatus());
+        $this->assertEquals('Success', $app->response()->getBody());
     }
 
     /**
@@ -72,8 +72,8 @@ class PrettyExceptionsTest extends PHPUnit_Framework_TestCase
         $mw->setApplication($app);
         $mw->setNextMiddleware($app);
         $mw->call();
-        $this->assertEquals(1, preg_match('@Slim Application Error@', $app->response()->body()));
-        $this->assertEquals(500, $app->response()->status());
+        $this->assertEquals(1, preg_match('@Slim Application Error@', $app->response()->getBody()));
+        $this->assertEquals(500, $app->response()->getStatus());
     }
 
     /**
@@ -120,7 +120,7 @@ class PrettyExceptionsTest extends PHPUnit_Framework_TestCase
         $mw->setNextMiddleware($app);
         $mw->call();
 
-        $this->assertContains('LogicException', $app->response()->body());
+        $this->assertContains('LogicException', $app->response()->getBody());
     }
 
     /**
@@ -148,6 +148,6 @@ class PrettyExceptionsTest extends PHPUnit_Framework_TestCase
         $mw->setNextMiddleware($app);
         $mw->call();
 
-        $this->assertContains('LogicException', $app->response()->body());
+        $this->assertContains('LogicException', $app->response()->getBody());
     }
 }

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -62,7 +62,7 @@ class CustomMiddleware extends \Slim\Middleware
         $res = $this->app->response();
         $env['slim.test'] = 'Hello';
         $this->next->call();
-        $res->header('X-Slim-Test', 'Hello');
+        $res->headers->set('X-Slim-Test', 'Hello');
         $res->write('Hello');
     }
 }
@@ -368,7 +368,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $callable = function () { echo "xyz"; };
         $route = $s->get('/bar', $mw1, $mw2, $callable);
         $s->call();
-        $this->assertEquals('foobarxyz', $s->response()->body());
+        $this->assertEquals('foobarxyz', $s->response()->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -389,7 +389,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $callable = function () { echo "xyz"; };
         $route = $s->post('/bar', $mw1, $mw2, $callable);
         $s->call();
-        $this->assertEquals('foobarxyz', $s->response()->body());
+        $this->assertEquals('foobarxyz', $s->response()->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -410,7 +410,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $callable = function () { echo "xyz"; };
         $route = $s->put('/bar', $mw1, $mw2, $callable);
         $s->call();
-        $this->assertEquals('foobarxyz', $s->response()->body());
+        $this->assertEquals('foobarxyz', $s->response()->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -431,7 +431,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $callable = function () { echo "xyz"; };
         $route = $s->patch('/bar', $mw1, $mw2, $callable);
         $s->call();
-        $this->assertEquals('foobarxyz', $s->response()->body());
+        $this->assertEquals('foobarxyz', $s->response()->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -452,7 +452,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $callable = function () { echo "xyz"; };
         $route = $s->delete('/bar', $mw1, $mw2, $callable);
         $s->call();
-        $this->assertEquals('foobarxyz', $s->response()->body());
+        $this->assertEquals('foobarxyz', $s->response()->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -473,7 +473,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $callable = function () { echo "xyz"; };
         $route = $s->options('/bar', $mw1, $mw2, $callable);
         $s->call();
-        $this->assertEquals('foobarxyz', $s->response()->body());
+        $this->assertEquals('foobarxyz', $s->response()->getBody());
         $this->assertEquals('/bar', $route->getPattern());
         $this->assertSame($callable, $route->getCallable());
     }
@@ -496,7 +496,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s->get('/baz', $mw2, $callable);
         });
         $s->call();
-        $this->assertEquals('foobarxyz', $s->response()->body());
+        $this->assertEquals('foobarxyz', $s->response()->getBody());
     }
 
     /*
@@ -517,7 +517,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s = new \Slim\Slim();
             $route = $s->any('/bar', $mw1, $mw2, $callable);
             $s->call();
-            $this->assertEquals('foobarxyz', $s->response()->body());
+            $this->assertEquals('foobarxyz', $s->response()->getBody());
             $this->assertEquals('/bar', $route->getPattern());
             $this->assertSame($callable, $route->getCallable());
         }
@@ -535,7 +535,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s = new \Slim\Slim();
         $s->get('/bar', function () { echo "xyz"; });
         $s->call();
-        $this->assertEquals(404, $s->response()->status());
+        $this->assertEquals(404, $s->response()->getStatus());
     }
 
     /**
@@ -549,8 +549,8 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s = new \Slim\Slim(array('routes.case_sensitive' => false));
         $route = $s->get('/bar', function () { echo "xyz"; });
         $s->call();
-        $this->assertEquals(200, $s->response()->status());
-        $this->assertEquals('xyz', $s->response()->body());
+        $this->assertEquals(200, $s->response()->getStatus());
+        $this->assertEquals('xyz', $s->response()->getBody());
         $this->assertEquals('/bar', $route->getPattern());
     }
 
@@ -566,7 +566,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $s = new \Slim\Slim();
         $s->get('/bar/:one/:two', function ($one, $two) { echo $one . $two; });
         $s->call();
-        $this->assertEquals('jo hnsmi th', $s->response()->body());
+        $this->assertEquals('jo hnsmi th', $s->response()->getBody());
     }
 
     /************************************************
@@ -602,9 +602,9 @@ class SlimTest extends PHPUnit_Framework_TestCase
     {
         $data = array('foo' => 'bar');
         $s = new \Slim\Slim();
-        $s->view()->setData($data);
+        $s->view()->replace($data);
         $s->view('CustomView');
-        $this->assertSame($data, $s->view()->getData());
+        $this->assertSame($data, $s->view()->all());
     }
 
     /************************************************
@@ -688,7 +688,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s->lastModified(1286139652);
         });
         $s->call();
-        $this->assertEquals(304, $s->response()->status());
+        $this->assertEquals(304, $s->response()->getStatus());
     }
 
     /**
@@ -706,7 +706,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s->lastModified(1286139250);
         });
         $s->call();
-        $this->assertEquals(200, $s->response()->status());
+        $this->assertEquals(200, $s->response()->getStatus());
     }
 
     public function testLastModifiedOnlyAcceptsIntegers()
@@ -757,7 +757,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s->etag('abc123');
         });
         $s->call();
-        $this->assertEquals(304, $s->response()->status());
+        $this->assertEquals(304, $s->response()->getStatus());
     }
 
     /**
@@ -775,7 +775,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s->etag('abc123');
         });
         $s->call();
-        $this->assertEquals(200, $s->response()->status());
+        $this->assertEquals(200, $s->response()->getStatus());
     }
 
     /**
@@ -974,7 +974,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             echo "Bar"; //<-- Should not be in response body!
         });
         $s->call();
-        $this->assertEquals('Foo', $s->response()->body());
+        $this->assertEquals('Foo', $s->response()->getBody());
     }
 
     /**
@@ -1089,7 +1089,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             echo $name; //<-- Should be in response body!
         });
         $s->call();
-        $this->assertEquals('Frank', $s->response()->body());
+        $this->assertEquals('Frank', $s->response()->getBody());
     }
 
     /**
@@ -1107,7 +1107,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s->pass();
         });
         $s->call();
-        $this->assertEquals(404, $s->response()->status());
+        $this->assertEquals(404, $s->response()->getStatus());
     }
 
     /**
@@ -1134,7 +1134,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s->status(403);
         });
         $s->call();
-        $this->assertEquals(403, $s->response()->status());
+        $this->assertEquals(403, $s->response()->getStatus());
     }
 
     /**
@@ -1229,7 +1229,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             echo 'Foo';
         });
         $s->run();
-        $this->assertEquals('Hello', $s->response()->header('X-Slim-Test'));
+        $this->assertEquals('Hello', $s->response()->headers->get('X-Slim-Test'));
     }
 
     /**
@@ -1330,7 +1330,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
             $s->error();
         });
         $s->call();
-        $this->assertEquals(500, $s->response()->status());
+        $this->assertEquals(500, $s->response()->getStatus());
     }
 
     /**
@@ -1418,8 +1418,8 @@ class SlimTest extends PHPUnit_Framework_TestCase
         });
         $s1->call();
         $s2->call();
-        $this->assertEquals(500, $s1->response()->status());
-        $this->assertEquals(200, $s2->response()->status());
+        $this->assertEquals(500, $s1->response()->getStatus());
+        $this->assertEquals(200, $s2->response()->getStatus());
     }
 
     /**
@@ -1432,7 +1432,7 @@ class SlimTest extends PHPUnit_Framework_TestCase
         ));
         $s->error(function ( \Exception $e ) use ($s) {
             $r = $s->response();
-            $r->status(503);
+            $r->setStatus(503);
             $r->write('Foo');
             $r['X-Powered-By'] = 'Slim';
             echo 'Bar';

--- a/tests/ViewTest.php
+++ b/tests/ViewTest.php
@@ -39,7 +39,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $prop->setAccessible(true);
         $prop->setValue($view, new \Slim\Helper\Set(array('foo' => 'bar')));
 
-        $this->assertSame(array('foo' => 'bar'), $view->getData());
+        $this->assertSame(array('foo' => 'bar'), $view->all());
     }
 
     public function testGetDataKeyExists()
@@ -49,7 +49,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $prop->setAccessible(true);
         $prop->setValue($view, new \Slim\Helper\Set(array('foo' => 'bar')));
 
-        $this->assertEquals('bar', $view->getData('foo'));
+        $this->assertEquals('bar', $view->get('foo'));
     }
 
     public function testGetDataKeyNotExists()
@@ -59,7 +59,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $prop->setAccessible(true);
         $prop->setValue($view, new \Slim\Helper\Set(array('foo' => 'bar')));
 
-        $this->assertNull($view->getData('abc'));
+        $this->assertNull($view->get('abc'));
     }
 
     public function testSetDataKeyValue()
@@ -67,7 +67,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $view = new \Slim\View();
         $prop = new \ReflectionProperty($view, 'data');
         $prop->setAccessible(true);
-        $view->setData('foo', 'bar');
+        $view->set('foo', 'bar');
 
         $this->assertEquals(array('foo' => 'bar'), $prop->getValue($view)->all());
     }
@@ -78,7 +78,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $prop = new \ReflectionProperty($view, 'data');
         $prop->setAccessible(true);
 
-        $view->setData('fooClosure', function () {
+        $view->keep('fooClosure', function () {
             return 'foo';
         });
 
@@ -92,7 +92,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $view = new \Slim\View();
         $prop = new \ReflectionProperty($view, 'data');
         $prop->setAccessible(true);
-        $view->setData(array('foo' => 'bar'));
+        $view->replace(array('foo' => 'bar'));
 
         $this->assertEquals(array('foo' => 'bar'), $prop->getValue($view)->all());
     }
@@ -110,7 +110,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $view = new \Slim\View();
         $prop = new \ReflectionProperty($view, 'data');
         $prop->setAccessible(true);
-        $view->appendData(array('foo' => 'bar'));
+        $view->replace(array('foo' => 'bar'));
 
         $this->assertEquals(array('foo' => 'bar'), $prop->getValue($view)->all());
     }
@@ -136,7 +136,7 @@ class ViewTest extends PHPUnit_Framework_TestCase
         $prop = new \ReflectionProperty($view, 'data');
         $prop->setAccessible(true);
         $prop->setValue($view, new \Slim\Helper\Set(array('foo' => 'bar')));
-        $view->appendData(array('foo' => '123'));
+        $view->replace(array('foo' => '123'));
 
         $this->assertEquals(array('foo' => '123'), $prop->getValue($view)->all());
     }


### PR DESCRIPTION
Addressing this issue:
https://github.com/codeguy/Slim/issues/924

I didn't know what to do with the tests, but I guessed that we wanted to update them where they still applied, and keep the ones that test specific behavior for the deprecated function until it gets removed.

https://github.com/ecoreng/Slim/blob/fw-remove-dep-depr/tests/ViewTest.php#L144
https://github.com/ecoreng/Slim/blob/fw-remove-dep-depr/tests/ViewTest.php#L100
