### PR TITLE
Update route strategy work

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -375,8 +375,7 @@ class App
             foreach ($routeInfo[2] as $k => $v) {
                 $routeArguments[$k] = urldecode($v);
             }
-            $request = $request->withAttribute('routeArguments', $routeArguments);
-            return $routeInfo[1]($request, $response);
+            return $routeInfo[1]($request, $response, $routeArguments);
         } elseif ($routeInfo[0] === Dispatcher::METHOD_NOT_ALLOWED) {
             /** @var callable $notAllowedHandler */
             $notAllowedHandler = $this->container->get('notAllowedHandler');

--- a/Slim/Handlers/Strategies/RequestResponse.php
+++ b/Slim/Handlers/Strategies/RequestResponse.php
@@ -25,11 +25,20 @@ class RequestResponse implements InvocationStrategyInterface
      * @param array|callable         $callable
      * @param ServerRequestInterface $request
      * @param ResponseInterface      $response
+     * @param array                  $routeArguments
      *
      * @return mixed
      */
-    public function __invoke(callable $callable, ServerRequestInterface $request, ResponseInterface $response)
-    {
-        return $callable($request, $response, $request->getAttribute('routeArguments'));
+    public function __invoke(
+        callable $callable,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        array $routeArguments
+    ) {
+        foreach ($routeArguments as $k => $v) {
+            $request = $request->withAttribute($k, $v);
+        }
+
+        return $callable($request, $response, $routeArguments);
     }
 }

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -25,15 +25,18 @@ class RequestResponseArgs implements InvocationStrategyInterface
      * @param array|callable         $callable
      * @param ServerRequestInterface $request
      * @param ResponseInterface      $response
+     * @param array                  $routeArguments
      *
      * @return mixed
      */
-    public function __invoke(callable $callable, ServerRequestInterface $request, ResponseInterface $response)
-    {
-        $arguments = [$request, $response];
-        foreach ($request->getAttribute('routeArguments') as $k => $v) {
-            array_push($arguments, $v);
-        }
-        return call_user_func_array($callable, $arguments);
+    public function __invoke(
+        callable $callable,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        array $routeArguments
+    ) {
+        array_unshift($routeArguments, $request, $response);
+
+        return call_user_func_array($callable, $routeArguments);
     }
 }

--- a/Slim/Interfaces/InvocationStrategyInterface.php
+++ b/Slim/Interfaces/InvocationStrategyInterface.php
@@ -22,8 +22,9 @@ interface InvocationStrategyInterface
      * @param callable               $callable The callable to invoke using the strategy.
      * @param ServerRequestInterface $request The request object.
      * @param ResponseInterface      $response The response object.
+     * @param array                  $routeParams The route's placholder arguments
      *
      * @return ResponseInterface|string The response from the callable.
      */
-    public function __invoke(callable $callable, ServerRequestInterface $request, ResponseInterface $response);
+    public function __invoke(callable $callable, ServerRequestInterface $request, ResponseInterface $response, array $routeArguments);
 }

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -212,6 +212,33 @@ class Route extends Routable implements RouteInterface
         return $this;
     }
 
+    /**
+     * Set a route argument
+     *
+     * @param string $name
+     * @param string $value
+     *
+     * @return $this
+     */
+    public function setRouteArgument($name, $value)
+    {
+        $this->routeArguments[$name] = $value;
+        return $this;
+    }
+
+    /**
+     * Replace route arguments
+     *
+     * @param array $arguments
+     *
+     * @return $this
+     */
+    public function setRouteArguments($arguments)
+    {
+        $this->routeArguments = $arguments;
+        return $this;
+    }
+
     /********************************************************************************
      * Route Runner
      *******************************************************************************/
@@ -231,7 +258,9 @@ class Route extends Routable implements RouteInterface
      */
     public function run(ServerRequestInterface $request, ResponseInterface $response, array $routeArguments)
     {
-        $this->routeArguments = $routeArguments;
+        foreach ($routeArguments as $k => $v) {
+            $this->setRouteArgument($k, $v);
+        }
 
         // Traverse middleware stack and fetch updated response
         return $this->callMiddlewareStack($request, $response);

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -249,6 +249,19 @@ class Route extends Routable implements RouteInterface
         return $this->arguments;
     }
 
+    /**
+     * Retrieve a specific route argument
+     *
+     * @return array
+     */
+    public function getArgument($name, $default = null)
+    {
+        if (array_key_exists($name, $this->arguments)) {
+            return $this->arguments[$name];
+        }
+        return $default;
+    }
+
     /********************************************************************************
      * Route Runner
      *******************************************************************************/

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -63,7 +63,7 @@ class Route extends Routable implements RouteInterface
      *
      * @var array
      */
-    protected $routeArguments = [];
+    protected $arguments = [];
 
     /**
      * Create new route
@@ -220,9 +220,9 @@ class Route extends Routable implements RouteInterface
      *
      * @return $this
      */
-    public function setRouteArgument($name, $value)
+    public function setArgument($name, $value)
     {
-        $this->routeArguments[$name] = $value;
+        $this->arguments[$name] = $value;
         return $this;
     }
 
@@ -233,9 +233,9 @@ class Route extends Routable implements RouteInterface
      *
      * @return $this
      */
-    public function setRouteArguments($arguments)
+    public function setArguments($arguments)
     {
-        $this->routeArguments = $arguments;
+        $this->arguments = $arguments;
         return $this;
     }
 
@@ -244,9 +244,9 @@ class Route extends Routable implements RouteInterface
      *
      * @return array
      */
