### PR TITLE
Using call_user_func instead of calling the callable directly

### DIFF
--- a/Slim/MiddlewareAwareTrait.php
+++ b/Slim/MiddlewareAwareTrait.php
@@ -63,7 +63,7 @@ trait MiddlewareAwareTrait
         }
         $next = $this->stack->top();
         $this->stack[] = function (ServerRequestInterface $req, ResponseInterface $res) use ($callable, $next) {
-            $result = $callable($req, $res, $next);
+            $result = call_user_func($callable, $req, $res, $next);
             if ($result instanceof ResponseInterface === false) {
                 throw new UnexpectedValueException('Middleware must return instance of \Psr\Http\Message\ResponseInterface');
             }


### PR DESCRIPTION
Classes with with static methods are callables. #1331 
