### PR TITLE
Add settings option to skip passing routes for more speed

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -1070,14 +1070,14 @@ class App extends \Pimple
      * @param  \Slim\Http\Request  The request instance
      * @param  \Slim\Http\Response The response instance
      */
-    protected function dispatchRequest(\Slim\Http\Request $request, \Slim\Http\Response $response)
+    protected function dispatchRequest(\Slim\Http\Request $request, \Slim\Http\Response $response, $noPass)
     {
         try {
             $this->applyHook('slim.before');
             ob_start();
             $this->applyHook('slim.before.router');
             $dispatched = false;
-            $matchedRoutes = $this['router']->getMatchedRoutes($request->getMethod(), $request->getPathInfo(), false);
+            $matchedRoutes = $this['router']->getMatchedRoutes($request->getMethod(), $request->getPathInfo(), false, $noPass);
             foreach ($matchedRoutes as $route) {
                 try {
                     $this->applyHook('slim.before.dispatch');
@@ -1156,7 +1156,10 @@ class App extends \Pimple
      */
     public function call()
     {
-        $this->dispatchRequest($this['request'], $this['response']);
+        /** @var \Slim\Interfaces\ConfigurationInterface $settings */
+        $settings = $this['settings'];
+        $noPass = $settings['routes.no_pass'];
+        $this->dispatchRequest($this['request'], $this['response'], $noPass);
     }
 
     /**

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -1067,17 +1067,18 @@ class App extends \Pimple
      * The provided Request and Response objects are updated by reference. There is no
      * value returned by this method.
      *
-     * @param  \Slim\Http\Request  The request instance
-     * @param  \Slim\Http\Response The response instance
+     * @param  \Slim\Http\Request  $request   The request instance
+     * @param  \Slim\Http\Response $response  The response instance
+     * @param  bool                $passable  Allow multiple route matches and Pass() exceptions
      */
-    protected function dispatchRequest(\Slim\Http\Request $request, \Slim\Http\Response $response, $noPass)
+    protected function dispatchRequest(\Slim\Http\Request $request, \Slim\Http\Response $response, $passable = true)
     {
         try {
             $this->applyHook('slim.before');
             ob_start();
             $this->applyHook('slim.before.router');
             $dispatched = false;
-            $matchedRoutes = $this['router']->getMatchedRoutes($request->getMethod(), $request->getPathInfo(), false, $noPass);
+            $matchedRoutes = $this['router']->getMatchedRoutes($request->getMethod(), $request->getPathInfo(), false, $passable);
             foreach ($matchedRoutes as $route) {
                 try {
                     $this->applyHook('slim.before.dispatch');
@@ -1158,8 +1159,8 @@ class App extends \Pimple
     {
         /** @var \Slim\Interfaces\ConfigurationInterface $settings */
         $settings = $this['settings'];
-        $noPass = $settings['routes.no_pass'];
-        $this->dispatchRequest($this['request'], $this['response'], $noPass);
+        $passable = $settings['routes.passable'];
+        $this->dispatchRequest($this['request'], $this['response'], $passable);
     }
 
     /**

--- a/Slim/Configuration.php
+++ b/Slim/Configuration.php
@@ -83,7 +83,7 @@ class Configuration implements ConfigurationInterface, \IteratorAggregate
         'http.version' => '1.1',
         // Routing
         'routes.case_sensitive' => true,
-        'routes.no_pass' => false
+        'routes.passable' => true
     );
 
     /**

--- a/Slim/Configuration.php
+++ b/Slim/Configuration.php
@@ -82,7 +82,8 @@ class Configuration implements ConfigurationInterface, \IteratorAggregate
         // HTTP
         'http.version' => '1.1',
         // Routing
-        'routes.case_sensitive' => true
+        'routes.case_sensitive' => true,
+        'routes.no_pass' => false
     );
 
     /**

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -124,10 +124,11 @@ class Router implements RouterInterface
      * @param  string             $httpMethod  The HTTP request method
      * @param  string             $resourceUri The resource URI
      * @param  bool               $reload      Should matching routes be re-parsed?
+     * @param  bool               $matchFirst  If true, will return the first match it finds
      * @return array[\Slim\Interfaces\RouteInterface]
      * @api
      */
-    public function getMatchedRoutes($httpMethod, $resourceUri, $save = true)
+    public function getMatchedRoutes($httpMethod, $resourceUri, $save = true, $matchFirst = false)
     {
         $matchedRoutes = array();
         foreach ($this->routes as $route) {
@@ -137,6 +138,9 @@ class Router implements RouterInterface
 
             if ($route->matches($resourceUri)) {
                 $matchedRoutes[] = $route;
+                if($matchFirst){
+                    return $matchedRoutes;
+                }
             }
         }
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -124,11 +124,11 @@ class Router implements RouterInterface
      * @param  string             $httpMethod  The HTTP request method
      * @param  string             $resourceUri The resource URI
      * @param  bool               $reload      Should matching routes be re-parsed?
-     * @param  bool               $matchFirst  If true, will return the first match it finds
+     * @param  bool               $allowPass   If false, will return the first match it finds
      * @return array[\Slim\Interfaces\RouteInterface]
      * @api
      */
-    public function getMatchedRoutes($httpMethod, $resourceUri, $save = true, $matchFirst = false)
+    public function getMatchedRoutes($httpMethod, $resourceUri, $save = true, $allowPass = true)
     {
         $matchedRoutes = array();
         foreach ($this->routes as $route) {
@@ -138,7 +138,7 @@ class Router implements RouterInterface
 
             if ($route->matches($resourceUri)) {
                 $matchedRoutes[] = $route;
-                if($matchFirst){
+                if(!$allowPass){
                     return $matchedRoutes;
                 }
             }


### PR DESCRIPTION
Adds a new settings default `route.no_pass` which if set to true will force the router to return the first matched route it finds without iterating through the entire stack. Should improve performance of the router for all but specialist use cases. Is set to false by default to maintain current behavior.
