### PR TITLE
Stack kernels MUST return a Response

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -188,6 +188,15 @@ class AppTest extends PHPUnit_Framework_TestCase
         $prop = new \ReflectionProperty($app, 'stack');
         $prop->setAccessible(true);
 
+        $bottom = new \ReflectionFunction($prop->getValue($app)->bottom());
+        $callable = null;
+        foreach ($bottom->getStaticVariables() as $k => $var) {
+            if ($k === 'callable') {
+                $callable = $var;
+                break;
+            }
+        }
+
         $this->assertEquals($app, $prop->getValue($app)->bottom());
     }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -177,7 +177,7 @@ class AppTest extends PHPUnit_Framework_TestCase
      * Middleware
      *******************************************************************************/
 
-    public function testBottomMiddlewareIsApp()
+    public function testBottomMiddlewareInvokesApp()
     {
         $app = new App();
         $mw = function ($req, $res, $next) {
@@ -197,7 +197,7 @@ class AppTest extends PHPUnit_Framework_TestCase
             }
         }
 
-        $this->assertEquals($app, $prop->getValue($app)->bottom());
+        $this->assertEquals($app, $callable);
     }
 
     public function testAddMiddleware()

--- a/tests/MiddlewareAwareTest.php
+++ b/tests/MiddlewareAwareTest.php
@@ -44,7 +44,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $this->assertSame($stack, $callable);
+        $this->assertSame($stackable, $callable);
     }
 
     public function testCallMiddlewareStack()

--- a/tests/MiddlewareAwareTest.php
+++ b/tests/MiddlewareAwareTest.php
@@ -35,6 +35,15 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $prop = new \ReflectionProperty($stack, 'stack');
         $prop->setAccessible(true);
 
+        $bottom = new \ReflectionFunction($prop->getValue($stackable)->bottom());
+        $callable = null;
+        foreach ($bottom->getStaticVariables() as $k => $var) {
+            if ($k === 'callable') {
+                $callable = $var;
+                break;
+            }
+        }
+
         $this->assertSame($stack, $prop->getValue($stack)->bottom());
     }
 
@@ -109,6 +118,15 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $stack->alternativeSeed();
         $prop = new \ReflectionProperty($stack, 'stack');
         $prop->setAccessible(true);
+
+        $bottom = new \ReflectionFunction($prop->getValue($stackable)->bottom());
+        $callable = null;
+        foreach ($bottom->getStaticVariables() as $k => $var) {
+            if ($k === 'callable') {
+                $callable = $var;
+                break;
+            }
+        }
 
         $this->assertSame('Slim\Tests\testMiddlewareKernel', $prop->getValue($stack)->bottom());
     }

--- a/tests/MiddlewareAwareTest.php
+++ b/tests/MiddlewareAwareTest.php
@@ -28,11 +28,11 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
 {
     public function testSeedsMiddlewareStack()
     {
-        $stack = new Stackable;
-        $stack->add(function ($req, $res, $next) {
+        $stackable = new Stackable;
+        $stackable->add(function ($req, $res, $next) {
             return $res->write('Hi');
         });
-        $prop = new \ReflectionProperty($stack, 'stack');
+        $prop = new \ReflectionProperty($stackable, 'stack');
         $prop->setAccessible(true);
 
         $bottom = new \ReflectionFunction($prop->getValue($stackable)->bottom());
@@ -44,7 +44,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $this->assertSame($stack, $prop->getValue($stack)->bottom());
+        $this->assertSame($stack, $callable);
     }
 
     public function testCallMiddlewareStack()
@@ -114,9 +114,9 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
 
     public function testAlternativeSeedMiddlewareStack()
     {
-        $stack = new Stackable;
-        $stack->alternativeSeed();
-        $prop = new \ReflectionProperty($stack, 'stack');
+        $stackable = new Stackable;
+        $stackable->alternativeSeed();
+        $prop = new \ReflectionProperty($stackable, 'stack');
         $prop->setAccessible(true);
 
         $bottom = new \ReflectionFunction($prop->getValue($stackable)->bottom());
@@ -128,7 +128,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $this->assertSame('Slim\Tests\testMiddlewareKernel', $prop->getValue($stack)->bottom());
+        $this->assertSame('Slim\Tests\testMiddlewareKernel', $callable);
     }
 
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -97,6 +97,15 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $prop = new \ReflectionProperty($route, 'stack');
         $prop->setAccessible(true);
 
+        $bottom = new \ReflectionFunction($prop->getValue($route)->bottom());
+        $callable = null;
+        foreach ($bottom->getStaticVariables() as $k => $var) {
+            if ($k === 'callable') {
+                $callable = $var;
+                break;
+            }
+        }
+
         $this->assertEquals($route, $prop->getValue($route)->bottom());
     }
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -86,7 +86,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
     }
 
 
-    public function testBottomMiddlewareIsRoute()
+    public function testBottomMiddlewareInvokesRoute()
     {
         $route = $this->routeFactory();
         $mw = function ($req, $res, $next) {
@@ -106,7 +106,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
             }
         }
 
-        $this->assertEquals($route, $prop->getValue($route)->bottom());
+        $this->assertEquals($route, $callable);
     }
 
     public function testAddMiddleware()


### PR DESCRIPTION
Please verify:
I believe that in the current implementation even route handler and the application, both kernel of their own middleware stack, are expected to return a psr-response-interface.
