### PR TITLE
Slim3: Fix hello-world app in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Requires PHP 5.4.0 or newer.
 
 ```php
 $app = new \Slim\App();
-$app->get('/hello/{name}', function ($request, $response, $args) {
-    echo "Hello, " . $args['name'];
+$app->get('/hello/{name}', function (\Slim\Http\Request $req, \Slim\Http\Response $res, array $args) {
+    $res->write("Hi {$args['name']}");
+    return $res;
 });
 $app->run();
 ```

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Requires PHP 5.4.0 or newer.
 
 ```php
 $app = new \Slim\App();
-$app->get('/hello/{name}', function ($req, $res, $args) {
-    $res->write("Hi {$args['name']}");
+$app->get('/hello/{name}', function ($request, $response, $args) {
+    $res->write("Hello, " . $args['name']);
     return $res;
 });
 $app->run();

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Requires PHP 5.4.0 or newer.
 ```php
 $app = new \Slim\App();
 $app->get('/hello/{name}', function ($request, $response, $args) {
-    $res->write("Hello, " . $args['name']);
-    return $res;
+    $response->write("Hello, " . $args['name']);
+    return $response;
 });
 $app->run();
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Requires PHP 5.4.0 or newer.
 
 ```php
 $app = new \Slim\App();
-$app->get('/hello/{name}', function (\Slim\Http\Request $req, \Slim\Http\Response $res, array $args) {
+$app->get('/hello/{name}', function ($req, $res, $args) {
     $res->write("Hi {$args['name']}");
     return $res;
 });


### PR DESCRIPTION
This follows on #1183 but not including the typehinting, so purely fixing `README.md` so strict PSR-7 is used to generate the sample Hello World app, instead of a simple `echo` which is currently throwing a fatal error
