### PR TITLE
Various minor fixes: phpdoc, type-hints, imports

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -8,7 +8,6 @@
  */
 namespace Slim;
 
-use Slim\Interfaces\Http\CookiesInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Pimple\ServiceProviderInterface;
@@ -75,7 +74,7 @@ class App extends \Pimple\Container
          * This Pimple service MUST return a shared instance
          * of \Slim\Interfaces\Http\EnvironmentInterface.
          */
-        $this['environment'] = function ($c) {
+        $this['environment'] = function () {
             return new Http\Environment($_SERVER);
         };
 
@@ -110,7 +109,7 @@ class App extends \Pimple\Container
          * This Pimple service MUST return a SHARED instance
          * of \Slim\Interfaces\RouterInterface.
          */
-        $this['router'] = function ($c) {
+        $this['router'] = function () {
             return new Router();
         };
 
@@ -125,7 +124,7 @@ class App extends \Pimple\Container
          * The callable MUST return an instance of
          * \Psr\Http\Message\ResponseInterface.
          */
-        $this['errorHandler'] = function ($c) {
+        $this['errorHandler'] = function () {
             return new Handlers\Error;
         };
 
@@ -139,7 +138,7 @@ class App extends \Pimple\Container
          * The callable MUST return an instance of
          * \Psr\Http\Message\ResponseInterface.
          */
-        $this['notFoundHandler'] = function ($c) {
+        $this['notFoundHandler'] = function () {
             return new Handlers\NotFound;
         };
 
@@ -154,7 +153,7 @@ class App extends \Pimple\Container
          * The callable MUST return an instance of
          * \Psr\Http\Message\ResponseInterface.
          */
-        $this['notAllowedHandler'] = function ($c) {
+        $this['notAllowedHandler'] = function () {
             return new Handlers\NotAllowed;
         };
     }
@@ -252,7 +251,6 @@ class App extends \Pimple\Container
      */
     public function map(array $methods, $pattern, $callable)
     {
-
         $callable = is_string($callable) ? $this->resolveCallable($callable) : $callable;
         if ($callable instanceof \Closure) {
             $callable = $callable->bindTo($this);
@@ -436,7 +434,7 @@ class App extends \Pimple\Container
      * application routes. The result response object is returned.
      *
      * @param  string            $method      The request method (e.g., GET, POST, PUT, etc.)
-     * @param  string            $uri         The request URI path
+     * @param  string            $path        The request URI path
      * @param  array             $headers     The request headers (key-value array)
      * @param  array             $cookies     The request cookies (key-value array)
      * @param  string            $bodyContent The request body

--- a/Slim/Autoloader.php
+++ b/Slim/Autoloader.php
@@ -19,7 +19,6 @@ class Autoloader
     {
         $className = ltrim($className, '\\');
         $fileName  = '';
-        $namespace = '';
         if ($lastNsPos = strrpos($className, '\\')) {
             $namespace = substr($className, 0, $lastNsPos);
             $className = substr($className, $lastNsPos + 1);

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -58,7 +58,7 @@ class Error
                 ->write($output);
     }
 
-    private function renderException($exception)
+    private function renderException(\Exception $exception)
     {
         $code = $exception->getCode();
         $message = $exception->getMessage();

--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -108,8 +108,8 @@ class Cookies implements CookiesInterface
     /**
      * Convert to `Set-Cookie` header
      *
-     * @param  string $name   Cookie name
-     * @param  array  $cookie Cookie properties
+     * @param  string $name       Cookie name
+     * @param  array  $properties Cookie properties
      *
      * @return string
      */

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -8,7 +8,6 @@
  */
 namespace Slim\Http;
 
-use Slim\Interfaces\EnvironmentInterface;
 use Slim\Interfaces\Http\HeadersInterface;
 
 /**

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -12,7 +12,6 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Message\StreamInterface;
 use Slim\Interfaces\Http\HeadersInterface;
-use Slim\Interfaces\Http\CollectionInterface;
 
 /**
  * Request
@@ -308,7 +307,7 @@ class Request implements RequestInterface
      *
      * @param  null|string $method
      * @return null|string
-     * @throws InvalidArgumentException on invalid HTTP method.
+     * @throws \InvalidArgumentException on invalid HTTP method.
      */
     protected function filterMethod($method)
     {

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -439,6 +439,7 @@ class Response implements ResponseInterface
      * Proxies to the underlying stream and writes the provided data to it.
      *
      * @param string $data
+     * @return self
      */
     public function write($data)
     {

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -284,7 +284,6 @@ class Uri implements \Psr\Http\Message\UriInterface
      */
     public function getAuthority()
     {
-        $scheme = $this->getScheme();
         $userInfo = $this->getUserInfo();
         $host = $this->getHost();
         $port = $this->getPort();
@@ -599,7 +598,7 @@ class Uri implements \Psr\Http\Message\UriInterface
     /**
      * Filters the query string or fragment of a URI.
      *
-     * @param  $query The raw uri query string
+     * @param string $query The raw uri query string
      * @return string The percent-encoded query string
      */
     protected function filterQuery($query)

--- a/Slim/Interfaces/Http/HeadersInterface.php
+++ b/Slim/Interfaces/Http/HeadersInterface.php
@@ -8,8 +8,6 @@
  */
 namespace Slim\Interfaces\Http;
 
-use \Slim\Interfaces\Http\CollectionInterface;
-
 /**
  * Headers Interface
  *

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -19,7 +19,7 @@ interface RouterInterface
      * @param string   $pattern The route pattern
      * @param callable $handler The route callable
      *
-     * @return \Slim\RouteInterface
+     * @return \Slim\Interfaces\RouteInterface
      */
     public function map($methods, $pattern, $handler);
 
@@ -53,8 +53,8 @@ interface RouterInterface
     /**
      * Build URL for named route
      *
-     * @param string $routeName Route name
-     * @param array  $data      Route URI segments replacement data
+     * @param string $name Route name
+     * @param array  $data Route URI segments replacement data
      *
      * @return string
      * @throws \RuntimeException         If named route does not exist

--- a/Slim/MiddlewareAware.php
+++ b/Slim/MiddlewareAware.php
@@ -40,10 +40,10 @@ trait MiddlewareAware
      *
      * This method prepends new middleware to the application middleware stack.
      *
-     * @param callable $newMiddleware Any callable that accepts three arguments:
-     *                                1. A Request object
-     *                                2. A Response object
-     *                                3. A "next" middleware callable
+     * @param callable $callable Any callable that accepts three arguments:
+     *                           1. A Request object
+     *                           2. A Response object
+     *                           3. A "next" middleware callable
      * @return self
      */
     public function add($callable)

--- a/Slim/ResolveCallable.php
+++ b/Slim/ResolveCallable.php
@@ -32,7 +32,7 @@ trait ResolveCallable
      *
      * @param  string $callable
      *
-     * @return Closure
+     * @return \Closure
      */
     protected function resolveCallable($callable)
     {

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -23,13 +23,15 @@ class Router extends \FastRoute\RouteCollector implements RouterInterface
 {
     /**
      * Routes
+     *
+     * @var Route[]
      */
     protected $routes = [];
 
     /**
      * Named routes
      *
-     * @var null|array
+     * @var null|Route[]
      */
     protected $namedRoutes;
 
@@ -150,8 +152,8 @@ class Router extends \FastRoute\RouteCollector implements RouterInterface
     /**
      * Build URL for named route
      *
-     * @param  string $routeName Route name
-     * @param  array  $data      Route URI segments replacement data
+     * @param  string $name Route name
+     * @param  array  $data Route URI segments replacement data
      *
      * @return string
      * @throws \RuntimeException         If named route does not exist


### PR DESCRIPTION
Hi there, first contribution here :) No a big change, but I opened the project in PhpStorm and there were a few warnings here and there:
- wrong on missing phpdoc
- missing type-hints that would help autocompletion and static analysis
- unused class imports
- unused variables

I have fixed some of them, I didn't add extensive phpdoc (which would help even more in autocompletion and static analysis) because I wasn't sure if it was OK regarding the style guide of the project.
