### PR TITLE
Updated interface that Route matches responses against

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -495,7 +495,7 @@ class Route implements RouteInterface
         // Invoke route middleware
         foreach ($this->middleware as $mw) {
             $newResponse = call_user_func_array($mw, [$request, $response, $this]);
-            if ($newResponse instanceof Interfaces\Http\ResponseInterface) {
+            if ($newResponse instanceof ResponseInterface) {
                 $response = $newResponse;
             }
         }
@@ -514,7 +514,7 @@ class Route implements RouteInterface
         }
 
         // End if route callback returns Interfaces\Http\ResponseInterface object
-        if ($newResponse instanceof Interfaces\Http\ResponseInterface) {
+        if ($newResponse instanceof ResponseInterface) {
             return $newResponse;
         }
 


### PR DESCRIPTION
Updated interface that Route matches responses against from legacy \Slim\Interfaces\Http\ResponseInterface to \Psr\Http\Message\ResponseInterface.

I hope this is an actual contribution. I'm using Slim 3 to develop a PSR-7 compatible library, and my Slim Routes would ignore the responses I generated because they checked for the legacy ResponseInterface.
This fix solves that for me. I am guessing and hoping this is how Slim 3 is intended to work, would love to hear why if I'm mistaken.
