### PR TITLE
Add helper function to retrieve accept headers if available

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -763,6 +763,24 @@ class Request implements RequestInterface
         return $result ? (int)$result[0] : null;
     }
 
+    /**
+     * Get accept headers if available
+     *
+     * @return Array the accept headers
+     */
+    public function getAcceptHeaders()
+    {
+        $acceptHeaders = [];
+
+        if (count($this->headers->get('ACCEPT')) > 0) {
+            foreach ($this->headers->get('ACCEPT') as $header) {
+                $acceptHeaders = array_merge($acceptHeaders, explode(', ', $header));
+            }
+        }
+
+        return $acceptHeaders;
+    }
+
     /*******************************************************************************
      * Cookies
      ******************************************************************************/


### PR DESCRIPTION
Simplifies the ability to retrieve accept headers, helpful in those situation where `X-Requested-With` is missing and thus the `isAjax` function doesn't respond correctly as then we can check for `application/json` in the accept headers.
