### PR TITLE
define properties proxied from container in app doc block

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -23,7 +23,7 @@ use Interop\Container\ContainerInterface;
  * Slim Framework middleware.
  *
  * @property-read array $settings App settings
- * @property-read \Slim\Interfaces\Http\EnvironmentInterface environment 
+ * @property-read \Slim\Interfaces\Http\EnvironmentInterface $environment 
  * @property-read \Psr\Http\Message\RequestInterface $request
  * @property-read \Psr\Http\Message\ResponseInterface $response
  * @property-read \Slim\Interfaces\RouterInterface $router

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -21,6 +21,15 @@ use Interop\Container\ContainerInterface;
  * register custom Pimple service providers on each
  * \Slim\App instance. The \Slim\App class also accepts
  * Slim Framework middleware.
+ *
+ * @property-read array $settings App settings
+ * @property-read \Slim\Interfaces\Http\EnvironmentInterface environment 
+ * @property-read \Psr\Http\Message\RequestInterface $request
+ * @property-read \Psr\Http\Message\ResponseInterface $response
+ * @property-read \Slim\Interfaces\RouterInterface $router
+ * @property-read callable $errorHandler
+ * @property-read callable function($request, $response) $notFoundHandler
+ * @property-read callable function($request, $response, $allowedHttpMethods) $notAllowedHandler
  */
 class App
 {


### PR DESCRIPTION
add properties definitions to Slim\App.php header doc block

```
 * @property-read array $settings App settings
 * @property-read \Slim\Interfaces\Http\EnvironmentInterface environment 
 * @property-read \Psr\Http\Message\RequestInterface $request
 * @property-read \Psr\Http\Message\ResponseInterface $response
 * @property-read \Slim\Interfaces\RouterInterface $router
 * @property-read callable $errorHandler
 * @property-read callable function($request, $response) $notFoundHandler
 * @property-read callable function($request, $response, $allowedHttpMethods) $notAllowedHandler
```
