### PR TITLE
Host should not include port number when creating URI from environment

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -82,7 +82,7 @@ class Uri implements \Psr\Http\Message\UriInterface
      * @var string
      */
     protected $query = '';
-    
+
     /**
      * Uri fragment string (without "#" prefix)
      *
@@ -178,7 +178,7 @@ class Uri implements \Psr\Http\Message\UriInterface
 
         // Query string
         $queryString = $env->get('QUERY_STRING', '');
-        
+
         // Fragment
         $fragment = '';
 

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -159,6 +159,7 @@ class Uri implements \Psr\Http\Message\UriInterface
         $user = $env->get('PHP_AUTH_USER', '');
         $password = $env->get('PHP_AUTH_PW', '');
         $host = $env->get('HTTP_HOST', $env->get('SERVER_NAME'));
+        $host = strstr($host, ':', true);
         $port = (int)$env->get('SERVER_PORT', 80);
 
         // Path

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -191,19 +191,19 @@ class UriTest extends PHPUnit_Framework_TestCase
 
         $this->assertAttributeEquals('slimframework.com', 'host', $uri);
     }
-    
+
     public function testGetPortWithSchemeAndNonDefaultPort()
     {
         $uri = new Slim\Http\Uri('https', 'www.example.com', 4000);
 
         $this->assertEquals(4000, $uri->getPort());
     }
-    
+
     public function testGetPortWithSchemeAndDefaultPort()
     {
         $uriHppt = new Slim\Http\Uri('http', 'www.example.com', 80);
         $uriHppts = new Slim\Http\Uri('https', 'www.example.com', 443);
-        
+
         $this->assertNull($uriHppt->getPort());
         $this->assertNull($uriHppts->getPort());
     }
@@ -211,14 +211,14 @@ class UriTest extends PHPUnit_Framework_TestCase
     public function testGetPortWithoutSchemeAndPort()
     {
         $uri = new Slim\Http\Uri('', 'www.example.com');
-        
+
         $this->assertNull($uri->getPort());
     }
 
     public function testGetPortWithSchemeWithoutPort()
     {
         $uri = new Slim\Http\Uri('http', 'www.example.com');
-        
+
         $this->assertNull($uri->getPort());
     }
 
@@ -344,7 +344,7 @@ class UriTest extends PHPUnit_Framework_TestCase
 
         $this->assertAttributeEquals('', 'query', $uri);
     }
-    
+
     /********************************************************************************
      * Fragment
      *******************************************************************************/

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -396,7 +396,6 @@ class UriTest extends PHPUnit_Framework_TestCase
             'SERVER_PORT' => 8080,
 
         ]);
-        //    ('https://josh:sekrit@example.com:8080/foo/bar?abc=123#section3');
 
         $uri = \Slim\Http\Uri::createFromEnvironment($environment);
 

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -383,4 +383,28 @@ class UriTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals('https://josh:sekrit@example.com/foo/bar?abc=123#section3', (string)$this->uriFactory());
     }
+
+    public function testCreateEnvironment()
+    {
+        $environment = \Slim\Http\Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'PHP_AUTH_USER' => 'josh',
+            'PHP_AUTH_PW' => 'sekrit',
+            'QUERY_STRING' => 'abc=123',
+            'HTTP_HOST' => 'example.com:8080',
+            'SERVER_PORT' => 8080,
+
+        ]);
+        //    ('https://josh:sekrit@example.com:8080/foo/bar?abc=123#section3');
+
+        $uri = \Slim\Http\Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('josh:sekrit', $uri->getUserInfo());
+        $this->assertEquals('example.com', $uri->getHost());
+        $this->assertEquals('8080', $uri->getPort());
+        $this->assertEquals('/foo/bar', $uri->getPath());
+        $this->assertEquals('abc=123', $uri->getQuery());
+        $this->assertEquals('', $uri->getFragment());
+    }
 }


### PR DESCRIPTION
Value of `$_SERVER["HTTP_HOST"]` is taken directly from `Host:` request header. This also includes port number.  When uri is created from environment the port wrongly becomes part of the host property.

```
%curl --include http://localhost:8080/foo
HTTP/1.1 200 OK
Host: localhost:8080
Connection: close
X-Powered-By: PHP/5.6.2
Content-type: text/html;charset=UTF-8
Content-Length: 1339

Slim\Http\Uri Object
(
    [scheme:protected] => http
    [user:protected] => 
    [password:protected] => 
    [host:protected] => localhost:8080
    [port:protected] => 8080
    [basePath:protected] => /
    [path:protected] => /foo
    [query:protected] => 
    [fragment:protected] => 
)
```

This PR fixes the behaviour and also adds tests for `URI::createFromEnvironment()`. 
