### PR TITLE
Rename App::mapRoute() to map() and remove map()

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -228,7 +228,7 @@ class App extends \Pimple\Container
      *
      * @return Route
      */
-    protected function map(array $methods, $args)
+    public function map(array $methods, $args)
     {
         static $routeCount = 0;
 

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -218,10 +218,10 @@ class App extends \Pimple\Container
      * This method's second argument is a numeric array
      * with these elements:
      *
-     * 1. (string) Route name
-     * 2. (string) Route URI pattern
-     * 3. (callable) One or more route middleware
-     * 4. (callable) Route handler
+     * 0. (string) Route URI pattern
+     * 1. (callable) One or more route middleware
+     * 2. (callable) Route handler
+     * 3. (string) Route name
      *
      * @param array $methods HTTP methods
      * @param array $args    See notes above

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -228,7 +228,7 @@ class App extends \Pimple\Container
      *
      * @return Route
      */
-    protected function mapRoute(array $methods, $args)
+    protected function map(array $methods, $args)
     {
         static $routeCount = 0;
 
@@ -257,7 +257,7 @@ class App extends \Pimple\Container
     {
         $args = func_get_args();
 
-        return $this->mapRoute(['GET'], $args);
+        return $this->map(['GET'], $args);
     }
 
     /**
@@ -269,7 +269,7 @@ class App extends \Pimple\Container
     {
         $args = func_get_args();
 
-        return $this->mapRoute(['POST'], $args);
+        return $this->map(['POST'], $args);
     }
 
     /**
@@ -281,7 +281,7 @@ class App extends \Pimple\Container
     {
         $args = func_get_args();
 
-        return $this->mapRoute(['PUT'], $args);
+        return $this->map(['PUT'], $args);
     }
 
     /**
@@ -293,7 +293,7 @@ class App extends \Pimple\Container
     {
         $args = func_get_args();
 
-        return $this->mapRoute(['PATCH'], $args);
+        return $this->map(['PATCH'], $args);
     }
 
     /**
@@ -305,7 +305,7 @@ class App extends \Pimple\Container
     {
         $args = func_get_args();
 
-        return $this->mapRoute(['DELETE'], $args);
+        return $this->map(['DELETE'], $args);
     }
 
     /**
@@ -317,23 +317,7 @@ class App extends \Pimple\Container
     {
         $args = func_get_args();
 
-        return $this->mapRoute(['OPTIONS'], $args);
-    }
-
-    /**
-     * Add route for multiple methods
-     *
-     * @return \Slim\Interfaces\RouteInterface
-     */
-    public function map()
-    {
-        $args = func_get_args();
-        $methods = array_shift($args);
-        if (!is_array($methods)) {
-            throw new \InvalidArgumentException('First argument must be an array of HTTP methods');
-        }
-
-        return $this->mapRoute($methods, $args);
+        return $this->map(['OPTIONS'], $args);
     }
 
     /**


### PR DESCRIPTION
We don't need map() as a separate method as the first parameter must always be an array which is what mapRoute() expects.

Also, I fixed the docblock's list of array elements to match the new reality of the name being last.
