### PR TITLE
Allow custom errors in debug mode

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1371,7 +1371,7 @@ class Slim
         } catch (\Slim\Exception\Stop $e) {
             $this->response()->write(ob_get_clean());
         } catch (\Exception $e) {
-            if ($this->config('debug')) {
+            if (true !== $this->config('custom_errors') && $this->config('debug')) {
                 throw $e;
             } else {
                 try {


### PR DESCRIPTION
A very small change that adds a new configuration option, "custom_errors," so that you can still use your custom errors even in debug mode. The option must be set to "true" to work. If the option is set to anything else (or not set at all) then it will continue to operate as before (custom error handling is ignored in debug mode)
