### PR TITLE
Remove useless variable

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -330,7 +330,6 @@ class App
      */
     public function run()
     {
-        static $responded = false;
         $request = $this->container->get('request');
         $response = $this->container->get('response');
 


### PR DESCRIPTION
This variable was a leftover in a1aa55b67663ae3d3997747c86245bdcb5d458a5
