### PR TITLE
same test called twice?

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -302,9 +302,8 @@ class Uri implements \Psr\Http\Message\UriInterface
         $userInfo = $this->getUserInfo();
         $host = $this->getHost();
         $port = $this->getPort();
-        $showPort = ($this->hasStandardPort() === false);
 
-        return ($userInfo ? $userInfo . '@' : '') . $host . ($port && $showPort ? ':' . $port : '');
+        return ($userInfo ? $userInfo . '@' : '') . $host . ($port !== null ? ':' . $port : '');
     }
 
     /**


### PR DESCRIPTION
Hielo Josh, please verify:

the getPort() method internally calls ::hasStandardPort(). It returns null for standard port/scheme combination. I think we just need to check for non null port values here.
