### PR TITLE
Implement fullUrlFor() 

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -416,4 +416,24 @@ class App
 
         return $this($request, $response);
     }
+
+    /**
+     * Build the fully qualified URL for a named route
+     *
+     * @param string $name              Route name
+     * @param array  $data              Named argument replacement data
+     * @param array  $queryParams       Optional query string parameters
+     * @param RequestInterface $request Optional request object
+     *
+     * @return string
+     * @throws \RuntimeException         If named route does not exist
+     * @throws \InvalidArgumentException If required data not provided
+     */
+    public function fullUrlFor($name, array $data = [], array $queryParams = [], $request = null)
+    {
+        $router = $this->container->get('router');
+        $request = $request ?: $this->container->get('request');
+
+        return $router->fullUrlFor($request, $name, $data, $queryParams);
+    }
 }

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -254,6 +254,28 @@ class Router extends RouteCollector implements RouterInterface
     }
 
     /**
+     * Build the fully qualified URL for a named route
+     *
+     * @param ServerRequestInterface $request     Request object
+     * @param string                 $name        Route name
+     * @param array                  $data        Named argument replacement data
+     * @param array                  $queryParams Optional query string parameters
+     *
+     * @return string
+     * @throws \RuntimeException         If named route does not exist
+     * @throws \InvalidArgumentException If required data not provided
+     */
+    public function fullUrlFor(ServerRequestInterface $request, $name, array $data = [], array $queryParams = [])
+    {
+        $uri = $request->getUri();
+
+        return $uri->getScheme() . '://' . $uri->getHost()
+            . ($uri->getPort() ? ':' . $uri->getPort() : '')
+            . rtrim($uri->getBasePath(), '/')
+            . $this->pathFor($name, $data, $queryParams);
+    }
+
+    /**
      * Build index of named routes
      */
     protected function buildNameIndex()

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -528,4 +528,32 @@ class AppTest extends PHPUnit_Framework_TestCase
         $this->expectOutputString('Hello');
     }
 
+    public function testFullUrlFor()
+    {
+        // Prepare request and response objects
+        $env = \Slim\Http\Environment::mock([
+            'SCRIPT_NAME' => '/base/index.php',
+            'REQUEST_URI' => '/base/hello',
+            'REQUEST_METHOD' => 'GET',
+            'HTTP_HOST' => 'example.com:8081',
+        ]);
+        // $uri = \Slim\Http\Uri::createFromEnvironment($env);
+        // $headers = \Slim\Http\Headers::createFromEnvironment($env);
+        // $cookies = [];
+        // $serverParams = $env->all();
+        // $body = new \Slim\Http\Body(fopen('php://temp', 'r+'));
+        // $request = new \Slim\Http\Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+
+        $app = new App();
+        $app->getContainer()['environment'] = $env;
+
+        $app->get('/hello/{first}', function ($req, $res) {
+            return $res;
+        })->setName('hello');
+
+
+        $url = $app->fullUrlFor('hello', ['first' => 'josh'], ['foo' => 'bar']);
+
+        $this->assertEquals('http://example.com:8081/base/hello/josh?foo=bar', $url);
+    }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -154,4 +154,32 @@ class RouterTest extends PHPUnit_Framework_TestCase
 
         $this->router->pathFor('bar', ['first' => 'josh', 'last' => 'lockhart']);
     }
+
+    public function testFullUrlFor()
+    {
+        // Prepare request and response objects
+        $env = \Slim\Http\Environment::mock([
+            'SCRIPT_NAME' => '/base/index.php',
+            'REQUEST_URI' => '/base/hello',
+            'REQUEST_METHOD' => 'GET',
+            'HTTP_HOST' => 'example.com:8081',
+        ]);
+        $uri = \Slim\Http\Uri::createFromEnvironment($env);
+        $headers = \Slim\Http\Headers::createFromEnvironment($env);
+        $cookies = [];
+        $serverParams = $env->all();
+        $body = new \Slim\Http\Body(fopen('php://temp', 'r+'));
+        $request = new \Slim\Http\Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+
+        $methods = ['GET'];
+        $pattern = '/hello/{first}';
+        $callable = function ($request, $response, $args) {
+        };
+        $route = $this->router->map($methods, $pattern, $callable);
+        $route->setName('hello');
+
+        $url = $this->router->fullUrlFor($request, 'hello', ['first' => 'josh'], ['foo' => 'bar']);
+
+        $this->assertEquals('http://example.com:8081/base/hello/josh?foo=bar', $url);
+    }
 }


### PR DESCRIPTION
I've put this on both Router and App that builds a fully qualified URL for a named route.

Ideally, I'd have called the `urlFor` but we couldn't have the deprecated method if I did that.

See #1326.
