### PR TITLE
Read flash messages without caring how they are stored.

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1150,6 +1150,16 @@ class Slim
         }
     }
 
+    /**
+     * Get all flash messages
+     */
+    public function flashData()
+    {
+        if (isset($this->environment['slim.flash'])) {
+            return $this->environment['slim.flash']->getMessages();
+        }
+    }
+
     /********************************************************************************
     * Hooks
     *******************************************************************************/

--- a/tests/SlimTest.php
+++ b/tests/SlimTest.php
@@ -1288,6 +1288,16 @@ class SlimTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('Foo', $_SESSION['slim.flash']['info']);
     }
 
+    public function testFlashData()
+    {
+        $s = new \Slim\Slim();
+        $s->get('/bar', function () use ($s) {
+            $s->flashNow('info', 'bar');
+        });
+        $s->run();
+        $this->assertEquals(array('info' => 'bar'), $s->flashData());
+    }
+
     /************************************************
      * NOT FOUND HANDLING
      ************************************************/


### PR DESCRIPTION
Developers should not know / care how flash messages are stored internally to be able to read them.  This method should alleviate the need to read from `$_SESSION['slim.flash']`.
