### PR TITLE
Do not override request attributes when invoking app

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -16,11 +16,11 @@ use Interop\Container\ContainerInterface;
  * App
  *
  * This is the primary class with which you instantiate,
- * configure, and run a Slim Framework application. 
+ * configure, and run a Slim Framework application.
  * The \Slim\App class also accepts Slim Framework middleware.
  *
  * @property-read array $settings App settings
- * @property-read \Slim\Interfaces\Http\EnvironmentInterface $environment 
+ * @property-read \Slim\Interfaces\Http\EnvironmentInterface $environment
  * @property-read \Psr\Http\Message\RequestInterface $request
  * @property-read \Psr\Http\Message\ResponseInterface $response
  * @property-read \Slim\Interfaces\RouterInterface $router
@@ -85,7 +85,7 @@ class App
     {
         return $this->container->get($name);
     }
-    
+
     public function __isset($name)
     {
         return $this->container->has($name);
@@ -172,7 +172,7 @@ class App
     {
         return $this->map(['OPTIONS'], $pattern, $callable);
     }
-    
+
     /**
      * Add route for any HTTP method
      *
@@ -364,10 +364,10 @@ class App
         if ($routeInfo[0] === \FastRoute\Dispatcher::FOUND) {
             // URL decode the named arguments from the router
             $attributes = $routeInfo[2];
-            array_walk($attributes, function (&$v, $k) {
-                $v = urldecode($v);
-            });
-            return $routeInfo[1]($request->withAttributes($attributes), $response);
+            foreach ($attributes as $k => $v) {
+                $request = $request->withAttribute($k, urldecode($v));
+            }
+            return $routeInfo[1]($request, $response);
         }
         if ($routeInfo[0] === \FastRoute\Dispatcher::NOT_FOUND) {
             $notFoundHandler = $this->container->get('notFoundHandler');


### PR DESCRIPTION
If we attach attributes to the Request in middleware, those attributes are deleted when url decoding the parameters parsed from the route pattern. This ensures we keep existing attributes.

/cc @akrabat @silentworks 
