### PR TITLE
[ResponseTest::testToString]fixed  failure under Windows

### DIFF
--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -374,7 +374,7 @@ X-Foo: Bar
 
 Where am I?
 END;
-        $this->expectOutputString($output);
+        $this->expectOutputString(str_replace("\n",PHP_EOL,$output));
         $response = new Response();
         $response = $response->withStatus(404)->withHeader('X-Foo', 'Bar')->write('Where am I?');
 


### PR DESCRIPTION
The heredoc syntax always terminates lines with \n regardless of the operating system.  The echo function uses PHP_EOL to terminate lines.  PHP_EOL is \n\r for Windows operating systems.  Hence phpunit::expectOutputString will fail under Windows when comparing heredoc and echo results.

I have researched this issue and have not found and easy way to work around it without adjusting the test itself.  Cannot find any way to convince heredoc to use PHP_EOL.  Replacing the heredoc's \n with PHP_EOL seems to be the best approach.  This ensures the test will work regardless of PHP_EOL.
