### PR TITLE
Allow Slim to be initialized with a route base

### DIFF
--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -138,7 +138,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
 
 		// Virtual path
 		if (isset($settings['route.base']))
-			$env['PATH_INFO'] = substr($requestUri, strlen($settings['route.base'])); // <-- remove route base from requestUri
+			$env['PATH_INFO'] = substr($requestUri, strlen($settings['route.base'])-1); // <-- remove route base from requestUri
 		else
 		{
 			if (strpos($requestUri, $physicalPath) === 0) {

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -6,7 +6,7 @@
  * @copyright   2011 Josh Lockhart
  * @link        http://www.slimframework.com
  * @license     http://www.slimframework.com/license
- * @version     2.4.2
+ * @version     2.4.3
  * @package     Slim
  *
  * MIT LICENSE
@@ -156,7 +156,11 @@ class Slim
 
         // Default environment
         $this->container->singleton('environment', function ($c) {
-            return \Slim\Environment::getInstance();
+			$environmentSettings =
+				isset($this->settings['environment.settings']) ?
+					$this->settings['environment.settings'] :
+					array();
+            return \Slim\Environment::getInstance(false, $environmentSettings);
         });
 
         // Default request


### PR DESCRIPTION
First pull request in my life ever, so please bear with me... - constructive feedback is great.

Slim can now be initialized with a route base set
which works great for sub folders when the
physical uri base doesn't match the request uri base
Often the case when using using htaccess or vhost on a sub folder
pretending to run the uri from root, which often happens when
trying to create public and private folders in the Server Root;
some hosts prevent access to above the root directory.

```
new \Slim\Slim(array(
 'environment.settings'=> array(
  'route.base'=>'/staging/insomnia/')
));
```

Builds off of: https://github.com/codeguy/Slim/pull/922

Changed documentation for version - not sure if this is the file's
last changed release version or if it should match the latest release
version.

Slim.php
- Checks settings for 'environment.settings' and passes them over
  to the environment if the key exists.

Environment.php
- allow getInstance to pass userSettings through to initializing the
  environment.
- in the constructor changed $settings to default to an empty array
- removed the check if settings was set
- added Andrew's change:
  https://github.com/andrew-forest/Slim/commit/da29004adc0d6011e189fc715b3a5fdac0b55882
  This works great if the $requestUri uses the root for its base
- added check for $settings['route.base'], if it's set it will
  remove that for the PATH_INFO
- the server variables passed in through $settings now get
  merged over the default global server variables
