### PR TITLE
fixed broken license link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -205,4 +205,4 @@ PHP programmers to best practices and good information.
 
 The Slim Framework is released under the MIT public license.
 
-<http://www.slimframework.com/license>
+<https://github.com/slimphp/Slim/blob/master/LICENSE>


### PR DESCRIPTION
the current /license was 404. Updated it to https://github.com/slimphp/Slim/blob/master/LICENSE.

Thanks to derecho.elijah.cs.cmu.edu:8585/@top for finding the broken link.
