### PR TITLE
Added missing "not" word in exception message

### DIFF
--- a/Slim/Http/Stream.php
+++ b/Slim/Http/Stream.php
@@ -382,7 +382,7 @@ class Stream implements StreamInterface
     public function getContents()
     {
         if (!$this->isReadable() || ($contents = stream_get_contents($this->stream)) === false) {
-            throw new RuntimeException('Could get contents of stream');
+            throw new RuntimeException('Could not get contents of stream');
         }
 
         return $contents;


### PR DESCRIPTION
Added missing "not" word in exception message in Slim\Http\Stream@getContents() method.
