### PR TITLE
unneeded string casting?

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -269,7 +269,7 @@ class Uri implements \Psr\Http\Message\UriInterface
         }
 
         $scheme = str_replace('://', '', strtolower((string)$scheme));
-        if (!isset($valid[(string)$scheme])) {
+        if (!isset($valid[$scheme])) {
             throw new \InvalidArgumentException('Uri scheme must be one of: "", "https", "http"');
         }
 


### PR DESCRIPTION
str_replace should always return a string for a string subject/haystack. $scheme is a string because it is casted in the previous line.
