### PR TITLE
Support for HTTP_X_FORWARDED_PROTO

### DIFF
--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -162,6 +162,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
             //Workaround for Nginx or HAProxy
             if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
                 $_SERVER['HTTPS']='on';
+                $env['SERVER_PORT'] = 443;
             }
 
             //Is the application running under HTTPS or HTTP protocol?

--- a/Slim/Environment.php
+++ b/Slim/Environment.php
@@ -159,6 +159,11 @@ class Environment implements \ArrayAccess, \IteratorAggregate
                 $env[$key] = $value;
             }
 
+            //Workaround for Nginx or HAProxy
+            if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+                $_SERVER['HTTPS']='on';
+            }
+
             //Is the application running under HTTPS or HTTP protocol?
             $env['slim.url_scheme'] = empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] === 'off' ? 'http' : 'https';
 


### PR DESCRIPTION
$_SERVER[‘HTTPS’] not set when using proxy. I saw that its fixed in develop, but I'm using Slim in production, so I can't use dev version of Slim...

It's just simple workaround.
