### PR TITLE
Minor improvements

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -311,8 +311,8 @@ class App
             if ($hasBody) {
                 $body = $response->getBody();
                 $body->rewind();
+                $settings = $this->container->get('settings');
                 while (!$body->eof()) {
-                    $settings = $this->container->get('settings');
                     echo $body->read($settings['responseChunkSize']);
                 }
             }

--- a/Slim/Http/Stream.php
+++ b/Slim/Http/Stream.php
@@ -314,7 +314,7 @@ class Stream implements StreamInterface
     {
         // Note that fseek returns 0 on success!
         if (!$this->isSeekable() || fseek($this->stream, $offset, $whence) === -1) {
-            throw new RuntimeException('Could not to seek in stream');
+            throw new RuntimeException('Could not seek in stream');
         }
     }
 
@@ -331,7 +331,7 @@ class Stream implements StreamInterface
     public function rewind()
     {
         if (!$this->isSeekable() || rewind($this->stream) === false) {
-            throw new RuntimeException('Could not to rewind stream');
+            throw new RuntimeException('Could not rewind stream');
         }
     }
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -223,13 +223,11 @@ class Route implements RouteInterface
             throw $e;
         }
 
-        // if route callback returns a ResponseInterface, then use it
         if ($newResponse instanceof ResponseInterface) {
+            // if route callback returns a ResponseInterface, then use it
             $response = $newResponse;
-        }
-
-        // if route callback returns a string, then append it to the response
-        if (is_string($newResponse)) {
+        } elseif (is_string($newResponse)) {
+            // if route callback returns a string, then append it to the response
             $response->getBody()->write($newResponse);
         }
 


### PR DESCRIPTION
- Fixed Stream exception message grammar
- Minor optimizations:
  -  Avoid retrieving container settings in a loop
  - If `$newResponse` is a `ResponseInterface`, it isn't necessary to also check if it is a string
