### PR TITLE
Fix #1110

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -118,13 +118,13 @@ class Uri implements \Psr\Http\Message\UriInterface
         }
 
         $parts = parse_url($uri);
-        $scheme = isset($parts['scheme']) ? $parts['scheme'] : '';
-        $user = isset($parts['user']) ? $parts['user'] : '';
-        $pass = isset($parts['pass']) ? $parts['pass'] : '';
-        $host = isset($parts['host']) ? $parts['host'] : '';
-        $port = isset($parts['port']) ? $parts['port'] : '';
-        $path = isset($parts['path']) ? $parts['path'] : '';
-        $query = isset($parts['query']) ? $parts['query'] : '';
+        $scheme = isset($parts['scheme']) ? $parts['scheme'] : null;
+        $user = isset($parts['user']) ? $parts['user'] : null;
+        $pass = isset($parts['pass']) ? $parts['pass'] : null;
+        $host = isset($parts['host']) ? $parts['host'] : null;
+        $port = isset($parts['port']) ? $parts['port'] : null;
+        $path = isset($parts['path']) ? $parts['path'] : null;
+        $query = isset($parts['query']) ? $parts['query'] : null;
 
         return new static($scheme, $host, $port, $path, $query, $user, $pass);
     }

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -331,6 +331,19 @@ class UriTest extends PHPUnit_Framework_TestCase
      * Helpers
      *******************************************************************************/
 
+    public function testCreateFromString()
+    {
+        $uri = \Slim\Http\Uri::createFromString('https://josh:sekrit@example.com/foo/bar?abc=123');
+
+        $this->assertEquals('https', $uri->getScheme());
+        $this->assertEquals('josh:sekrit', $uri->getUserInfo());
+        $this->assertEquals('example.com', $uri->getHost());
+        $this->assertNull($uri->getPort());
+        $this->assertEquals('/foo/bar', $uri->getPath());
+        $this->assertEquals('abc=123', $uri->getQuery());
+        $this->assertEquals('https://josh:sekrit@example.com/foo/bar?abc=123', (string)$uri);
+    }
+
     public function testToString()
     {
         $this->assertEquals('https://josh:sekrit@example.com/foo/bar?abc=123', (string)$this->uriFactory());


### PR DESCRIPTION
This quickly fixes the `createFromString` issue #1110. It basically lets the constructor take care of the default values.
