### PR TITLE
Make ->flash() r/w

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1108,11 +1108,23 @@ class Slim
      * Set flash message for subsequent request
      * @param  string   $key
      * @param  mixed    $value
+     * @return mixed
      */
-    public function flash($key, $value)
+    public function flash()
     {
-        if (isset($this->environment['slim.flash'])) {
-            $this->environment['slim.flash']->set($key, $value);
+        $n = func_num_args();
+        if ($n < 1 || $n > 2) {
+            throw new \BadMethodCallException('flash() expects 1 or 2 parameters, '.$n.' given');
+        }
+
+        if (!isset($this->environment['slim.flash'])) {
+            return null; 
+        }
+
+        if ($n === 2) {
+            return $this->environment['slim.flash']->set(func_get_arg(0), func_get_arg(1));
+        } else {
+            return $this->environment['slim.flash'][func_get_arg(0)];
         }
     }
 

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -1288,6 +1288,14 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Foo', $_SESSION['slim.flash']['info']);
     }
 
+    public function testGetFlashValue()
+    {
+        $_SESSION['slim.flash'] = array('info' => 'Foo');
+        $s = new \Slim\Slim();
+        $s->run();
+        $this->assertEquals('Foo', $s->flash('info'));
+    }
+
     /************************************************
      * NOT FOUND HANDLING
      ************************************************/


### PR DESCRIPTION
A callable sets flash variables like:

``` php
$app->flash('key','value');
```

but to get a flash variable's value, it must query:

``` php
$value = $app->environment['slim.flash']['key'];
```

which feels dirty. This PR makes this possible while continuing to allow setting of any value (including null and false):

``` php
// set a flash variable
$app->flash('key','value');

// get a flash variable
$value = $app->flash('key');
```
