### PR TITLE
Bugfix in ConfigurationTest: wrong usage of ksort

### DIFF
--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -85,9 +85,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $con = new Configuration(new HandlerTest);
         $defaultKeys = array_keys($this->defaults);
-        $defaultKeys = ksort($defaultKeys);
+        ksort($defaultKeys);
         $configKeys = $con->callHandlerMethod('getKeys');
-        $configKeys = ksort($configKeys);
+        ksort($configKeys);
 
         $this->assertEquals($defaultKeys, $configKeys);
     }


### PR DESCRIPTION
Ksort sorts the array by reference and returns a boolean. So the
returned booleans were compared instead of the actual arrays.
