### PR TITLE
Add helper function to retrieve accept headers if available

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -874,6 +874,37 @@ class Request implements ServerRequestInterface
         return $result ? (int)$result[0] : null;
     }
 
+    /**
+     * Get accept headers if available
+     *
+     * Note: This method is not part of the PSR-7 standard.
+     *
+     * @return Array the accept headers
+     */
+    public function getAcceptHeaders()
+    {
+        $acceptHeaders = [];
+        if (count($this->headers->get('ACCEPT')) > 0) {
+            foreach ($this->headers->get('ACCEPT') as $header) {
+                $acceptHeaders = array_merge($acceptHeaders, explode(', ', $header));
+            }
+        }
+        return $acceptHeaders;
+    }
+
+    /**
+     * Checks is a specified accept header exists in the request
+     *
+     * Note: This method is not part of the PSR-7 standard.
+     *
+     * @param  string  $acceptHeader the header to look for
+     * @return boolean               whether the specified accept header exists in the request
+     */
+    public function hasAcceptHeader($acceptHeader)
+    {
+        return in_array($acceptHeader, $this->getAcceptHeaders());
+    }
+
     /*******************************************************************************
      * Cookies
      ******************************************************************************/

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -62,7 +62,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse(property_exists($request, 'foo'));
     }
-    
+
     public function testAddsHostHeaderFromUri()
     {
         $request = $this->requestFactory();
@@ -590,6 +590,62 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $request = $this->requestFactory();
 
         $this->assertNull($request->getContentLength());
+    }
+
+    public function testSingleGetAcceptHeaders()
+    {
+        $headers = new Headers([
+            'Accept' => '*/*',
+        ]);
+        $request = $this->requestFactory();
+        $headersProp = new \ReflectionProperty($request, 'headers');
+        $headersProp->setAccessible(true);
+        $headersProp->setValue($request, $headers);
+
+        $this->assertEquals(1, count($request->getAcceptHeaders()));
+        $this->assertTrue(in_array('*/*', $request->getAcceptHeaders()));
+        $this->assertFalse(in_array('application/json', $request->getAcceptHeaders()));
+    }
+
+    public function testMultipleGetAcceptHeaders()
+    {
+        $headers = new Headers([
+            'Accept' => '*/*, application/json',
+        ]);
+        $request = $this->requestFactory();
+        $headersProp = new \ReflectionProperty($request, 'headers');
+        $headersProp->setAccessible(true);
+        $headersProp->setValue($request, $headers);
+
+        $this->assertEquals(2, count($request->getAcceptHeaders()));
+        $this->assertTrue(in_array('*/*', $request->getAcceptHeaders()));
+        $this->assertTrue(in_array('application/json', $request->getAcceptHeaders()));
+    }
+
+    public function testGetAcceptHeadersWithoutHeader()
+    {
+        $headers = new Headers([]);
+        $request = $this->requestFactory();
+        $headersProp = new \ReflectionProperty($request, 'headers');
+        $headersProp->setAccessible(true);
+        $headersProp->setValue($request, $headers);
+
+        $this->assertEmpty($request->getAcceptHeaders());
+    }
+
+    public function testHasAcceptHeader()
+    {
+        $headers = new Headers([
+            'Accept' => '*/*, application/json',
+        ]);
+        $request = $this->requestFactory();
+        $headersProp = new \ReflectionProperty($request, 'headers');
+        $headersProp->setAccessible(true);
+        $headersProp->setValue($request, $headers);
+
+        $this->assertTrue($request->hasAcceptHeader('*/*'));
+        $this->assertTrue($request->hasAcceptHeader('application/json'));
+        $this->assertFalse($request->hasAcceptHeader('application/xml'));
     }
 
     /*******************************************************************************


### PR DESCRIPTION
Add 2 helper methods for checking what accept headers exist within the request.

Simplifies the ability to retrieve accept headers, helpful in those situation where X-Requested-With is missing and thus the isAjax function doesn't respond correctly as then we can check for application/json in the accept headers.
