### PR TITLE
URL decode router parameters before setting into the request object

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -414,7 +414,12 @@ class App extends \Pimple\Container
     {
         $routeInfo = $this['router']->dispatch($request);
         if ($routeInfo[0] === \FastRoute\Dispatcher::FOUND) {
-            return $routeInfo[1]($request->withAttributes($routeInfo[2]), $response, $routeInfo[2]);
+            // URL decode the named arguments from the router
+            $attributes = $routeInfo[2];
+            array_walk($attributes, function(&$v, $k) {
+                $v = urldecode($v);
+            });
+            return $routeInfo[1]($request->withAttributes($attributes), $response);
         }
         if ($routeInfo[0] === \FastRoute\Dispatcher::NOT_FOUND) {
             return $this['notFoundHandler']($request, $response);

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -53,13 +53,6 @@ class Route implements RouteInterface, ServiceProviderInterface
     protected $name;
 
     /**
-     * Route parsed arguments
-     *
-     * @var array
-     */
-    protected $parsedArgs = [];
-
-    /**
      * Create new route
      *
      * @param string[] $methods       The route HTTP methods
@@ -181,15 +174,8 @@ class Route implements RouteInterface, ServiceProviderInterface
      * and captures the resultant HTTP response object. It then sends the response
      * back to the Application.
      */
-    public function run(RequestInterface $request, ResponseInterface $response, array $args)
+    public function run(RequestInterface $request, ResponseInterface $response)
     {
-        // URL decode the named arguments from the router
-        array_walk($args, function(&$v, $k) {
-            $v = urldecode($v);
-        });
-
-        $this->parsedArgs = $args;
-
         // Traverse middleware stack and fetch updated response
         return $this->callMiddlewareStack($request, $response);
     }
@@ -210,6 +196,6 @@ class Route implements RouteInterface, ServiceProviderInterface
     {
         $function = $this->callable;
 
-        return $function($request, $response, $this->parsedArgs);
+        return $function($request, $response, $request->getAttributes());
     }
 }


### PR DESCRIPTION
Sorry @codeguy, I put the url-decoding in the wrong place in PR #1194.

This PR also ensures that the `Request`'s `attributes` and the `$args` parameter that is passed to the route callable are the same at the point that we dispatch the callable. This means that route middleware can sanitise the `attributes` and be sure that `$args` also has the sanitised data.
