### PR TITLE
escape html code in exception page

### DIFF
--- a/Slim/Middleware/PrettyExceptions.php
+++ b/Slim/Middleware/PrettyExceptions.php
@@ -86,10 +86,10 @@ class PrettyExceptions extends \Slim\Middleware
     {
         $title = 'Slim Application Error';
         $code = $exception->getCode();
-        $message = $exception->getMessage();
+        $message = htmlspecialchars($exception->getMessage());
         $file = $exception->getFile();
         $line = $exception->getLine();
-        $trace = str_replace(array('#', "\n"), array('<div>#', '</div>'), $exception->getTraceAsString());
+        $trace = str_replace(array('#', "\n"), array('<div>#', '</div>'), htmlspecialchars($exception->getTraceAsString()));
         $html = sprintf('<h1>%s</h1>', $title);
         $html .= '<p>The application could not run because of the following error:</p>';
         $html .= '<h2>Details</h2>';


### PR DESCRIPTION
if code like `<h1>blabla...` exist in $message or $trace, page will look not that 'pretty'. we shall only show the code.
