### PR TITLE
outputBuffer setting

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -237,6 +237,7 @@ class App
         if (method_exists($route, 'setContainer')) {
             $route->setContainer($this->container);
         }
+        $route->setOutputBuffering($this->container->get('settings')['outputBuffering']);
 
         return $route;
     }
@@ -344,7 +345,7 @@ class App
         }
 
         $this->respond($response);
-        
+
         return $response;
     }
 

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -54,7 +54,7 @@ final class Container extends PimpleContainer implements ContainerInterface
         'cookieHttpOnly' => false,
         'httpVersion' => '1.1',
         'responseChunkSize' => 4096,
-        'outputBuffer' => 'append',
+        'outputBuffering' => 'append',
     ];
 
 

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -53,7 +53,8 @@ final class Container extends PimpleContainer implements ContainerInterface
         'cookieSecure' => false,
         'cookieHttpOnly' => false,
         'httpVersion' => '1.1',
-        'responseChunkSize' => 4096
+        'responseChunkSize' => 4096,
+        'outputBuffer' => 'append',
     ];
 
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -64,6 +64,13 @@ class Route implements RouteInterface
     protected $name;
 
     /**
+     * Output buffering mode
+     *
+     * @var boolean|string
+     */
+    protected $outputBuffering = 'append';
+
+    /**
      * Create new route
      *
      * @param string[] $methods       The route HTTP methods
@@ -114,6 +121,26 @@ class Route implements RouteInterface
     public function getPattern()
     {
         return $this->pattern;
+    }
+
+    /**
+     * Get output buffering mode
+     *
+     * @return boolean|string
+     */
+    public function getOutputBuffering()
+    {
+        return $this->outputBuffering;
+    }
+
+    /**
+     * Set output buffering mode
+     *
+     * @param boolean|string $mode
+     */
+    public function setOutputBuffering($mode)
+    {
+        $this->outputBuffering = $mode;
     }
 
     /**
@@ -205,15 +232,10 @@ class Route implements RouteInterface
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
-        $outputBuffer = 'append';
-        if (($this->container !== null) && isset($this->container->get('settings')['outputBuffer'])) {
-            $outputBuffer = $this->container->get('settings')['outputBuffer'];
-        }
-
         $function = $this->callable;
 
         // invoke route callable
-        if ($outputBuffer === false) {
+        if ($this->outputBuffering === false) {
             $newResponse = $function($request, $response, $request->getAttributes());
         } else {
             try {
@@ -232,7 +254,7 @@ class Route implements RouteInterface
         }
 
         // prepend output buffer content if there is any
-        if (isset($output) && ($outputBuffer === 'prepend')) {
+        if (isset($output) && ($this->outputBuffering === 'prepend')) {
             $body = new Http\Body(fopen('php://temp', 'r+'));
             $body->write($output);
             $body->write((string)$response->getBody());
@@ -245,7 +267,7 @@ class Route implements RouteInterface
         }
 
         // append output buffer content if there is any
-        if (isset($output) && ($outputBuffer === 'append')) {
+        if (isset($output) && ($this->outputBuffering === 'append')) {
             $response->getBody()->write($output);
         }
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -226,22 +226,17 @@ class RouteTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensure that if `outputBuffer` setting is set to `prepend` correct response
+     * Ensure that if `outputBuffering` property is set to `prepend` correct response
      * body is returned by __invoke().
      */
     public function testInvokeWhenPrependingOutputBuffer()
     {
-        $container = new \Slim\Container();
-        $container->extend('settings', function ($settings, $c) {
-            $settings['outputBuffer'] = 'prepend';
-            return $settings;
-        });
         $callable = function ($req, $res, $args) {
             echo 'foo';
             return $res->write('bar');
         };
         $route = new Route(['GET'], '/', $callable);
-        $route->setContainer($container);
+        $route->setOutputBuffering('prepend');
 
         $env = \Slim\Http\Environment::mock();
         $uri = \Slim\Http\Uri::createFromString('https://example.com:80');
@@ -258,22 +253,17 @@ class RouteTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensure that if `outputBuffer` setting is set to `false` correct response
+     * Ensure that if `outputBuffering` property is set to `false` correct response
      * body is returned by __invoke().
      */
     public function testInvokeWhenDisablingOutputBuffer()
     {
-        $container = new \Slim\Container();
-        $container->extend('settings', function ($settings, $c) {
-            $settings['outputBuffer'] = false;
-            return $settings;
-        });
         $callable = function ($req, $res, $args) {
             echo 'foo';
             return $res->write('bar');
         };
         $route = new Route(['GET'], '/', $callable);
-        $route->setContainer($container);
+        $route->setOutputBuffering(false);
 
         $env = \Slim\Http\Environment::mock();
         $uri = \Slim\Http\Uri::createFromString('https://example.com:80');

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -224,4 +224,68 @@ class RouteTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo', (string)$response->getBody());
     }
+
+    /**
+     * Ensure that if `outputBuffer` setting is set to `prepend` correct response
+     * body is returned by __invoke().
+     */
+    public function testInvokeWhenPrependingOutputBuffer()
+    {
+        $container = new \Slim\Container();
+        $container->extend('settings', function ($settings, $c) {
+            $settings['outputBuffer'] = 'prepend';
+            return $settings;
+        });
+        $callable = function ($req, $res, $args) {
+            echo 'foo';
+            return $res->write('bar');
+        };
+        $route = new Route(['GET'], '/', $callable);
+        $route->setContainer($container);
+
+        $env = \Slim\Http\Environment::mock();
+        $uri = \Slim\Http\Uri::createFromString('https://example.com:80');
+        $headers = new \Slim\Http\Headers();
+        $cookies = [];
+        $serverParams = $env->all();
+        $body = new \Slim\Http\Body(fopen('php://temp', 'r+'));
+        $request = new \Slim\Http\Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+        $response = new \Slim\Http\Response;
+
+        $response = $route->__invoke($request, $response);
+
+        $this->assertEquals('foobar', (string)$response->getBody());
+    }
+
+    /**
+     * Ensure that if `outputBuffer` setting is set to `false` correct response
+     * body is returned by __invoke().
+     */
+    public function testInvokeWhenDisablingOutputBuffer()
+    {
+        $container = new \Slim\Container();
+        $container->extend('settings', function ($settings, $c) {
+            $settings['outputBuffer'] = false;
+            return $settings;
+        });
+        $callable = function ($req, $res, $args) {
+            echo 'foo';
+            return $res->write('bar');
+        };
+        $route = new Route(['GET'], '/', $callable);
+        $route->setContainer($container);
+
+        $env = \Slim\Http\Environment::mock();
+        $uri = \Slim\Http\Uri::createFromString('https://example.com:80');
+        $headers = new \Slim\Http\Headers();
+        $cookies = [];
+        $serverParams = $env->all();
+        $body = new \Slim\Http\Body(fopen('php://temp', 'r+'));
+        $request = new \Slim\Http\Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+        $response = new \Slim\Http\Response;
+
+        $response = $route->__invoke($request, $response);
+
+        $this->assertEquals('bar', (string)$response->getBody());
+    }
 }


### PR DESCRIPTION
this PR introduces `outputBuffer` setting (with values: `false` or `'append'` or `'prepend'`) which let's user decide how output buffering is handled
