### PR TITLE
Fix: Method doesn't return anything

### DIFF
--- a/Slim/Helper/Set.php
+++ b/Slim/Helper/Set.php
@@ -160,7 +160,7 @@ class Set implements \ArrayAccess, \Countable, \IteratorAggregate
 
     public function __unset($key)
     {
-        return $this->remove($key);
+        $this->remove($key);
     }
 
     /**


### PR DESCRIPTION
This PR
- [x] fixes an issue where a method attempts to return the return value of a method that returns nothing