-    public function getRouteArguments()
+    public function getArguments()
     {
-        return $this->routeArguments;
+        return $this->arguments;
     }
 
     /********************************************************************************
@@ -262,14 +262,14 @@ class Route extends Routable implements RouteInterface
      *
      * @param ServerRequestInterface $request
      * @param ResponseInterface      $response
-     * @param array                  $routeArguments
+     * @param array                  $arguments
      *
      * @return ResponseInterface
      */
-    public function run(ServerRequestInterface $request, ResponseInterface $response, array $routeArguments)
+    public function run(ServerRequestInterface $request, ResponseInterface $response, array $arguments)
     {
-        foreach ($routeArguments as $k => $v) {
-            $this->setRouteArgument($k, $v);
+        foreach ($arguments as $k => $v) {
+            $this->setArgument($k, $v);
         }
 
         // add this route to the request's attributes in case route middleware needs access to route arguments
@@ -298,11 +298,11 @@ class Route extends Routable implements RouteInterface
 
         // invoke route callable
         if ($this->outputBuffering === false) {
-            $newResponse = $handler($this->callable, $request, $response, $this->routeArguments);
+            $newResponse = $handler($this->callable, $request, $response, $this->arguments);
         } else {
             try {
                 ob_start();
-                $newResponse = $handler($this->callable, $request, $response, $this->routeArguments);
+                $newResponse = $handler($this->callable, $request, $response, $this->arguments);
                 $output = ob_get_clean();
             } catch (Exception $e) {
                 ob_end_clean();

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -59,6 +59,13 @@ class Route extends Routable implements RouteInterface
     protected $outputBuffering = 'append';
 
     /**
+     * Route parameters
+     *
+     * @var array
+     */
+    protected $routeArguments = [];
+
+    /**
      * Create new route
      *
      * @param string[]     $methods The route HTTP methods
@@ -218,11 +225,14 @@ class Route extends Routable implements RouteInterface
      *
      * @param ServerRequestInterface $request
      * @param ResponseInterface      $response
+     * @param array                  $routeArguments
      *
      * @return ResponseInterface
      */
-    public function run(ServerRequestInterface $request, ResponseInterface $response)
+    public function run(ServerRequestInterface $request, ResponseInterface $response, array $routeArguments)
     {
+        $this->routeArguments = $routeArguments;
+
         // Traverse middleware stack and fetch updated response
         return $this->callMiddlewareStack($request, $response);
     }
@@ -246,11 +256,11 @@ class Route extends Routable implements RouteInterface
 
         // invoke route callable
         if ($this->outputBuffering === false) {
-            $newResponse = $handler($this->callable, $request, $response);
+            $newResponse = $handler($this->callable, $request, $response, $this->routeArguments);
         } else {
             try {
                 ob_start();
-                $newResponse = $handler($this->callable, $request, $response);
+                $newResponse = $handler($this->callable, $request, $response, $this->routeArguments);
                 $output = ob_get_clean();
             } catch (Exception $e) {
                 ob_end_clean();

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -239,6 +239,16 @@ class Route extends Routable implements RouteInterface
         return $this;
     }
 
+    /**
+     * Retrieve route arguments
+     *
+     * @return array
+     */
+    public function getRouteArguments()
+    {
+        return $this->routeArguments;
+    }
+
     /********************************************************************************
      * Route Runner
      *******************************************************************************/
@@ -261,6 +271,9 @@ class Route extends Routable implements RouteInterface
         foreach ($routeArguments as $k => $v) {
             $this->setRouteArgument($k, $v);
         }
+
+        // add this route to the request's attributes in case route middleware needs access to route arguments
+        $request = $request->withAttribute('route', $this);
 
         // Traverse middleware stack and fetch updated response
         return $this->callMiddlewareStack($request, $response);

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -97,6 +97,8 @@ class RouteTest extends PHPUnit_Framework_TestCase
         
         $route->setArguments(['a' => 'b']);
         $this->assertSame($route->getArguments(), ['a' => 'b']);
+        $this->assertSame($route->getArgument('a', 'default'), 'b');
+        $this->assertSame($route->getArgument('b', 'default'), 'default');
     }
 
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -85,6 +85,20 @@ class RouteTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_callable($callable));
     }
 
+    public function testArgumentSetting()
+    {
+        $route = $this->routeFactory();
+        $route->setArguments(['foo' => 'FOO', 'bar' => 'BAR']);
+        $this->assertSame($route->getArguments(), ['foo' => 'FOO', 'bar' => 'BAR']);
+        $route->setArgument('bar', 'bar');
+        $this->assertSame($route->getArguments(), ['foo' => 'FOO', 'bar' => 'bar']);
+        $route->setArgument('baz', 'BAZ');
+        $this->assertSame($route->getArguments(), ['foo' => 'FOO', 'bar' => 'bar', 'baz' => 'BAZ']);
+        
+        $route->setArguments(['a' => 'b']);
+        $this->assertSame($route->getArguments(), ['a' => 'b']);
+    }
+
 
     public function testBottomMiddlewareIsRoute()
     {


### PR DESCRIPTION
This PR improves the route strategy work to allow the the strategies themselves to decide how to handle the route's arguments rather than putting them into a sub-key of the request.

As a result, the strategies can now do different things that make more sense for each case:
- For the `RequestResponse` strategy, we put the routes arguments directly into the request's `attributes` so that the user can benefit from the default argument on the request's `getAttribute` method.
- For the `RequestResponseArg` strategy we d not put the route arguments into the request at all as they are passed as separate arguments to the callback and so the defaults can be set in the function signature.
