### PR TITLE
Throw a RuntimeException in the closure created by App::resolveCallable()

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -311,12 +311,12 @@ class App extends \Pimple\Container
                         $obj = $this[$class];
                     } else {
                         if (!class_exists($class)) {
-                            throw new \InvalidArgumentException('Route callable class does not exist');
+                            throw new \RuntimeException('Route callable class does not exist');
                         }
                         $obj = new $class;
                     }
                     if (!method_exists($obj, $method)) {
-                        throw new \InvalidArgumentException('Route callable method does not exist');
+                        throw new \RuntimeException('Route callable method does not exist');
                     }
                 }
                 return call_user_func_array(array($obj, $method), func_get_args());

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -493,7 +493,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         
         $app->get('/foo', 'foo:bar');
         
-        $this->setExpectedException('\InvalidArgumentException', 'Route callable method does not exist');
+        $this->setExpectedException('\RuntimeException', 'Route callable method does not exist');
 
         // Invoke app
         $app($req, $res);


### PR DESCRIPTION
As per JoeBengalen's comment in #1098, use a RuntimeException rather than an InvalidArgumentException.
