### PR TITLE
PROPOSAL: allow string http-methods definitions

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -243,14 +243,21 @@ class App extends \Pimple\Container
     /**
      * Add route with multiple methods
      *
-     * @param  string[] $methods  Numeric array of HTTP method names
-     * @param  string   $pattern  The route URI pattern
-     * @param  mixed    $callable The route callback routine
+     * @param  string|string[] $methods  HTTP method names array or comma separated list
+     * @param  string          $pattern  The route URI pattern
+     * @param  mixed           $callable The route callback routine
      *
      * @return \Slim\Interfaces\RouteInterface
      */
-    public function map(array $methods, $pattern, $callable)
+    public function map($methods, $pattern, $callable)
     {
+        if (!is_array($methods)) {
+            if (!is_string($methods)) {
+                throw new \InvalidArgumentException('Route $methods MUST be an array or a string');
+            }
+            $methods = preg_split('/\s*,\s*/', trim($methods));
+        }
+
         $callable = is_string($callable) ? $this->resolveCallable($callable) : $callable;
         if ($callable instanceof \Closure) {
             $callable = $callable->bindTo($this);


### PR DESCRIPTION
Just a proposal, not sure if it would be much overhead.
It basically allows the following route defintion alternatives

``` php
$app->map('GET,POST', '/books', function ($request, $response, $args) {
    //...
    return $response;
});
$app->map('GET', '/books', function ($request, $response, $args) {
    //...
    return $response;
});
```

If accepted, maybe a better place for this change would be the router map method itself.
