### PR TITLE
add class exist judge for route callable

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -166,6 +166,9 @@ class Route
             $class = $matches[1];
             $method = $matches[2];
             $callable = function() use ($class, $method) {
+                if(!class_exists($class)) {
+                    return false;
+                }
                 static $obj = null;
                 if ($obj === null) {
                     $obj = new $class;


### PR DESCRIPTION
if route callable class not exist, the following `$obj=new $class;` would lead an error
