### PR TITLE
Fix: Remove useless assignment

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -119,7 +119,6 @@ class Slim
 
         $className = ltrim($className, '\\');
         $fileName  = $baseDir;
-        $namespace = '';
         if ($lastNsPos = strripos($className, '\\')) {
             $namespace = substr($className, 0, $lastNsPos);
             $className = substr($className, $lastNsPos + 1);


### PR DESCRIPTION
This PR
- [x] removes a variable which is assigned a value before a condition, but never used when the condition evaluates to false and instantly overwritten when the condition evaluates to true

Because, you know, cycles!
