### PR TITLE
Being able to create custom http status codes

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1292,9 +1292,9 @@ class Slim
         if (headers_sent() === false) {
             //Send status
             if (strpos(PHP_SAPI, 'cgi') === 0) {
-                header(sprintf('Status: %s', \Slim\Http\Response::getMessageForCode($status)));
+                header(sprintf('Status: %s', $this->container->get('response')->getMessageForCode($status)));
             } else {
-                header(sprintf('HTTP/%s %s', $this->config('http.version'), \Slim\Http\Response::getMessageForCode($status)));
+                header(sprintf('HTTP/%s %s', $this->config('http.version'), $this->container->get('response')->getMessageForCode($status)));
             }
 
             //Send headers


### PR DESCRIPTION
The run function now use the instance of the response object in the container to get the message for the http status.

This way, after injecting our own implementation of the Response class in the container, we can do something like that:

class MyResponse extends Response 
{
    public function __construct($body = '', $status = 200, $headers = array()) {
        parent::__construct($body = '', $status = 200, $headers = array());
        parent::$messages[460] = '460 Undefined route';
    }
}
