### PR TITLE
Uri::getBaseUrl()

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -769,4 +769,35 @@ class Uri implements UriInterface
             . ($query ? '?' . $query : '')
             . ($fragment ? '#' . $fragment : '');
     }
+
+    /**
+     * Return the fully qualified base URL.
+     *
+     * Note that this method never includes a trailing /
+     *
+     * This method is not part of PSR-7.
+     *
+     * @return string
+     */
+    public function getBaseUrl()
+    {
+        $scheme = $this->getScheme();
+        $authority = $this->getAuthority();
+        $basePath = $this->getBasePath();
+        $basePath = $this->getBasePath();
+        $query = $this->getQuery();
+        $fragment = $this->getFragment();
+
+        if ($authority && substr($basePath, 0, 1) !== '/') {
+            $basePath = $basePath . '/' . $basePath;
+        }
+        if (!$authority && substr($basePath, 0, 2) === '//') {
+            $basePath = '/' . ltrim($basePath);
+        }
+
+        return ($scheme ? $scheme . ':' : '')
+            . ($authority ? '//' . $authority : '')
+            . rtrim($basePath, '/');
+
+    }
 }

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -784,20 +784,15 @@ class Uri implements UriInterface
         $scheme = $this->getScheme();
         $authority = $this->getAuthority();
         $basePath = $this->getBasePath();
-        $basePath = $this->getBasePath();
         $query = $this->getQuery();
         $fragment = $this->getFragment();
 
         if ($authority && substr($basePath, 0, 1) !== '/') {
             $basePath = $basePath . '/' . $basePath;
         }
-        if (!$authority && substr($basePath, 0, 2) === '//') {
-            $basePath = '/' . ltrim($basePath);
-        }
 
         return ($scheme ? $scheme . ':' : '')
             . ($authority ? '//' . $authority : '')
             . rtrim($basePath, '/');
-
     }
 }

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -446,4 +446,48 @@ class UriTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('example3.com', $uri->getHost());
     }
+
+    public function testGetBaseUrl()
+    {
+        $environment = \Slim\Http\Environment::mock([
+            'SCRIPT_NAME' => '/foo/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'QUERY_STRING' => 'abc=123',
+            'HTTP_HOST' => 'example.com:80',
+            'SERVER_PORT' => 80
+        ]);
+        $uri = \Slim\Http\Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('http://example.com/foo', $uri->getBaseUrl());
+    }
+
+    public function testGetBaseUrlWithNoBasePath()
+    {
+        $environment = \Slim\Http\Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'QUERY_STRING' => 'abc=123',
+            'HTTP_HOST' => 'example.com:80',
+            'SERVER_PORT' => 80
+        ]);
+        $uri = \Slim\Http\Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('http://example.com', $uri->getBaseUrl());
+    }
+
+    public function testGetBaseUrlWithAuthority()
+    {
+        $environment = \Slim\Http\Environment::mock([
+            'SCRIPT_NAME' => '/foo/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'PHP_AUTH_USER' => 'josh',
+            'PHP_AUTH_PW' => 'sekrit',
+            'QUERY_STRING' => 'abc=123',
+            'HTTP_HOST' => 'example.com:8080',
+            'SERVER_PORT' => 8080
+        ]);
+        $uri = \Slim\Http\Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('http://josh:sekrit@example.com:8080/foo', $uri->getBaseUrl());
+    }
 }


### PR DESCRIPTION
This addresses some of the issues in #1326.

It provides a new method on `Uri` called `getBaseUrl()` which provides a fully qualified URL with just the base path included. It never has a trailing slash and so is ideal for combing with `pathFor` like this:

``` php
$router = $this->router;
$uri = $request->getUri();

$fullUrl = $uri->getBaseUrl() . $router->pathFor('news', ['year'=>'2015'], ['foo' => 'bar']);
```
