### PR TITLE
When specifying a Pimple callable, __call magic methods should be allowed

### DIFF
--- a/Slim/ResolveCallable.php
+++ b/Slim/ResolveCallable.php
@@ -56,7 +56,7 @@ trait ResolveCallable
                         }
                         $obj = new $class;
                     }
-                    if ((is_object($obj) && !is_callable([$obj, $method])) || (!is_object($obj) && !method_exists($obj, $method))) {
+                    if (!is_callable([$obj, $method])) {
                         throw new \RuntimeException('Route callable method does not exist');
                     }
                 }

--- a/Slim/ResolveCallable.php
+++ b/Slim/ResolveCallable.php
@@ -56,7 +56,7 @@ trait ResolveCallable
                         }
                         $obj = new $class;
                     }
-                    if ((is_object($obj) && !is_callable([$obj, $method])) || (!is_object($obj) && method_exists($obj, $method))) {
+                    if ((is_object($obj) && !is_callable([$obj, $method])) || (!is_object($obj) && !method_exists($obj, $method))) {
                         throw new \RuntimeException('Route callable method does not exist');
                     }
                 }

--- a/Slim/ResolveCallable.php
+++ b/Slim/ResolveCallable.php
@@ -38,11 +38,11 @@ trait ResolveCallable
     {
         if (is_string($callable) && preg_match('!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!', $callable, $matches)) {
             // $callable is a class:method string, so wrap it into a closure, retriving the class from Pimple if registered there
-     
+
             if ((! $this instanceof Container) && (! $this->container instanceof Container)) {
                 throw new \RuntimeException('Cannot resolve callable string');
             }
-     
+
             $class = $matches[1];
             $method = $matches[2];
             $callable = function() use ($class, $method) {
@@ -56,7 +56,7 @@ trait ResolveCallable
                         }
                         $obj = new $class;
                     }
-                    if (!method_exists($obj, $method)) {
+                    if ((is_object($obj) && !is_callable([$obj, $method])) || (!is_object($obj) && method_exists($obj, $method))) {
                         throw new \RuntimeException('Route callable method does not exist');
                     }
                 }


### PR DESCRIPTION
Currently Slim3 allows you to define callables that are actually fetched via Pimple, when using the form `PimpleKey:method`. However this only works if `method` is actually a defined method in whatever object is returned by Pimple when the `PimpleKey` is fetched.

This PR takes into account the `__call` magic method, so objects that define such method and are returned as part of a Pimple fetch, will now work. The unit test attachted to this PR should describe this further.
