### PR TITLE
DIC-aware route middleware

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -20,6 +20,7 @@ use Psr\Http\Message\ResponseInterface;
  */
 class App extends \Pimple\Container
 {
+    use ResolveCallable;
     use MiddlewareAware;
 
     /**
@@ -288,42 +289,6 @@ class App extends \Pimple\Container
             call_user_func($callable);
         }
         $this['router']->popGroup();
-    }
-
-    /**
-     * Resolve a string of the format 'class:method' into a closure that the
-     * router can dispatch.
-     *
-     * @param  string $callable
-     *
-     * @return Closure
-     */
-    protected function resolveCallable($callable)
-    {
-        if (is_string($callable) && preg_match('!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!', $callable, $matches)) {
-            // $callable is a class:method string, so wrap it into a closure, retriving the class from Pimple if registered there
-            $class = $matches[1];
-            $method = $matches[2];
-            $callable = function() use ($class, $method) {
-                static $obj = null;
-                if ($obj === null) {
-                    if (isset($this[$class])) {
-                        $obj = $this[$class];
-                    } else {
-                        if (!class_exists($class)) {
-                            throw new \RuntimeException('Route callable class does not exist');
-                        }
-                        $obj = new $class;
-                    }
-                    if (!method_exists($obj, $method)) {
-                        throw new \RuntimeException('Route callable method does not exist');
-                    }
-                }
-                return call_user_func_array(array($obj, $method), func_get_args());
-            };
-        }
-
-        return $callable;
     }
 
     /********************************************************************************

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -10,6 +10,7 @@ namespace Slim;
 
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Pimple\ServiceProviderInterface;
 
 /**
  * App
@@ -266,7 +267,11 @@ class App extends \Pimple\Container
             $callable = $callable->bindTo($this);
         }
 
-        return $this['router']->map($methods, $pattern, $callable);
+        $route = $this['router']->map($methods, $pattern, $callable);
+        if ($route instanceof ServiceProviderInterface) {
+            $route->register($this);
+        }
+        return $route;
     }
 
     /**

--- a/Slim/MiddlewareAware.php
+++ b/Slim/MiddlewareAware.php
@@ -46,9 +46,13 @@ trait MiddlewareAware
      *                                3. A "next" middleware callable
      * @return self
      */
-    public function add(callable $callable)
+    public function add($callable)
     {
-        if($this->middlewareLock) {
+        if (!is_callable($callable)) {
+            throw new \RuntimeException('Expected a callable to be added');
+        }
+
+        if ($this->middlewareLock) {
             throw new \RuntimeException('Middleware can’t be added once the stack is dequeuing');
         }
 

--- a/Slim/ResolveCallable.php
+++ b/Slim/ResolveCallable.php
@@ -8,6 +8,8 @@
  */
 namespace Slim;
 
+use Pimple\Container;
+
 /**
  * ResolveCallable
  *
@@ -17,6 +19,13 @@ namespace Slim;
  */
 trait ResolveCallable
 {
+    /**
+     * Container
+     *
+     * @var Container
+     */
+    protected $container;
+
     /**
      * Resolve a string of the format 'class:method' into a closure that the
      * router can dispatch.
@@ -30,7 +39,7 @@ trait ResolveCallable
         if (is_string($callable) && preg_match('!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!', $callable, $matches)) {
             // $callable is a class:method string, so wrap it into a closure, retriving the class from Pimple if registered there
      
-            if ((! $this instanceof \Pimple\Container) && (! $this->getContainer() instanceof \Pimple\Container)) {
+            if ((! $this instanceof Container) && (! $this->container instanceof Container)) {
                 throw new \RuntimeException('Cannot resolve callable string');
             }
      

--- a/Slim/ResolveCallable.php
+++ b/Slim/ResolveCallable.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/codeguy/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/codeguy/Slim/blob/master/LICENSE (MIT License)
+ */
+namespace Slim;
+
+/**
+ * ResolveCallable
+ *
+ * This is an internal class that enables resolution of 'class:method' strings
+ * into a closure. This class is an implementation detail and is used only inside
+ * of the Slim application.
+ */
+trait ResolveCallable
+{
+    /**
+     * Resolve a string of the format 'class:method' into a closure that the
+     * router can dispatch.
+     *
+     * @param  string $callable
+     *
+     * @return Closure
+     */
+    protected function resolveCallable($callable)
+    {
+        if (is_string($callable) && preg_match('!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!', $callable, $matches)) {
+            // $callable is a class:method string, so wrap it into a closure, retriving the class from Pimple if registered there
+     
+            if ((! $this instanceof \Pimple\Container) && (! $this->getContainer() instanceof \Pimple\Container)) {
+                throw new \RuntimeException('Cannot resolve callable string');
+            }
+     
+            $class = $matches[1];
+            $method = $matches[2];
+            $callable = function() use ($class, $method) {
+                static $obj = null;
+                if ($obj === null) {
+                    if (isset($this[$class])) {
+                        $obj = $this[$class];
+                    } else {
+                        if (!class_exists($class)) {
+                            throw new \RuntimeException('Route callable class does not exist');
+                        }
+                        $obj = new $class;
+                    }
+                    if (!method_exists($obj, $method)) {
+                        throw new \RuntimeException('Route callable method does not exist');
+                    }
+                }
+                return call_user_func_array(array($obj, $method), func_get_args());
+            };
+        }
+
+        return $callable;
+    }
+}

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -60,13 +60,6 @@ class Route implements RouteInterface, ServiceProviderInterface
     protected $parsedArgs = [];
 
     /**
-     * Container for resolving callable strings
-     *
-     * @var \Pimple\Container
-     */
-    protected $container;
-
-    /**
      * Create new route
      *
      * @param string[] $methods       The route HTTP methods

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -11,13 +11,18 @@ namespace Slim;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Slim\Interfaces\RouteInterface;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 
 /**
  * Route
  */
-class Route implements RouteInterface
+class Route implements RouteInterface, ServiceProviderInterface
 {
-    use MiddlewareAware;
+    use ResolveCallable;
+    use MiddlewareAware {
+        add as addMiddleware;
+    }
 
     /**
      * HTTP methods supported by this route
@@ -55,6 +60,13 @@ class Route implements RouteInterface
     protected $parsedArgs = [];
 
     /**
+     * Container for resolving callable strings
+     *
+     * @var \Pimple\Container
+     */
+    protected $container;
+
+    /**
      * Create new route
      *
      * @param string[] $methods       The route HTTP methods
@@ -67,6 +79,25 @@ class Route implements RouteInterface
         $this->pattern = $pattern;
         $this->setCallable($callable);
         $this->seedMiddlewareStack();
+    }
+
+    /**
+     * Add middleware
+     *
+     * This method prepends new middleware to the route's middleware stack.
+     *
+     * @param  mixed    $callable The callback routine
+     *
+     * @return RouteInterface
+     */
+    public function add($callable)
+    {
+        $callable = $this->resolveCallable($callable);
+        if ($callable instanceof \Closure) {
+            $callable = $callable->bindTo($this->container);
+        }
+
+        return $this->addMiddleware($callable);
     }
 
     /**
@@ -132,6 +163,17 @@ class Route implements RouteInterface
             throw new \InvalidArgumentException('Route name must be a string');
         }
         $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * Set container for use with resolveCallable
+     *
+     * @param \Pimple\Container $container
+     */
+    public function register(Container $container)
+    {
+        $this->container = $container;
         return $this;
     }
 

--- a/tests/MiddlewareAwareTest.php
+++ b/tests/MiddlewareAwareTest.php
@@ -136,4 +136,11 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $stack->alternativeSeed();
     }
 
+    public function testAddingNonCallableFails()
+    {
+        $stack = new Stackable;
+        $this->setExpectedException('RuntimeException', 'Expected a callable to be added');
+        $stack->add('string');
+
+    }
 }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -31,6 +31,14 @@
  */
 
 use Slim\Route;
+use Pimple\Container;
+
+class MiddlewareStub
+{
+    public function run($request, $response, $next) {
+        return $next($request, $response);
+    }
+}
 
 class RouteTest extends PHPUnit_Framework_TestCase
 {
@@ -110,7 +118,30 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $route = $this->routeFactory();
         $this->assertEquals($route, $route->setName('foo'));
         $this->assertEquals('foo', $route->getName());
-    }    
+    }
+
+    public function testAddMiddlewareAsString()
+    {
+        $route = $this->routeFactory();
+
+        $container = new Container();
+        $route->register($container);
+        $route->add('MiddlewareStub:run');
+
+        $uri = \Slim\Http\Uri::createFromString('https://example.com:80');
+        $headers = new \Slim\Http\Headers();
+        $cookies = new \Slim\Collection([
+            'user' => 'john',
+            'id' => '123',
+        ]);
+        $body = new \Slim\Http\Body(fopen('php://temp', 'r+'));
+        $request = new \Slim\Http\Request('GET', $uri, $headers, $cookies, $body);
+
+        $response = new \Slim\Http\Response;
+        $result = $route->callMiddlewareStack($request, $response);
+
+        $this->assertInstanceOf('Slim\Http\Response', $result);
+    }
 
     // TODO: Test adding controller callables with "Foo:bar" syntax
 


### PR DESCRIPTION
This PR resolves #1014: "Using 'Class:method' as a route middleware" which means that it supports:

``` php
$app->get(
    '/',
    function($request, $response) {
        echo "<p>Hello world</p>";
    }
)
->add('ClassRouteMiddleware:run');
```

This is more invasive than I expected as  `$app->map()` now returns a `Route` with which we use `add()` in order to add middleware to the route.

However, the Route object doesn't know about the DI container and its  `add()` method comes from the `MiddlewareAware` trait which has a signature that is type hinted to `callable`. Also, the `Route` object is  directly instantiated by the `Router` object in `Router::map`.

As a result, I've created a `ResolveCallable` trait that is used by both `App` and `Route` and modified `Route` to use it. I also decided to make the `Route` object `Container`-aware, but injected the container via a setter so that I didn't need to change the Router class. The `resolveCallable()` method checks that the container has been set if you try to use the 'class:method' string and throws a runtime exception if it doesn't have a valid container.

I'm mostly concerned about the `testAddMiddlewareAsString` test as it seems more of an integration than unit test, but I couldn't work out how else to test. If there's a better way to do it, then it should be changed!
