### PR TITLE
Adds Slim Request and Response Interfaces

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -8,8 +8,8 @@
  */
 namespace Slim;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Slim\Interfaces\Http\RequestInterface;
+use Slim\Interfaces\Http\ResponseInterface;
 use Pimple\ServiceProviderInterface;
 
 /**
@@ -71,7 +71,7 @@ class App extends \Pimple\Container
          * Request factory
          *
          * This factory method MUST return a NEW instance
-         * of \Psr\Http\Message\RequestInterface.
+         * of \Slim\Interfaces\Http\RequestInterface.
          */
         $this['request'] = $this->factory(function ($c) {
             $env = $c['environment'];
@@ -89,7 +89,7 @@ class App extends \Pimple\Container
          * Response factory
          *
          * This factory method MUST return a NEW instance
-         * of \Psr\Http\Message\ResponseInterface.
+         * of \Slim\Interfaces\Http\ResponseInterface.
          */
         $this['response'] = $this->factory(function ($c) {
             $headers = new Http\Headers(['Content-Type' => 'text/html']);
@@ -121,12 +121,12 @@ class App extends \Pimple\Container
          * This factory method MUST return a callable
          * that accepts three arguments:
          *
-         * 1. Instance of \Psr\Http\Message\RequestInterface
-         * 2. Instance of \Psr\Http\Message\ResponseInterface
+         * 1. Instance of \Slim\Interfaces\Http\RequestInterface
+         * 2. Instance of \Slim\Interfaces\Http\ResponseInterface
          * 3. Instance of \Exception
          *
          * The callable MUST return an instance of
-         * \Psr\Http\Message\ResponseInterface.
+         * \Slim\Interfaces\Http\ResponseInterface.
          */
         $this['errorHandler'] = function ($c) {
             return new Handlers\Error;
@@ -138,11 +138,11 @@ class App extends \Pimple\Container
          * This factory method MUST return a callable
          * that accepts two arguments:
          *
-         * 1. Instance of \Psr\Http\Message\RequestInterface
-         * 2. Instance of \Psr\Http\Message\ResponseInterface
+         * 1. Instance of \Slim\Interfaces\Http\RequestInterface
+         * 2. Instance of \Slim\Interfaces\Http\ResponseInterface
          *
          * The callable MUST return an instance of
-         * \Psr\Http\Message\ResponseInterface.
+         * \Slim\Interfaces\Http\ResponseInterface.
          */
         $this['notFoundHandler'] = function ($c) {
             return new Handlers\NotFound;
@@ -154,12 +154,12 @@ class App extends \Pimple\Container
          * This factory method MUST return a callable
          * that accepts three arguments:
          *
-         * 1. Instance of \Psr\Http\Message\RequestInterface
-         * 2. Instance of \Psr\Http\Message\ResponseInterface
+         * 1. Instance of \Slim\Interfaces\Http\RequestInterface
+         * 2. Instance of \Slim\Interfaces\Http\ResponseInterface
          * 3. Array of allowed HTTP methods
          *
          * The callable MUST return an instance of
-         * \Psr\Http\Message\ResponseInterface.
+         * \Slim\Interfaces\Http\ResponseInterface.
          */
         $this['notAllowedHandler'] = function ($c) {
             return new Handlers\NotAllowed;

--- a/Slim/Exception.php
+++ b/Slim/Exception.php
@@ -8,7 +8,7 @@
  */
 namespace Slim;
 
-use Psr\Http\Message\ResponseInterface;
+use Slim\Interfaces\Http\ResponseInterface;
 
 /**
  * Stop Exception

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -8,8 +8,8 @@
  */
 namespace Slim\Handlers;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Slim\Interfaces\Http\RequestInterface;
+use Slim\Interfaces\Http\ResponseInterface;
 use Slim\Http\Body;
 
 /**

--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -8,8 +8,8 @@
  */
 namespace Slim\Handlers;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Slim\Interfaces\Http\RequestInterface;
+use Slim\Interfaces\Http\ResponseInterface;
 use Slim\Http\Body;
 
 /**

--- a/Slim/Handlers/NotFound.php
+++ b/Slim/Handlers/NotFound.php
@@ -8,8 +8,8 @@
  */
 namespace Slim\Handlers;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Slim\Interfaces\Http\RequestInterface;
+use Slim\Interfaces\Http\ResponseInterface;
 use Slim\Http\Body;
 
 /**

--- a/Slim/Http/Body.php
+++ b/Slim/Http/Body.php
@@ -8,6 +8,8 @@
  */
 namespace Slim\Http;
 
+use Psr\Http\Message\StreamableInterface;
+
 /**
  * Body
  *
@@ -16,7 +18,7 @@ namespace Slim\Http;
  *
  * @link https://github.com/php-fig/http-message/blob/master/src/StreamableInterface.php
  */
-class Body implements \Psr\Http\Message\StreamableInterface
+class Body implements StreamableInterface
 {
     /**
      * Resource modes

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -8,11 +8,11 @@
  */
 namespace Slim\Http;
 
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Message\StreamableInterface;
 use Slim\Interfaces\Http\HeadersInterface;
 use Slim\Interfaces\CollectionInterface;
+use Slim\Interfaces\Http\RequestInterface;
 use Slim\Collection;
 
 /**

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -10,7 +10,7 @@ namespace Slim\Http;
 
 use Slim\Interfaces\Http\HeadersInterface;
 use Slim\Interfaces\Http\CookiesInterface;
-use Psr\Http\Message\ResponseInterface;
+use Slim\Interfaces\Http\ResponseInterface;
 use Psr\Http\Message\StreamableInterface;
 
 /**

--- a/Slim/Interfaces/Http/RequestInterface.php
+++ b/Slim/Interfaces/Http/RequestInterface.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     2.3.0
+ * @package     Slim
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+namespace Slim\Interfaces\Http;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Slim Request Interface
+ *
+ * @package Slim
+ * @author  Jeremy Kendall
+ * @since   3.0.0
+ */
+interface RequestInterface extends ServerRequestInterface
+{
+    /**
+     * Get the original HTTP method (ignore override)
+     *
+     * @return string
+     */
+    public function getOriginalMethod();
+
+    /**
+     * Does this request use a given method?
+     *
+     * @param  string $method HTTP method
+     * @return bool
+     */
+    public function isMethod($method);
+
+    /**
+     * Is this a GET request?
+     *
+     * @return bool
+     */
+    public function isGet();
+
+    /**
+     * Is this a POST request?
+     *
+     * @return bool
+     */
+    public function isPost();
+
+    /**
+     * Is this a PUT request?
+     *
+     * @return bool
+     */
+    public function isPut();
+
+    /**
+     * Is this a PATCH request?
+     *
+     * @return bool
+     */
+    public function isPatch();
+
+    /**
+     * Is this a DELETE request?
+     *
+     * @return bool
+     */
+    public function isDelete();
+
+    /**
+     * Is this a HEAD request?
+     *
+     * @return bool
+     */
+    public function isHead();
+
+    /**
+     * Is this a OPTIONS request?
+     *
+     * @return bool
+     */
+    public function isOptions();
+
+    /**
+     * Is this an AJAX request?
+     *
+     * @return bool
+     */
+    public function isAjax();
+
+    /**
+     * Is this an XHR request?
+     *
+     * @see    isAjax()
+     * @return bool
+     */
+    public function isXhr();
+
+    /**
+     * Get request content type
+     *
+     * @return string|null The request content type, if known
+     */
+    public function getContentType();
+
+    /**
+     * Get request media type, if known
+     *
+     * @return string|null The request media type, minus content-type params
+     */
+    public function getMediaType();
+
+    /**
+     * Get request media type params, if known
+     *
+     * @return array
+     */
+    public function getMediaTypeParams();
+
+    /**
+     * Get request content character set, if known
+     *
+     * @return string|null
+     */
+    public function getContentCharset();
+
+    /**
+     * Get request content length, if known
+     *
+     * @return int|null
+     */
+    public function getContentLength();
+
+    /**
+     * Register media type parser
+     *
+     * @param string   $mediaType A HTTP media type (excluding content-type params)
+     * @param callable $callable  A callable that returns parsed contents for media type
+     */
+    public function registerMediaTypeParser($mediaType, callable $callable);
+
+    /**
+     * Fetch request parameter value from
+     * body or query string (in that order).
+     *
+     * @param  string $key The parameter key
+     *
+     * @return mixed The parameter value
+     */
+    public function getParam($key);
+
+    /**
+     * Fetch assocative array of body and query string parameters
+     *
+     * @return array
+     */
+    public function getParams();
+}

--- a/Slim/Interfaces/Http/ResponseInterface.php
+++ b/Slim/Interfaces/Http/ResponseInterface.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Slim - a micro PHP 5 framework
+ *
+ * @author      Josh Lockhart <info@slimframework.com>
+ * @copyright   2011 Josh Lockhart
+ * @link        http://www.slimframework.com
+ * @license     http://www.slimframework.com/license
+ * @version     2.3.0
+ * @package     Slim
+ *
+ * MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+namespace Slim\Interfaces\Http;
+
+use Psr\Http\Message\ResponseInterface as HttpMessageResponseInterface;
+
+/**
+ * Slim Request Interface
+ *
+ * @package Slim
+ * @author  Jeremy Kendall
+ * @since   3.0.0
+ */
+interface ResponseInterface extends HttpMessageResponseInterface
+{
+    /**
+     * Retrieves all cookies.
+     *
+     * The keys represent the cookie name as it will be sent over the wire, and
+     * each value is an array of properties associated with the cookie.
+     *
+     *     // Represent the headers as a string
+     *     foreach ($message->getCookies() as $name => $values) {
+     *         echo $values['value'];
+     *         echo $values['expires'];
+     *         echo $values['path'];
+     *         echo $values['domain'];
+     *         echo $values['secure'];
+     *         echo $values['httponly'];
+     *     }
+     *
+     * @return array Returns an associative array of the cookie's properties. Each
+     *               key MUST be a cookie name, and each value MUST be an array of properties.
+     */
+    public function getCookies();
+
+    /**
+     * Checks if a cookie exists by the given case-insensitive name.
+     *
+     * @param  string $name Case-insensitive header name.
+     * @return bool         Returns true if any cookie names match the given cookie
+     *                      name using a case-insensitive string comparison. Returns false if
+     *                      no matching cookie name is found in the message.
+     */
+    public function hasCookie($name);
+
+    /**
+     * Retrieve a cookie by the given case-insensitive name, as a string.
+     *
+     * This method returns all of the cookie values of the given
+     * case-insensitive cookie name as a string as it will
+     * appear in the HTTP response's `Set-Cookie` header.
+     *
+     * @param  string      $name Case-insensitive cookie name.
+     * @return string|null
+     */
+    public function getCookie($name);
+
+    /**
+     * Retrieves a cookie by the given case-insensitive name as an array of properties.
+     *
+     * @param  string        $name Case-insensitive cookie name.
+     * @return string[]|null
+     */
+    public function getCookieProperties($name);
+
+    /**
+     * Create a new instance with the provided cookie, replacing any existing
+     * values of any cookies with the same case-insensitive name.
+     *
+     * While cookie names are case-insensitive, the casing of the cookie will
+     * be preserved by this function, and returned from getCookies().
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * new and/or updated cookie and value.
+     *
+     * @param  string          $name  Cookie name
+     * @param  string|string[] $value Cookie value(s).
+     * @return self
+     */
+    public function withCookie($name, $value);
+
+    /**
+     * Creates a new instance, without the specified cookie.
+     *
+     * Cookie resolution MUST be done without case-sensitivity.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that removes
+     * the named cookie.
+     *
+     * @param  string $name HTTP cookie to remove
+     * @return self
+     */
+    public function withoutCookie($name);
+
+    /**
+     * Write data to the response body
+     *
+     * Proxies to the underlying stream and writes the provided data to it.
+     *
+     * @param string $data
+     */
+    public function write($data);
+
+    /**
+     * Finalize response for delivery to client
+     *
+     * @return self
+     */
+    public function finalize();
+
+    /**
+     * Send HTTP headers to client
+     *
+     * @return self
+     */
+    public function sendHeaders();
+
+    /**
+     * Send HTTP body to client
+     *
+     * @param  int $bufferSize
+     * @return self
+     */
+    public function sendBody($bufferSize = 1024);
+
+    /**
+     * Redirect
+     *
+     * This method prepares the response object to return an HTTP Redirect response
+     * to the client.
+     *
+     * @param  string $url    The redirect destination
+     * @param  int    $status The redirect HTTP status code
+     * @return self
+     */
+    public function withRedirect($url, $status = 302);
+
+    /**
+     * Is this response empty?
+     *
+     * @return bool
+     */
+    public function isEmpty();
+
+    /**
+     * Is this response informational?
+     *
+     * @return bool
+     */
+    public function isInformational();
+
+    /**
+     * Is this response OK?
+     *
+     * @return bool
+     */
+    public function isOk();
+
+    /**
+     * Is this response successful?
+     *
+     * @return bool
+     */
+    public function isSuccessful();
+
+    /**
+     * Is this response a redirect?
+     *
+     * @return bool
+     */
+    public function isRedirect();
+
+    /**
+     * Is this response a redirection?
+     *
+     * @return bool
+     */
+    public function isRedirection();
+
+    /**
+     * Is this response forbidden?
+     *
+     * @return bool
+     * @api
+     */
+    public function isForbidden();
+
+    /**
+     * Is this response not Found?
+     *
+     * @return bool
+     */
+    public function isNotFound();
+
+    /**
+     * Is this response a client error?
+     *
+     * @return bool
+     */
+    public function isClientError();
+
+    /**
+     * Is this response a server error?
+     *
+     * @return bool
+     */
+    public function isServerError();
+}

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -8,8 +8,8 @@
  */
 namespace Slim\Interfaces;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Slim\Interfaces\Http\RequestInterface;
+use Slim\Interfaces\Http\ResponseInterface;
 
 interface RouteInterface
 {

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -8,7 +8,7 @@
  */
 namespace Slim\Interfaces;
 
-use Psr\Http\Message\RequestInterface;
+use Slim\Interfaces\Http\RequestInterface;
 
 interface RouterInterface
 {

--- a/Slim/MiddlewareAware.php
+++ b/Slim/MiddlewareAware.php
@@ -8,8 +8,8 @@
  */
 namespace Slim;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Slim\Interfaces\Http\RequestInterface;
+use Slim\Interfaces\Http\ResponseInterface;
 
 /**
  * Middleware
@@ -63,7 +63,7 @@ trait MiddlewareAware
         $this->stack[] = function (RequestInterface $req, ResponseInterface $res) use ($callable, $next) {
             $result = $callable($req, $res, $next);
             if ($result instanceof ResponseInterface === false) {
-                throw new \UnexpectedValueException('Middleware must return instance of \Psr\Http\Message\ResponseInterface');
+                throw new \UnexpectedValueException('Middleware must return instance of \Slim\Interfaces\Http\ResponseInterface');
             }
 
             return $result;

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -8,8 +8,8 @@
  */
 namespace Slim;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Slim\Interfaces\Http\RequestInterface;
+use Slim\Interfaces\Http\ResponseInterface;
 use Slim\Interfaces\RouteInterface;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
@@ -198,7 +198,7 @@ class Route implements RouteInterface, ServiceProviderInterface
      *
      * @param RequestInterface $request The current Request object
      * @param ResponseInterface $response The current Response object
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return \Slim\Interfaces\Http\ResponseInterface
      * @throws \Exception
      */
     public function __invoke(RequestInterface $request, ResponseInterface $response)

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -8,7 +8,7 @@
  */
 namespace Slim;
 
-use Psr\Http\Message\RequestInterface;
+use Slim\Interfaces\Http\RequestInterface;
 use Slim\Interfaces\RouterInterface;
 
 /**

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=5.4.0",
         "pimple/pimple": "3.*",
-        "psr/http-message": "~0.8",
+        "psr/http-message": "^0.9.0",
         "nikic/fast-route": "~0.4"
     },
     "require-dev": {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -256,7 +256,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         // Invoke app
         $resOut = $app($req, $res);
 
-        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
+        $this->assertInstanceOf('\Slim\Interfaces\Http\ResponseInterface', $resOut);
         $this->assertEquals('Hello', (string)$res->getBody());
     }
 
@@ -286,7 +286,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         // Invoke app
         $resOut = $app($req, $res);
 
-        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
+        $this->assertInstanceOf('\Slim\Interfaces\Http\ResponseInterface', $resOut);
         $this->assertAttributeEquals(404, 'status', $resOut);
     }
 
@@ -354,7 +354,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         // Invoke app
         $resOut = $app($req, $res);
 
-        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
+        $this->assertInstanceOf('\Slim\Interfaces\Http\ResponseInterface', $resOut);
         $this->assertEquals('Hello', (string)$res->getBody());
     }
 

--- a/tests/MiddlewareAwareTest.php
+++ b/tests/MiddlewareAwareTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace Slim\Tests;
 
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use Slim\Interfaces\Http\RequestInterface;
+use Slim\Interfaces\Http\ResponseInterface;
 
 function testMiddlewareKernel(RequestInterface $req, ResponseInterface $res)
 {
@@ -125,8 +125,8 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         });
         $this->setExpectedException('RuntimeException');
         $stack->callMiddlewareStack(
-            $this->getMock('Psr\Http\Message\RequestInterface'),
-            $this->getMock('Psr\Http\Message\ResponseInterface')
+            $this->getMock('Slim\Interfaces\Http\RequestInterface'),
+            $this->getMock('Slim\Interfaces\Http\ResponseInterface')
         );
     }
 


### PR DESCRIPTION
Since the Slim Request and Response add methods beyond the PSR-7
interfaces, Slim should have its own Request and Response interfaces
that extend the appropriate http-message interfaces.
