### PR TITLE
ordered request (route) attributes (params)

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -194,8 +194,12 @@ class Route implements RouteInterface, ServiceProviderInterface
      */
     public function __invoke(RequestInterface $request, ResponseInterface $response)
     {
-        $function = $this->callable;
-
-        return $function($request, $response, $request->getAttributes());
+        return call_user_func_array(
+            $this->callable, 
+            array_merge(
+                [$request, $response], 
+                array_values($request->getAttributes()
+            )
+        );
     }
 }


### PR DESCRIPTION
Since we can easily use getAttributes() on the 1st argument, i believe it would be better to have any route attributes as orderer optional handler arguments (ala old style handlers).
example:

``` php
$handler = function (RequestInterface $request, ResponseInterface $response, $sort = 'firstname', $dir='asc') {
    //....
   return $response;
}
```

PS
That said, i believe we will seldom use extra handler params since we are now all about the req, res, res bermuda triangle...the mistery of what happens inside being your responsibility to implement.
