### PR TITLE
[IN PROGRESS] Trusted Proxies Support

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -298,13 +298,13 @@ class App extends \Pimple\Container
     }
 
     /********************************************************************************
-     * Reverse Proxy Handling //TODO: Better Name
+     * Client Details / Reverse Proxy Handling
      *******************************************************************************/
 
     /**
      * Get the HTTP Client IP address, taking reverse proxies into account
      *
-     * @param bool $returnAll
+     * @param bool $returnAll If multiple XFF headers are given, return all addresses in an array.
      * @return array|string
      */
     public function getClientIp($returnAll = false)

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -298,6 +298,53 @@ class App extends \Pimple\Container
     }
 
     /********************************************************************************
+     * Reverse Proxy Handling //TODO: Better Name
+     *******************************************************************************/
+
+    /**
+     * Get the HTTP Client IP address, taking reverse proxies into account
+     *
+     * @param bool $returnAll
+     * @return array|string
+     */
+    public function getClientIp($returnAll = false)
+    {
+        $trustedProxies = Http\TrustedProxies::create($this['settings']['http.trusted_proxies'],
+            $this['settings']['http.trusted_headers']);
+
+        if(isset($this['environment'][$trustedProxies->getTrustedHeaderName(Http\TrustedProxies::HEADER_CLIENT_IP)]) and
+            $trustedProxies->check($this['environment']['REMOTE_ADDR']))
+        {
+            $XFF = $this['environment'][$trustedProxies->getTrustedHeaderName(Http\TrustedProxies::HEADER_CLIENT_IP)];
+
+            if(strpos($XFF, ", ") !== false)
+            {
+                $XFF = explode(", ", $XFF);
+
+                if($returnAll === false)
+                {
+                    return trim(array_pop($XFF)); // If user only wants one IP, use the latest one - most secure since
+                                                  // directly from the trusted proxy
+                }
+                else
+                {
+                    return array_map("trim", $XFF);
+                }
+            }
+            else
+            {
+                // The X-Forwarded-For header only has a single IP address, and is immediately usable
+                return trim($XFF);
+            }
+        }
+        else
+        {
+            // Either there is no reverse proxy or it is fake or spoofed
+            return $this['environment']['REMOTE_ADDR'];
+        }
+    }
+
+    /********************************************************************************
     * Application Behavior Methods
     *******************************************************************************/
 

--- a/Slim/Configuration.php
+++ b/Slim/Configuration.php
@@ -47,6 +47,8 @@ class Configuration implements ConfigurationInterface, \IteratorAggregate
         'cookies.httponly' => false,
         // HTTP
         'http.version' => '1.1',
