### PR TITLE
Fix bug that caused no valid headers to be sent

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -801,7 +801,7 @@ class Response implements ResponseInterface
             }
 
             foreach ($this->getHeaders() as $name => $values) {
-                header($name, $this->getHeader($name));
+                header($name .': ' .$this->getHeader($name));
             }
         }
 


### PR DESCRIPTION
No header values would be sent without this fix, I think this is how it was supposed to work.
