### PR TITLE
added null value in doc block for $port

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -58,7 +58,7 @@ class Uri implements \Psr\Http\Message\UriInterface
     /**
      * Uri port number
      *
-     * @var int
+     * @var null|int
      */
     protected $port;
 


### PR DESCRIPTION
as null is accepted by psr-7 specs for an unset-standard port.
