### PR TITLE
Add RouteGroup to allow registration of middleware consistently

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -234,7 +234,7 @@ class App
             $callable = $callable->bindTo($this);
         }
 
-        $route = $this->router->map($methods, $pattern, $callable);
+        $route = $this->container->get('router')->map($methods, $pattern, $callable);
         if (method_exists($route, 'setContainer')) {
             $route->setContainer($this->container);
         }
@@ -250,11 +250,12 @@ class App
      * declarations in the callback will be prepended by the group(s)
      * that it is in.
      *
-     * @param string     $pattern
-     * @param callable   $callable
-     * @param callable[] $middleware
+     * @param string   $pattern
+     * @param callable $callable
+     *
+     * @return RouteGroup
      */
-    public function group($pattern, $callable/*, $middleware = []*/)
+    public function group($pattern, $callable)
     {
         $group = new RouteGroup($pattern, $callable);
         $this->container->get('router')->pushGroup($group);

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -10,6 +10,7 @@ namespace Slim;
 
 use Exception;
 use Closure;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Interop\Container\ContainerInterface;
@@ -19,6 +20,8 @@ use Slim\Http\Uri;
 use Slim\Http\Headers;
 use Slim\Http\Body;
 use Slim\Http\Request;
+use Slim\Interfaces\Http\EnvironmentInterface;
+use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouterInterface;
 
@@ -30,10 +33,10 @@ use Slim\Interfaces\RouterInterface;
  * The \Slim\App class also accepts Slim Framework middleware.
  *
  * @property-read array $settings App settings
- * @property-read \Slim\Interfaces\Http\EnvironmentInterface $environment
- * @property-read \Psr\Http\Message\RequestInterface $request
- * @property-read \Psr\Http\Message\ResponseInterface $response
- * @property-read \Slim\Interfaces\RouterInterface $router
+ * @property-read EnvironmentInterface $environment
+ * @property-read RequestInterface $request
+ * @property-read ResponseInterface $response
+ * @property-read RouterInterface $router
  * @property-read callable $errorHandler
  * @property-read callable $notFoundHandler function($request, $response)
  * @property-read callable $notAllowedHandler function($request, $response, $allowedHttpMethods)
@@ -93,11 +96,11 @@ class App
     /**
      * Add middleware
      *
-     * This method prepends new middleware to the route's middleware stack.
+     * This method prepends new middleware to the app's middleware stack.
      *
      * @param  mixed    $callable The callback routine
      *
-     * @return RouteInterface
+     * @return static
      */
     public function add($callable)
     {
@@ -225,7 +228,7 @@ class App
      * @param  string   $pattern  The route URI pattern
      * @param  mixed    $callable The route callback routine
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return RouteInterface
      */
     public function map(array $methods, $pattern, $callable)
     {
@@ -253,12 +256,11 @@ class App
      * @param string   $pattern
      * @param callable $callable
      *
-     * @return RouteGroup
+     * @return RouteGroupInterface
      */
     public function group($pattern, $callable)
     {
-        $group = new RouteGroup($pattern, $callable);
-        $this->container->get('router')->pushGroup($group);
+        $group = $this->container->get('router')->pushGroup($pattern, $callable);
         $group($this);
         $this->container->get('router')->popGroup();
         return $group;

--- a/Slim/Interfaces/RouteGroupInterface.php
+++ b/Slim/Interfaces/RouteGroupInterface.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/codeguy/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/codeguy/Slim/blob/master/LICENSE (MIT License)
+ */
+namespace Slim\Interfaces;
+
+use Slim\App;
+
+/**
+ * RouteGroup Interface
+ *
+ * @package Slim
+ * @since   3.0.0
+ */
+interface RouteGroupInterface
+{
+    /**
+     * Get route pattern
+     *
+     * @return string
+     */
+    public function getPattern();
+
+    /**
+     * Execute route group callable in the context of the Slim App
+     *
+     * This method invokes the route group object's callable, collecting
+     * nested route objects
+     *
+     * @param App $app
+     */
+    public function __invoke(App $app);
+}

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -43,11 +43,12 @@ interface RouterInterface
     /**
      * Add a route group to the array
      *
-     * @param RouteGroup $group The route group
+     * @param string   $pattern The group pattern
+     * @param callable $callable A group callable
      *
-     * @return int The index of the new group
+     * @return RouteGroup
      */
-    public function pushGroup($group);
+    public function pushGroup($pattern, $callable);
 
     /**
      * Removes the last route group from the array

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -9,6 +9,7 @@
 namespace Slim\Interfaces;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Slim\RouteGroup;
 
 /**
  * Router Interface
@@ -42,12 +43,11 @@ interface RouterInterface
     /**
      * Add a route group to the array
      *
-     * @param string     $group      The group pattern prefix
-     * @param array|null $middleware Optional middleware
+     * @param RouteGroup &$group The route group
      *
      * @return int The index of the new group
      */
-    public function pushGroup($group, $middleware = []);
+    public function pushGroup(&$group);
 
     /**
      * Removes the last route group from the array

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -43,11 +43,11 @@ interface RouterInterface
     /**
      * Add a route group to the array
      *
-     * @param RouteGroup &$group The route group
+     * @param RouteGroup $group The route group
      *
      * @return int The index of the new group
      */
-    public function pushGroup(&$group);
+    public function pushGroup($group);
 
     /**
      * Removes the last route group from the array

--- a/Slim/MiddlewareAwareTrait.php
+++ b/Slim/MiddlewareAwareTrait.php
@@ -48,7 +48,7 @@ trait MiddlewareAwareTrait
      *                           1. A Request object
      *                           2. A Response object
      *                           3. A "next" middleware callable
-     * @return self
+     * @return static
      * @throws RuntimeException if middleware is added while the stack is dequeuing
      * @throws UnexpectedValueException If the middleware doesn't return an instance of \Psr\Http\Message\ResponseInterface
      */

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/codeguy/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/codeguy/Slim/blob/master/LICENSE (MIT License)
+ */
+namespace Slim;
+
+
+use Closure;
+use Interop\Container\ContainerInterface;
+use Slim\Interfaces\RouteInterface;
+
+/**
+ * A routable, middleware-aware object
+ *
+ * @package Slim
+ * @since   3.0.0
+ */
+abstract class Routable
+{
+    use CallableResolverAwareTrait;
+
+    /**
+     * Route callable
+     *
+     * @var callable
+     */
+    protected $callable;
+
+    /**
+     * Container
+     *
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * Route middleware
+     *
+     * @var callable[]
+     */
+    protected $middleware = [];
+
+    /**
+     * Route pattern
+     *
+     * @var string
+     */
+    protected $pattern;
+
+    /**
+     * Get the middleware registered for the group
+     *
+     * @return callable[]
+     */
+    public function getMiddleware()
+    {
+        return $this->middleware;
+    }
+
+    /**
+     * Get the route pattern
+     *
+     * @return string
+     */
+    public function getPattern()
+    {
+        return $this->pattern;
+    }
+
+    /**
+     * Set container for use with resolveCallable
+     *
+     * @param ContainerInterface $container
+     *
+     * @return $this
+     */
+    public function setContainer(ContainerInterface $container)
+    {
+        $this->container = $container;
+        return $this;
+    }
+}

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -87,10 +87,13 @@ class Route extends Routable implements RouteInterface
         }
 
         $this->middleware[] = $callable;
-        return $this/*->addMiddleware($callable)*/;
+        return $this;
     }
 
-    public function compile()
+    /**
+     * Finalize the route in preparation for dispatching
+     */
+    public function finalize()
     {
         foreach ($this->getGroups() as $group) {
             foreach ($group->getMiddleware() as $middleware) {

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -13,25 +13,16 @@ use Exception;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Interop\Container\ContainerInterface;
 use Slim\Interfaces\RouteInterface;
 
 /**
  * Route
  */
-class Route implements RouteInterface
+class Route extends Routable implements RouteInterface
 {
-    use CallableResolverAwareTrait;
     use MiddlewareAwareTrait {
         add as addMiddleware;
     }
-
-    /**
-     * Container
-     *
-     * @var ContainerInterface
-     */
-    private $container;
 
     /**
      * HTTP methods supported by this route
@@ -41,25 +32,18 @@ class Route implements RouteInterface
     protected $methods = [];
 
     /**
-     * Route pattern
-     *
-     * @var string
-     */
-    protected $pattern;
-
-    /**
-     * Route callable
-     *
-     * @var callable
-     */
-    protected $callable;
-
-    /**
      * Route name
      *
      * @var null|string
      */
     protected $name;
+
+    /**
+     * Parent route groups
+     *
+     * @var RouteGroup[]
+     */
+    protected $groups;
 
     /**
      * Output buffering mode
@@ -73,15 +57,17 @@ class Route implements RouteInterface
     /**
      * Create new route
      *
-     * @param string[] $methods       The route HTTP methods
-     * @param string   $pattern       The route pattern
-     * @param callable $callable      The route callable
+     * @param string[]     $methods  The route HTTP methods
+     * @param string       $pattern  The route pattern
+     * @param callable     $callable The route callable
+     * @param RouteGroup[] $groups   The parent route groups
      */
-    public function __construct($methods, $pattern, $callable)
+    public function __construct($methods, $pattern, $callable, $groups = [])
     {
-        $this->methods = $methods;
-        $this->pattern = $pattern;
+        $this->methods  = $methods;
+        $this->pattern  = $pattern;
         $this->callable = $callable;
+        $this->groups   = $groups;
     }
 
     /**
@@ -100,7 +86,30 @@ class Route implements RouteInterface
             $callable = $callable->bindTo($this->container);
         }
 
-        return $this->addMiddleware($callable);
+        $this->middleware[] = $callable;
+        return $this/*->addMiddleware($callable)*/;
+    }
+
+    public function compile()
+    {
+        foreach ($this->getGroups() as $group) {
+            foreach ($group->getMiddleware() as $middleware) {
+                array_unshift($this->middleware, $middleware);
+            }
+        }
+        foreach ($this->getMiddleware() as $middleware) {
+            $this->addMiddleware($middleware);
+        }
+    }
+
+    /**
+     * Get route callable
+     *
+     * @return callable
+     */
+    public function getCallable()
+    {
+        return $this->callable;
     }
 
     /**
@@ -114,13 +123,23 @@ class Route implements RouteInterface
     }
 
     /**
-     * Get route pattern
+     * Get parent route groups
      *
-     * @return string
+     * @return RouteGroup[]
      */
-    public function getPattern()
+    public function getGroups()
     {
-        return $this->pattern;
+        return $this->groups;
+    }
+
+    /**
+     * Get route name
+     *
+     * @return null|string
+     */
+    public function getName()
+    {
+        return $this->name;
     }
 
     /**
@@ -149,16 +168,6 @@ class Route implements RouteInterface
     }
 
     /**
-     * Get route callable
-     *
-     * @return callable
-     */
-    public function getCallable()
-    {
-        return $this->callable;
-    }
-
-    /**
      * Set route callable
      *
      * @param callable $callable
@@ -168,16 +177,6 @@ class Route implements RouteInterface
     protected function setCallable(callable $callable)
     {
         $this->callable = $callable;
-    }
-
-    /**
-     * Get route name
-     *
-     * @return null|string
-     */
-    public function getName()
-    {
-        return $this->name;
     }
 
     /**
@@ -194,19 +193,6 @@ class Route implements RouteInterface
             throw new InvalidArgumentException('Route name must be a string');
         }
         $this->name = $name;
-        return $this;
-    }
-
-    /**
-     * Set container for use with resolveCallable
-     *
-     * @param ContainerInterface $container
-     *
-     * @return $this
-     */
-    public function setContainer(ContainerInterface $container)
-    {
-        $this->container = $container;
         return $this;
     }
 

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/codeguy/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/codeguy/Slim/blob/master/LICENSE (MIT License)
+ */
+namespace Slim;
+
+use Closure;
+
+/**
+ * A collector for Routable objects with a common middleware stack
+ *
+ * @package Slim
+ */
+class RouteGroup extends Routable
+{
+    protected $routes = [];
+
+    public function __construct($pattern, $callable)
+    {
+        $this->pattern = $pattern;
+        $this->callable = $callable;
+    }
+
+    /**
+     * Prepend middleware to the group middleware collection
+     *
+     * @param mixed $callable The callback routine
+     *
+     * @return static
+     */
+    public function add($callable)
+    {
+        $callable = $this->resolveCallable($callable);
+        if ($callable instanceof Closure) {
+            $callable = $callable->bindTo($this->container);
+        }
+
+        array_unshift($this->middleware, $callable);
+
+        return $this;
+    }
+
+    function __invoke(&$app)
+    {
+        $callable = $this->resolveCallable($this->callable);
+        if ($callable instanceof Closure) {
+            $callable = $callable->bindTo($app);
+        }
+
+        $callable();
+    }
+}

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -9,13 +9,14 @@
 namespace Slim;
 
 use Closure;
+use Slim\Interfaces\RouteGroupInterface;
 
 /**
  * A collector for Routable objects with a common middleware stack
  *
  * @package Slim
  */
-class RouteGroup extends Routable
+class RouteGroup extends Routable implements RouteGroupInterface
 {
     protected $routes = [];
 

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -44,6 +44,11 @@ class RouteGroup extends Routable
         return $this;
     }
 
+    /**
+     * Invoke the group to register any Routable objects within it.
+     *
+     * @param App &$app The App to bind the callable to.
+     */
     function __invoke(&$app)
     {
         $callable = $this->resolveCallable($this->callable);

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -18,8 +18,12 @@ use Slim\Interfaces\RouteGroupInterface;
  */
 class RouteGroup extends Routable implements RouteGroupInterface
 {
-    protected $routes = [];
-
+    /**
+     * Create a new RouteGroup
+     *
+     * @param string $pattern The pattern prefix for the group
+     * @param callable $callable The group callable
+     */
     public function __construct($pattern, $callable)
     {
         $this->pattern = $pattern;

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -47,9 +47,9 @@ class RouteGroup extends Routable
     /**
      * Invoke the group to register any Routable objects within it.
      *
-     * @param App &$app The App to bind the callable to.
+     * @param App $app The App to bind the callable to.
      */
-    function __invoke(&$app)
+    function __invoke(App $app)
     {
         $callable = $this->resolveCallable($this->callable);
         if ($callable instanceof Closure) {

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -165,13 +165,16 @@ class Router extends RouteCollector implements RouterInterface
     /**
      * Add a route group to the array
      *
-     * @param RouteGroup $group The route group
+     * @param string   $pattern
+     * @param callable $callable
      *
-     * @return int The index of the new group
+     * @return RouteGroup
      */
-    public function pushGroup($group)
+    public function pushGroup($pattern, $callable)
     {
-        return array_push($this->routeGroups, $group);
+        $group = new RouteGroup($pattern, $callable);
+        array_push($this->routeGroups, $group);
+        return $group;
     }
 
     /**

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -57,7 +57,7 @@ class Router extends RouteCollector implements RouterInterface
      */
     protected $routeGroups = [];
 
-    private $compiled = false;
+    private $finalized = false;
 
     /**
      * Create new router
@@ -102,14 +102,19 @@ class Router extends RouteCollector implements RouterInterface
         return $route;
     }
 
-    public function compile()
+    /**
+     * Finalize registered routes in preparation for dispatching
+     *
+     * NOTE: The routes can only be finalized once.
+     */
+    public function finalize()
     {
-        if (!$this->compiled) {
+        if (!$this->finalized) {
             foreach ($this->getRoutes() as $route) {
-                $route->compile();
+                $route->finalize();
                 $this->addRoute($route->getMethods(), $route->getPattern(), [$route, 'run']);
             }
-            $this->compiled = true;
+            $this->finalized = true;
         }
     }
 
@@ -123,6 +128,8 @@ class Router extends RouteCollector implements RouterInterface
      */
     public function dispatch(ServerRequestInterface $request)
     {
+        $this->finalize();
+
         $dispatcher = new GroupCountBasedDispatcher($this->getData());
 
         return $dispatcher->dispatch(
@@ -131,6 +138,11 @@ class Router extends RouteCollector implements RouterInterface
         );
     }
 
+    /**
+     * Get route objects
+     *
+     * @return Route[]
+     */
     public function getRoutes()
     {
         return $this->routes;

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -165,11 +165,11 @@ class Router extends RouteCollector implements RouterInterface
     /**
      * Add a route group to the array
      *
-     * @param RouteGroup &$group The route group
+     * @param RouteGroup $group The route group
      *
      * @return int The index of the new group
      */
-    public function pushGroup(&$group)
+    public function pushGroup($group)
     {
         return array_push($this->routeGroups, $group);
     }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -160,8 +160,10 @@ class AppTest extends PHPUnit_Framework_TestCase
 
         });
 
-        $app->router->compile();
-        $this->assertAttributeEquals('/foo/bar', 'pattern', $app->router->getRoutes()[0]);
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->getRoutes()[0]);
     }
 
     /********************************************************************************

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -157,8 +157,11 @@ class AppTest extends PHPUnit_Framework_TestCase
             $route = $app->get('/bar', function ($req, $res) {
                 // Do something
             });
-            $this->assertAttributeEquals('/foo/bar', 'pattern', $route);
+
         });
+
+        $app->router->compile();
+        $this->assertAttributeEquals('/foo/bar', 'pattern', $app->router->getRoutes()[0]);
     }
 
     /********************************************************************************

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -93,6 +93,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
             return $res;
         };
         $route->add($mw);
+        $route->compile();
 
         $prop = new \ReflectionProperty($route, 'stack');
         $prop->setAccessible(true);
@@ -107,6 +108,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
             return $res;
         };
         $route->add($mw);
+        $route->compile();
 
         $prop = new \ReflectionProperty($route, 'stack');
         $prop->setAccessible(true);

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -93,7 +93,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
             return $res;
         };
         $route->add($mw);
-        $route->compile();
+        $route->finalize();
 
         $prop = new \ReflectionProperty($route, 'stack');
         $prop->setAccessible(true);
@@ -108,7 +108,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
             return $res;
         };
         $route->add($mw);
-        $route->compile();
+        $route->finalize();
 
         $prop = new \ReflectionProperty($route, 'stack');
         $prop->setAccessible(true);

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -61,7 +61,7 @@ class RouterTest extends PHPUnit_Framework_TestCase
             echo sprintf('Hello %s %s', $args['first'], $args['last']);
         };
 
-        $this->router->pushGroup(new \Slim\RouteGroup('/prefix', function() {}));
+        $this->router->pushGroup('/prefix', function() {});
         $route = $this->router->map($methods, $pattern, $callable);
         $this->router->popGroup();
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -32,6 +32,7 @@
 
 class RouterTest extends PHPUnit_Framework_TestCase
 {
+    /** @var \Slim\Router */
     protected $router;
 
     public function setUp()
@@ -60,7 +61,7 @@ class RouterTest extends PHPUnit_Framework_TestCase
             echo sprintf('Hello %s %s', $args['first'], $args['last']);
         };
 
-        $this->router->pushGroup('/prefix', []);
+        $this->router->pushGroup(new \Slim\RouteGroup('/prefix', function() {}));
         $route = $this->router->map($methods, $pattern, $callable);
         $this->router->popGroup();
 


### PR DESCRIPTION
Requires routes be collected and compiled before usage; see changes to App->run() and App->__invoke()

Attempts to address #1265
