### PR TITLE
skip uri cloning

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -175,7 +175,6 @@ class Request implements RequestInterface
      */
     public function __clone()
     {
-        $this->uri = clone $this->uri;
         $this->headers = clone $this->headers;
         $this->attributes = clone $this->attributes;
         $this->body = clone $this->body;


### PR DESCRIPTION
I believe we can safely skip cloning the uri property. 
Uri instances are immutable value objects, so we will never have a cloned request being able to modify its uri (and so neither the uri of the original request object as they are references to the same Uri instance). Being immutable an uri cannot alter itself and so neither any other reference to itself.
We can only point properties referencing them  to different instances as clones.
