### PR TITLE
Fix getPort() following psr-7 spec

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -94,7 +94,7 @@ class Uri implements \Psr\Http\Message\UriInterface
      * @param string $user     Uri user
      * @param string $password Uri password
      */
-    public function __construct($scheme, $host, $port = 80, $path = '/', $query = '', $user = '', $password = '')
+    public function __construct($scheme, $host, $port = null, $path = '/', $query = '', $user = '', $password = '')
     {
         $this->scheme = $this->filterScheme($scheme);
         $this->host = $host;
@@ -122,7 +122,7 @@ class Uri implements \Psr\Http\Message\UriInterface
         $user = isset($parts['user']) ? $parts['user'] : '';
         $pass = isset($parts['pass']) ? $parts['pass'] : '';
         $host = isset($parts['host']) ? $parts['host'] : '';
-        $port = isset($parts['port']) ? $parts['port'] : 80;
+        $port = isset($parts['port']) ? $parts['port'] : null;
         $path = isset($parts['path']) ? $parts['path'] : '';
         $query = isset($parts['query']) ? $parts['query'] : '';
 

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -184,24 +184,35 @@ class UriTest extends PHPUnit_Framework_TestCase
 
         $this->assertAttributeEquals('slimframework.com', 'host', $uri);
     }
-
-    public function testGetPortStandard()
+    
+    public function testGetPortWithSchemeAndNonDefaultPort()
     {
-        $this->assertNull($this->uriFactory()->getPort());
-    }
-
-    public function testGetPortNonStandard()
-    {
-        $scheme = 'https';
-        $user = 'josh';
-        $password = 'sekrit';
-        $host = 'example.com';
-        $path = '/foo/bar';
-        $port = 4000;
-        $query = 'abc=123';
-        $uri = new \Slim\Http\Uri($scheme, $host, $port, $path, $query, $user, $password);
+        $uri = new Slim\Http\Uri('https', 'www.example.com', 4000);
 
         $this->assertEquals(4000, $uri->getPort());
+    }
+    
+    public function testGetPortWithSchemeAndDefaultPort()
+    {
+        $uriHppt = new Slim\Http\Uri('http', 'www.example.com', 80);
+        $uriHppts = new Slim\Http\Uri('https', 'www.example.com', 443);
+        
+        $this->assertNull($uriHppt->getPort());
+        $this->assertNull($uriHppts->getPort());
+    }
+
+    public function testGetPortWithoutSchemeAndPort()
+    {
+        $uri = new Slim\Http\Uri('', 'www.example.com');
+        
+        $this->assertNull($uri->getPort());
+    }
+
+    public function testGetPortWithSchemeWithoutPort()
+    {
+        $uri = new Slim\Http\Uri('http', 'www.example.com');
+        
+        $this->assertNull($uri->getPort());
     }
 
     public function testWithPort()


### PR DESCRIPTION
Following the discussion in #1110 

``` php
// If a port is present, and it is non-standard for the current scheme, this method MUST return it as an integer.
$uri = new Slim\Http\Uri('https', 'www.example.com', 80);
var_dump($uri->getPort());
// result -> 80

// If the port is the standard port used with the current scheme, this method SHOULD return null.
$uri = new Slim\Http\Uri('http', 'www.example.com', 80);
var_dump($uri->getPort());
// result -> null

// If no port is present, and no scheme is present, this method MUST return a null value.
$uri = new Slim\Http\Uri('', 'www.example.com');
var_dump($uri->getPort());
// result -> null

// If no port is present, but a scheme is present, this method MAY return the standard port for that scheme, but SHOULD return null.
$uri = new Slim\Http\Uri('http', 'www.example.com');
var_dump($uri->getPort());
// result -> null
```

Let me know what you think!
