### PR TITLE
Fix README in regards to sample app

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Requires PHP 5.4.0 or newer.
 
 ```php
 $app = new \Slim\App();
-$app->get('/hello/{name}', function ($request, $response, $args) {
-    echo "Hello, " . $args['name'];
+$app->get('/hello/{name}', function (\Slim\Http\Request $req, \Slim\Http\Response $res, array $args) {
+    $res->write("Hi {$args['name']}");
+    return $res;
 });
 $app->run();
 ```


### PR DESCRIPTION
The sample app provided in README.md does not take into account the `Response` interface for writing a response
