### PR TITLE
remove `Slim\Exception\Pass` exception and replace with `return false`

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -778,7 +778,7 @@ class App extends \Pimple
     public function pass()
     {
         $this->cleanBuffer();
-        throw new \Slim\Exception\Pass();
+        throw new \Slim\Exception\Depreciated();
     }
 
     /**
@@ -1079,15 +1079,15 @@ class App extends \Pimple
             $dispatched = false;
             $matchedRoutes = $this['router']->getMatchedRoutes($request->getMethod(), $request->getPathInfo(), false);
             foreach ($matchedRoutes as $route) {
-                try {
-                    $this->applyHook('slim.before.dispatch');
-                    $dispatched = $route->dispatch();
-                    $this->applyHook('slim.after.dispatch');
-                    if ($dispatched) {
-                        break;
-                    }
-                } catch (\Slim\Exception\Pass $e) {
+                $this->applyHook('slim.before.dispatch');
+                $dispatched = $route->dispatch();
+                $this->applyHook('slim.after.dispatch');
+                if(false === $dispatched){
+                    // Clear the buffer and move on
+                    $this->cleanBuffer();
                     continue;
+                } else {
+                    break;
                 }
             }
             if (!$dispatched) {

--- a/Slim/Exception/Depreciated.php
+++ b/Slim/Exception/Depreciated.php
@@ -32,18 +32,18 @@
  */
 namespace Slim\Exception;
 
+
 /**
- * Pass Exception
+ * Depreciated Exception
  *
- * This Exception will cause the Router::dispatch method
- * to skip the current matching route and continue to the next
- * matching route. If no subsequent routes are found, a
- * HTTP 404 Not Found response will be sent to the client.
+ * This Exception is thrown when user calls a depreciated or removed Slim
+ * method. It should eventually be removed, but might ease the transition
+ * process.
  *
  * @package Slim
  * @author  Josh Lockhart
  * @since   1.0.0
  */
-class Pass extends \Exception
-{
-}
+class Depreciated extends \Exception {
+
+} 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -951,18 +951,20 @@ class AppTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test pass cleans buffer and throws exception
+     * Test pass throws depreciated exception
      */
     public function testPass()
     {
-        ob_start();
-        echo "Foo";
-        try {
-            $this->app->pass();
-            $this->fail('Did not catch Slim_Exception_Pass');
-        } catch (\Slim\Exception\Pass $e) {}
-        $output = ob_get_clean();
-        $this->assertEquals('', $output);
+        $this->setExpectedException('\\Slim\\Exception\\Depreciated');
+        $this->app->pass();
+//        ob_start();
+//        echo "Foo";
+//        try {
+//            $this->app->pass();
+//            $this->fail('Did not catch Slim_Exception_Pass');
+//        } catch (\Slim\Exception\Pass $e) {}
+//        $output = ob_get_clean();
+//        $this->assertEquals('', $output);
     }
 
     /**
@@ -976,7 +978,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         ));
         $app->get('/name/Frank', function () use ($app) {
             echo "Fail"; // <-- Should not be in response body!
-            $app->pass();
+            return false;
         });
         $app->get('/name/:name', function ($name) {
             echo $name; // <-- Should be in response body!
@@ -997,7 +999,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         ));
         $app->get('/name/Frank', function () use ($app) {
             echo "Fail"; // <-- Should not be in response body!
-            $app->pass();
+            return false;
         });
         $app->call();
 


### PR DESCRIPTION
Changed router flow control to bail out of a route by returning `false` from the route's callable rather than throwing a `\Slim\Exception\Pass`. 

Have also added in a `\Slim\Exception\Depreciated` that is thrown if a user tries to use the now redundant $app->pass() method and wonders why nothing happens.