+        'http.trusted_proxies' => [],
+        'http.trusted_headers' => [],
     ];
 
     /**

--- a/Slim/Http/TrustedProxies.php
+++ b/Slim/Http/TrustedProxies.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/codeguy/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/codeguy/Slim/blob/master/LICENSE (MIT License)
+ */
+namespace Slim\Http;
+
+/**
+ * TrustedProxies
+ *
+ * This class is used to store trusted proxy data for XFF headers.
+ */
+class TrustedProxies
+{
+    const HEADER_CLIENT_PROTO = 0;
+    const HEADER_CLIENT_IP = 1;
+    const HEADER_CLIENT_PORT = 2;
+
+    /**
+     * Array of addresses (with or without CIDR) of trusted reverse proxies.
+     *
+     * @var array
+     */
+    protected $trustedProxies;
+
+    /**
+     * Array of the trusted reverse proxy's header names that will be used to recover the original request.
+     *
+     * @var array
+     */
+    protected $trustedHeaderNames = array(
+        self::HEADER_CLIENT_PROTO => "X-Forwarded-Proto",
+        self::HEADER_CLIENT_IP => "X-Forwarded-For",
+        self::HEADER_CLIENT_PORT => "X-Forwarded_Port"
+    );
+
+    /**
+     * Create a new TrustedProxies object
+     *
+     * @param array $trustedProxies
+     * @param array $trustedHeaderNames
+     */
+    private function __construct($trustedProxies = array(), $trustedHeaderNames = array())
+    {
+        $this->trustedProxies = $trustedProxies;
+        $this->trustedHeaderNames = array_merge($this->trustedHeaderNames, $trustedHeaderNames);
+    }
+
+    /**
+     * Get an array of trusted proxies
+     *
+     * @return array
+     */
+    public function getTrustedProxies()
+    {
+        return $this->trustedProxies;
+    }
+
+    public function getTrustedHeaderName($key)
+    {
+        if(isset($this->trustedHeaderNames[$key]))
+        {
+            return $this->trustedHeaderNames[$key];
+        }
+
+        //TODO: Else?
+    }
+
+    /**
+     * Get an array of trusted header names
+     *
+     * @return array
+     */
+    public function getTrustedHeaderNames()
+    {
+        return $this->trustedHeaderNames;
+    }
+
+    public function check($address)
+    {
+        return static::checkIp($address, $this->trustedProxies);
+    }
+
+    public static function create($trustedProxies = array(), $trustedHeaderNames = array())
+    {
+        return static::__set_state($trustedProxies, $trustedHeaderNames);
+    }
+
+    public static function __set_state($trustedProxies = array(), $trustedHeaderNames = array())
+    {
+        return new static($trustedProxies, $trustedHeaderNames);
+    }
+
+    /*****************************************************************************
+     * Below portion of source code was taken from Symfony/HttpFoundation
+     * https://github.com/symfony/HttpFoundation/blob/master/IpUtils.php
+     * Under the MIT License.
+     *****************************************************************************/
+
+    /**
+     * Checks if an IPv4 or IPv6 address is contained in the list of given IPs or subnets.
+     *
+     * @param string       $requestIp IP to check
+     * @param string|array $ips       List of IPs or subnets (can be a string if only a single one)
+     *
+     * @return bool Whether the IP is valid
+     */
+    protected static function checkIp($requestIp, $ips)
+    {
+        if (!is_array($ips)) {
+            $ips = array($ips);
+        }
+
+        $method = substr_count($requestIp, ':') > 1 ? 'checkIp6' : 'checkIp4';
+
+        foreach ($ips as $ip) {
+            if (self::$method($requestIp, $ip)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Compares two IPv4 addresses.
+     * In case a subnet is given, it checks if it contains the request IP.
+     *
+     * @param string $requestIp IPv4 address to check
+     * @param string $ip        IPv4 address or subnet in CIDR notation
+     *
+     * @return bool Whether the IP is valid
+     */
+    protected static function checkIp4($requestIp, $ip)
+    {
+        if (false !== strpos($ip, '/')) {
+            list($address, $netmask) = explode('/', $ip, 2);
+
+            if ($netmask < 1 || $netmask > 32) {
+                return false;
+            }
+        } else {
+            $address = $ip;
+            $netmask = 32;
+        }
+
+        return 0 === substr_compare(sprintf('%032b', ip2long($requestIp)), sprintf('%032b', ip2long($address)), 0, $netmask);
+    }
+
+    /**
+     * Compares two IPv6 addresses.
+     * In case a subnet is given, it checks if it contains the request IP.
+     *
+     * @author David Soria Parra <dsp at php dot net>
+     *
+     * @see https://github.com/dsp/v6tools
+     *
+     * @param string $requestIp IPv6 address to check
+     * @param string $ip        IPv6 address or subnet in CIDR notation
+     *
+     * @return bool Whether the IP is valid
+     *
+     * @throws \RuntimeException When IPV6 support is not enabled
+     */
+    protected static function checkIp6($requestIp, $ip)
+    {
+        if (!((extension_loaded('sockets') && defined('AF_INET6')) || @inet_pton('::1'))) {
+            throw new \RuntimeException('Unable to check Ipv6. Check that PHP was not compiled with option "disable-ipv6".');
+        }
+
+        if (false !== strpos($ip, '/')) {
+            list($address, $netmask) = explode('/', $ip, 2);
+
+            if ($netmask < 1 || $netmask > 128) {
+                return false;
+            }
+        } else {
+            $address = $ip;
+            $netmask = 128;
+        }
+
+        $bytesAddr = unpack("n*", inet_pton($address));
+        $bytesTest = unpack("n*", inet_pton($requestIp));
+
+        for ($i = 1, $ceil = ceil($netmask / 16); $i <= $ceil; $i++) {
+            $left = $netmask - 16 * ($i-1);
+            $left = ($left <= 16) ? $left : 16;
+            $mask = ~(0xffff >> $left) & 0xffff;
+            if (($bytesAddr[$i] & $mask) != ($bytesTest[$i] & $mask)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Slim/Http/TrustedProxies.php
+++ b/Slim/Http/TrustedProxies.php
@@ -14,6 +14,10 @@ use Slim\Interfaces\Http\TrustedProxiesInterface;
  * TrustedProxies
  *
  * This class is used to store trusted proxy data for XFF headers.
+ *
+ * @package Slim\Http
+ * @author Michael Yoo <michael@yoo.id.au>
+ * @since 3.0.0
  */
 class TrustedProxies implements TrustedProxiesInterface
 {
@@ -36,7 +40,7 @@ class TrustedProxies implements TrustedProxiesInterface
     protected $trustedHeaderNames = array(
         self::HEADER_CLIENT_PROTO => "X-Forwarded-Proto",
         self::HEADER_CLIENT_IP => "X-Forwarded-For",
-        self::HEADER_CLIENT_PORT => "X-Forwarded_Port"
+        self::HEADER_CLIENT_PORT => "X-Forwarded-Port"
     );
 
     /**
@@ -48,7 +52,7 @@ class TrustedProxies implements TrustedProxiesInterface
     private function __construct($trustedProxies = array(), $trustedHeaderNames = array())
     {
         $this->trustedProxies = $trustedProxies;
-        $this->trustedHeaderNames = array_merge($this->trustedHeaderNames, $trustedHeaderNames);
+        $this->trustedHeaderNames = $trustedHeaderNames + $this->trustedHeaderNames;
     }
 
     /**

--- a/Slim/Http/TrustedProxies.php
+++ b/Slim/Http/TrustedProxies.php
@@ -65,6 +65,14 @@ class TrustedProxies implements TrustedProxiesInterface
         return $this->trustedProxies;
     }
 
+    /**
+     * Get the corresponding HTTP header for a unique header identifier.
+     *
+     * @param string $key
+     *
+     * @throws \LogicException
+     * @return string
+     */
     public function getTrustedHeaderName($key)
     {
         if(isset($this->trustedHeaderNames[$key]))
@@ -85,19 +93,29 @@ class TrustedProxies implements TrustedProxiesInterface
         return $this->trustedHeaderNames;
     }
 
+	/**
+	 * Checks if an IP address (IPv4 and IPv6) belongs in the TrustedProxies address space
+	 *
+	 * @param string $address
+	 *
+	 * @return bool
+	 */
     public function check($address)
     {
         return static::checkIp($address, $this->trustedProxies);
     }
 
+	/**
+	 * Used for better syntax.
+	 *
+	 * @param array $trustedProxies
+	 * @param array $trustedHeaderNames
+	 *
+	 * @return TrustedProxies
+	 */
     public static function create($trustedProxies = array(), $trustedHeaderNames = array())
     {
-        return static::__set_state($trustedProxies, $trustedHeaderNames);
-    }
-
-    public static function __set_state($trustedProxies = array(), $trustedHeaderNames = array())
-    {
-        return new static($trustedProxies, $trustedHeaderNames);
+	    return new static($trustedProxies, $trustedHeaderNames);
     }
 
     /*****************************************************************************

--- a/Slim/Http/TrustedProxies.php
+++ b/Slim/Http/TrustedProxies.php
@@ -8,12 +8,14 @@
  */
 namespace Slim\Http;
 
+use Slim\Interfaces\Http\TrustedProxiesInterface;
+
 /**
  * TrustedProxies
  *
  * This class is used to store trusted proxy data for XFF headers.
  */
-class TrustedProxies
+class TrustedProxies implements TrustedProxiesInterface
 {
     const HEADER_CLIENT_PROTO = 0;
     const HEADER_CLIENT_IP = 1;
@@ -66,7 +68,7 @@ class TrustedProxies
             return $this->trustedHeaderNames[$key];
         }
 
-        //TODO: Else?
+        throw new \LogicException("Trusted Header Name $key is undefined");
     }
 
     /**

--- a/Slim/Interfaces/Http/TrustedProxiesInterface.php
+++ b/Slim/Interfaces/Http/TrustedProxiesInterface.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     2.3.0
+ * @package     Slim
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+namespace Slim\Interfaces\Http;
+
+/**
+ * Interface TrustedProxiesInterface
+ *
+ * This is an interface for the TrustedProxies class.
+ *
+ * @package Slim\Interfaces\Http
+ * @author Michael Yoo <michael@yoo.id.au>
+ * @since 3.0.0
+ */
+interface TrustedProxiesInterface
+{
+    // Instantiation
+    /**
+     * Instantiate a TrustedProxies object using the arguments given.
+     *
+     * @param array $trustedProxies
+     * @param array $trustedHeaderNames
+     *
+     * @return object
+     */
+    public static function create($trustedProxies = array(), $trustedHeaderNames = array());
+
+    // Getters
+    /**
+     * Returns an array of trusted proxies.
+     *
+     * @return array
+     */
+    public function getTrustedProxies();
+
+    /**
+     * Returns an array of trusted header names.
+     *
+     * @return array
+     */
+    public function getTrustedHeaderNames();
+
+    /**
+     * Returns a string containing the header name for the given header key
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    public function getTrustedHeaderName($key);
+
+    // Validation
+    /**
+     * Checks if an address is in the range of a trusted proxy.
+     *
+     * @param string $address
+     *
+     * @return boolean
+     */
+    public function check($address);
+}

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -10,6 +10,7 @@
 use \Slim\App;
 use \Slim\Collection;
 use \Slim\Http\Environment;
+use Slim\Http\TrustedProxies;
 use \Slim\Http\Uri;
 use \Slim\Http\Body;
 use \Slim\Http\Headers;
@@ -498,6 +499,26 @@ class AppTest extends PHPUnit_Framework_TestCase
         // Invoke app
         $app($req, $res);
     }
+
+	/********************************************************************************
+	 * Client Details / Reverse Proxy Handling
+	 *******************************************************************************/
+
+	public function testGetClientIp()
+	{
+		$_SERVER['REMOTE_ADDR'] = "127.0.0.1";
+
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = "1.2.3.4";
+
+		$app1 = new App([
+			'http.trusted_proxies' => "127.0.0.1"
+		]);
+
+		$app2 = new App();
+
+		$this->assertEquals("1.2.3.4", $app1->getClientIp());
+		$this->assertNotEquals("1.2.3.4", $app2->getClientIp());
+	}
 
     // TODO: Test subRequest()
 

--- a/tests/Http/TrustedProxiesTest.php
+++ b/tests/Http/TrustedProxiesTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     2.3.0
+ * @package     Slim
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+use Slim\Http\TrustedProxies;
+
+class TrustedProxiesTest extends PHPUnit_Framework_TestCase
+{
+    public function testInstantiation()
+    {
+        $trustedProxies = [
+            "8.0.0.0/8",
+            "155.1.1.1"
+        ];
+
+        $trustedHeaderNames = [
+            TrustedProxies::HEADER_CLIENT_PROTO => "X-TEST-Proto",
+            TrustedProxies::HEADER_CLIENT_IP => "X-TEST-For",
+            TrustedProxies::HEADER_CLIENT_PORT => "X-TEST-Port"
+        ];
+
+        $trustedProxiesObject = TrustedProxies::create($trustedProxies, $trustedHeaderNames);
+
+        $this->assertEquals($trustedProxies, $trustedProxiesObject->getTrustedProxies(),
+            "Trusted Proxies Instntiation Proxies Mismatch");
+        $this->assertEquals($trustedHeaderNames, $trustedProxiesObject->getTrustedHeaderNames(),
+            "Trusted Proxies Instntiation Headers Mismatch");
+    }
+
+    /**
+     * @param string|array $range Range(s) of valid IPv4 addresses
+     * @param string $address Address to validate
+     * @param boolean $expected
+     *
+     * @dataProvider provideTestIPv4AddressValidation
+     */
+    public function testIPv4AddressValidation($range, $address, $expected)
+    {
+        $trustedProxiesObject = TrustedProxies::create($range);
+
+        $this->assertEquals($expected, $trustedProxiesObject->check($address));
+    }
+
+    public function provideTestIPv4AddressValidation()
+    {
+        return [
+            ["1.2.3.4", "1.2.3.4", true],
+            ["1.0.0.0/8", "1.2.3.4", true]//TODO: Write more
+        ];
+    }
+
+    //TODO: public function testIPv6AddressValidation();
+}
+ 

--- a/tests/Http/TrustedProxiesTest.php
+++ b/tests/Http/TrustedProxiesTest.php
@@ -37,6 +37,7 @@ class TrustedProxiesTest extends PHPUnit_Framework_TestCase
 {
     public function testInstantiation()
     {
+	    // Doesn't need to be big, just checking that it's instantiated correctly.
         $trustedProxies = [
             "8.0.0.0/8",
             "155.1.1.1"
@@ -52,6 +53,7 @@ class TrustedProxiesTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($trustedProxies, $trustedProxiesObject->getTrustedProxies(),
             "Trusted Proxies Instntiation Proxies Mismatch");
+
         $this->assertEquals($trustedHeaderNames, $trustedProxiesObject->getTrustedHeaderNames(),
             "Trusted Proxies Instntiation Headers Mismatch");
     }
@@ -73,11 +75,48 @@ class TrustedProxiesTest extends PHPUnit_Framework_TestCase
     public function provideTestIPv4AddressValidation()
     {
         return [
+	        // Range, Address, Expected
+
+	        // True Assertions
             ["1.2.3.4", "1.2.3.4", true],
-            ["1.0.0.0/8", "1.2.3.4", true]//TODO: Write more
+            ["1.0.0.0/8", "1.2.3.4", true],
+	        ["127.0.0.1/32", "127.0.0.1", true],
+
+	        // False Assertions
+            ["8.0.0.1", "1.2.3.4", false],
+            ["8.0.0.0/8", "1.2.3.4", false],
+            ["127.0.0.1/32", "123.123.123.123", false]
         ];
     }
 
-    //TODO: public function testIPv6AddressValidation();
+	/**
+	 * @param string|array $range Range(s) of valid IPv6 addresses
+	 * @param string $address Address to validate
+	 * @param boolean $expected
+	 *
+	 * @dataProvider provideTestIPv6AddressValidation
+	 */
+	public function testIPv6AddressValidation($range, $address, $expected)
+	{
+		$trustedProxiesObject = TrustedProxies::create($range);
+
+		$this->assertEquals($expected, $trustedProxiesObject->check($address));
+	}
+
+	public function provideTestIPv6AddressValidation()
+	{
+		return [
+			// Range, Address, Expected
+
+			// True Assertions
+			["2001:0db8:0a0b:12f0:0000:0000:0000:0000/63", "2001:0db8:0a0b:12f0:0000:0000:0000:0001", true],
+			["2001:0db8:0a0b:12f0:0000:0000:0000:0000/63", "2001:0db8:0a0b:12f1:0000:0000:0000:0001", true],
+			["::1", "::1", true],
+
+			// False Assertions
+			["2001:0db8:0a0b:12f0:0000:0000:0000:0000/63", "2001:0db8:0a0b:12c0:0000:0000:0000:0001", false],
+			["::1", "2001:0db8:0a0b:12c0:0000:0000:0000:0001", false]
+		];
+	}
 }
  


### PR DESCRIPTION
Hello,

I am working on implementing trusted proxies support, for reverse proxies and X-Forwarded-For headers.

Putting this quick prototype here so others comment on the implementation before I work too much on it.

TODO:
- [x] Write Unit Tests for the code written
  - [x] Write unit test for Instantiation
  - [x] Write unit test for IPv4 validation
  - [x] Write unit test for IPv6 validation
  - [x] Modify unit tests for other classes
- [ ] Test in production
- [x] Add TrustedProxies Interface
- [ ] NEW: Make sure that the API is as easy to work with as possible

Removed from TODO:
- Implement #892
- Implement HTTP Forwarded header: http://tools.ietf.org/html/rfc7239

Please note that I will be squashing all the commits before the final request for merge.
