### PR TITLE
Add 3.0.x-dev alias to develop branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,5 +35,10 @@
         "psr-0": {
             "Slim": "."
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-develop": "3.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
NOTE: this should be removed when develop is moved to master
