### PR TITLE
Arguments passed to route callable, no more an array of args

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -206,7 +206,7 @@ class Route implements RouteInterface, ServiceProviderInterface
         // Invoke route callable
         try {
             ob_start();
-            $newResponse = call_user_func_array($this->callable, [$request, $response, $this->parsedArgs]);
+            $newResponse = call_user_func_array($this->callable, [$request, $response] + $this->parsedArgs);
             $output = ob_get_clean();
         } catch (\Exception $e) {
             ob_end_clean();

--- a/index.php
+++ b/index.php
@@ -20,9 +20,10 @@ require 'vendor/autoload.php';
  */
 $app = new \Slim\App();
 
-$app->map(['GET', 'POST'], '/hello/{first}/{last}', function ($req, $res, $args) {
+$app->map(['GET', 'POST'], '/hello/{first}/{last}', function ($req, $res, $first, $last) {
     echo $this['router']->urlFor('testGet', ['first' => 'Josh', 'last' => 'Lockhart']);
-    var_dump($args);
+    var_dump($first);
+    var_dump($last);
 })->setName('testGet');
 
 $app->get('/etaghit', function ($request, $response, $args) {

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -46,8 +46,8 @@ class RouteTest extends PHPUnit_Framework_TestCase
     public function routeFactory()
     {
         $methods = ['GET', 'POST'];
-        $pattern = '/hello/{name}';
-        $callable = function ($req, $res, $args) {
+        $pattern = '/hello';
+        $callable = function ($req, $res) {
             // Do something
         };
 
@@ -57,8 +57,8 @@ class RouteTest extends PHPUnit_Framework_TestCase
     public function testConstructor()
     {
         $methods = ['GET', 'POST'];
-        $pattern = '/hello/{name}';
-        $callable = function ($req, $res, $args) {
+        $pattern = '/hello';
+        $callable = function ($req, $res) {
             // Do something
         };
         $route = new Route($methods, $pattern, $callable);
@@ -75,7 +75,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
 
     public function testGetPattern()
     {
-        $this->assertEquals('/hello/{name}', $this->routeFactory()->getPattern());
+        $this->assertEquals('/hello', $this->routeFactory()->getPattern());
     }
 
     public function testGetCallable()
@@ -145,6 +145,47 @@ class RouteTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Slim\Http\Response', $result);
     }
+
+    public function testRouteHandlerCallableParams()
+    {
+        // routing
+
+        $router = new \Slim\Router;
+
+        $methods = ['GET', 'POST'];
+        $pattern = '/category/{slug}/page/{page}';
+        $callable = function ($req, $res, $slug, $page)
+        {
+            echo '/category/' . $slug . '/page/' . $page;
+        };
+
+        $router->map($methods, $pattern, $callable);
+
+        // env
+
+        $env = \Slim\Http\Environment::mock();
+        $uri = \Slim\Http\Uri::createFromString('https://example.com/category/hello/page/10');
+        $headers = new \Slim\Http\Headers;
+        $cookies = new \Slim\Http\Collection;
+        $serverParams = new Collection($env->all());
+        $body = new \Slim\Http\Body(fopen('php://temp', 'r+'));
+        $request = new \Slim\Http\Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+
+        $response = new \Slim\Http\Response;
+
+        // router dispath
+
+        $routeInfo = $router->dispatch($request);
+
+        $result = $routeInfo[1]($request->withAttributes($routeInfo[2]), $response, $routeInfo[2]);
+
+        // test
+
+        $this->assertInstanceOf('Slim\Http\Response', $result);
+
+        $this->assertEquals($result->getBody(), '/category/hello/page/10');
+    }
+
 
     // TODO: Test adding controller callables with "Foo:bar" syntax
 


### PR DESCRIPTION
Allow using route argument(s) directly into its callable, no more an array of results.
In my opinion, it's more clean.

Example : 

``` php
$app->get('/category/{slug}', 'categoryHandler');

$app->get('/category/{slug}/{page}', 'categoryHandler');
```

``` php
function categoryHandler( $request, $response, $slug, $page = 1 )
{
    // Do something
}
```

instead of :

``` php
function categoryHandler( $request, $response, $args )
{
    $slug = $args['slug'];
    $page = isset($args['page']) ? $args['page'] : 1;

    // Do something
}
```

Test is done under : RouteTest::testRouteHandlerCallableParams()

What do guys thinking ?
