### PR TITLE
Remove Zend encryption from Response

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -563,20 +563,6 @@ class Response implements ResponseInterface
         return $clone;
     }
 
-    /**
-     * Return a copy of this response with encrypted cookies
-     *
-     * @param  \Zend\Crypt\BlockCipher $crypt
-     * @return self
-     */
-    public function withEncryptedCookies(\Zend\Crypt\BlockCipher $crypt)
-    {
-        $clone = clone $this;
-        $clone->cookies->encrypt($crypt);
-
-        return $clone;
-    }
-
     /*******************************************************************************
      * Body
      ******************************************************************************/

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -10,7 +10,6 @@ namespace Slim\Http;
 
 use \Slim\Interfaces\Http\HeadersInterface;
 use \Slim\Interfaces\Http\CookiesInterface;
-use \Slim\Interfaces\CryptInterface;
 use \Psr\Http\Message\ResponseInterface;
 use \Psr\Http\Message\StreamableInterface;
 


### PR DESCRIPTION
Zend encryption was removed everywhere, except from the Request object. Guess this was forgotten.
