### PR TITLE
handler return value in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ Requires PHP 5.4.0 or newer.
 ```php
 $app = new \Slim\App();
 $app->get('/hello/{name}', function ($request, $response, $args) {
-    $response->write("Hello, " . $args['name']);
-    return $response;
+    $content = "<p>Hello, " . $args['name'] . "</p>";
+    return $response
+        ->withHeader('Content-Type', 'text/html; charset=utf-8')
+        ->write($content)
+    ;
 });
 $app->run();
 ```


### PR DESCRIPTION
Updating the hello example in readme to reflect latest slim-develop changes.
Route handlers must return a \Psr\Http\Message\ResponseInterface since they are part of the middleware stack.
