### PR TITLE
Include route in dispatch hooks

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1334,9 +1334,9 @@ class Slim
             $matchedRoutes = $this->router->getMatchedRoutes($this->request->getMethod(), $this->request->getResourceUri());
             foreach ($matchedRoutes as $route) {
                 try {
-                    $this->applyHook('slim.before.dispatch');
+                    $this->applyHook('slim.before.dispatch', ['route' => $route]);
                     $dispatched = $route->dispatch();
-                    $this->applyHook('slim.after.dispatch');
+                    $this->applyHook('slim.after.dispatch', ['route' => $route]);
                     if ($dispatched) {
                         break;
                     }


### PR DESCRIPTION
Hi there,

Hope you don't mind the pull request.  I'm fairly new to this, but thought this might be of interest to you adding into the core code...

I've had need to access the current route within the dispatch hooks, so I've added the $route object as an argument to the dispatch hook.  I've added it as an array so that other people could add additional items to it without needing to worry about  the order of the arguments, and avoiding the need to amend the applyHook code to support multiple arguments.

I've also added a test for this to the SlimTest class.

Please let me have any feedback about this pull request to help me contribute better in future.

Thanks,

Toby
