### PR TITLE
avoid creating stack for every route

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -64,7 +64,6 @@ class Route implements RouteInterface, ServiceProviderInterface
         $this->methods = $methods;
         $this->pattern = $pattern;
         $this->callable = $callable;
-        $this->seedMiddlewareStack();
     }
 
     /**


### PR DESCRIPTION
Please verify:
- add() will create the stack with this route as the kernel when adding a middleware
- if the route is a match, the run() method (=the FastRoute route handler) will call callMiddlewareStack() that will seed a new stack if it wasn't created before.

if no route middleware is added, the stack will be created only for the matching route with this route as the kernel and only middleware. (We could also skip stack creation in this case, and invoke the route directly...in my implementation with a separate class stack, the stack is invokable and when invoked it start calling the middlewares. So for a MiddlewareAware - StackKernelTrait like object i set a $runner var to the stack if present or the object itself and invoke the $runner)

``` php
//pseudo-code
$runner = $this->getStack() ?: $this;
$response = $runner($req, $res);
```

regards
