### PR TITLE
Add default attributes to the route

### DIFF
--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -20,6 +20,24 @@ use Psr\Http\Message\ResponseInterface;
  */
 interface RouteInterface
 {
+
+    /**
+     * Retrieve a specific route argument
+     *
+     * @param string $name
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getArgument($name, $default = null);
+
+    /**
+     * Get route arguments
+     *
+     * @return array
+     */
+    public function getArguments();
+
     /**
      * Get route name
      *
@@ -33,6 +51,25 @@ interface RouteInterface
      * @return string
      */
     public function getPattern();
+
+    /**
+     * Set a route argument
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @return static
+     */
+    public function setArgument($name, $value);
+
+    /**
+     * Replace route arguments
+     *
+     * @param array $arguments
+     *
+     * @return static
+     */
+    public function setArguments(array $arguments);
 
     /**
      * Set route name

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -233,7 +233,7 @@ class Route extends Routable implements RouteInterface
      *
      * @return $this
      */
-    public function setArguments($arguments)
+    public function setArguments(array $arguments)
     {
         $this->arguments = $arguments;
         return $this;
@@ -252,7 +252,10 @@ class Route extends Routable implements RouteInterface
     /**
      * Retrieve a specific route argument
      *
-     * @return array
+     * @param string $name
+     * @param mixed $default
+     *
+     * @return mixed
      */
     public function getArgument($name, $default = null)
     {

--- a/index.php
+++ b/index.php
@@ -31,6 +31,11 @@ $app->get('/', function ($request, $response, $args) {
     return $response;
 });
 
+$app->get('/hello/world', function ($request, $response, $args) {
+    $response->write("Hello " . $args['extra']);
+    return $response;
+})->setArgument('extra', 'world');
+
 $app->get('/hello/{name}', function ($request, $response, $args) {
     $response->write("Hello, " . $args['name']);
     return $response;

--- a/index.php
+++ b/index.php
@@ -32,9 +32,9 @@ $app->get('/', function ($request, $response, $args) {
 });
 
 $app->get('/hello[/{name}]', function ($request, $response, $args) {
-    $response->write("Hello " . $args['name']);
+    $response->write("Hello, " . $args['name']);
     return $response;
-})->setArgument('name', 'world');
+})->setArgument('name', 'World!');
 
 /**
  * Step 4: Run the Slim application

--- a/index.php
+++ b/index.php
@@ -31,15 +31,10 @@ $app->get('/', function ($request, $response, $args) {
     return $response;
 });
 
-$app->get('/hello/world', function ($request, $response, $args) {
-    $response->write("Hello " . $args['extra']);
+$app->get('/hello[/{name}]', function ($request, $response, $args) {
+    $response->write("Hello " . $args['name']);
     return $response;
-})->setArgument('extra', 'world');
-
-$app->get('/hello/{name}', function ($request, $response, $args) {
-    $response->write("Hello, " . $args['name']);
-    return $response;
-});
+})->setArgument('name', 'world');
 
 /**
  * Step 4: Run the Slim application


### PR DESCRIPTION
Added setDefaultAttributes method to the route class. Allows you to set default attributes when defining a route. 

For example:

```
$app->get('/hello/world', function ($request, $response, $args) {
    $response->write("Hello " . $args['extra']);
    return $response;
})->setDefaultAttributes(['extra' => 'world']);
```
