### PR TITLE
allow other callables

### DIFF
--- a/Slim/MiddlewareAware.php
+++ b/Slim/MiddlewareAware.php
@@ -61,7 +61,7 @@ trait MiddlewareAware
         }
         $next = $this->stack->top();
         $this->stack[] = function (RequestInterface $req, ResponseInterface $res) use ($callable, $next) {
-            $result = $callable($req, $res, $next);
+            $result = call_user_func($callable, $req, $res, $next);
             if ($result instanceof ResponseInterface === false) {
                 throw new \UnexpectedValueException('Middleware must return instance of \Psr\Http\Message\ResponseInterface');
             }


### PR DESCRIPTION
is_callable and callable type hinting validate and allows:

``` php
'someClass::anotherStaticMethod';

```

in these cases we need to use call_user_func to call them. 
Otherwise we need to restrict the $callable to be an invokable object.
