### PR TITLE
Remove ignoring of HTTP_CONTENT_TYPE header

### DIFF
--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -52,7 +52,7 @@ class Headers extends Collection implements HeadersInterface
         foreach ($environment as $key => $value) {
             $key = strtoupper($key);
             if (strpos($key, 'HTTP_') === 0 || isset(static::$special[$key])) {
-                if ($key !== 'HTTP_CONTENT_TYPE' && $key !== 'HTTP_CONTENT_LENGTH') {
+                if ($key !== 'HTTP_CONTENT_LENGTH') {
                     $data[$key] =  $value;
                 }
             }


### PR DESCRIPTION
HTTP_CONTENT_TYPE is assigned by the inbuilt php server rather than the
more standard CONTENT_TYPE
