### PR TITLE
Workaround for the failing unittests.

### DIFF
--- a/Slim/Middleware/PrettyExceptionRenderer.php
+++ b/Slim/Middleware/PrettyExceptionRenderer.php
@@ -1,0 +1,47 @@
+<?php
+
+
+namespace Slim\Middleware;
+
+
+use Exception;
+
+class PrettyExceptionRenderer
+{
+
+    /**
+     * @param Exception $exception
+     * @return string
+     */
+    public static function renderException(Exception $exception)
+    {
+        $title = 'Slim Application Error';
+        $code = $exception->getCode();
+        $message = htmlspecialchars($exception->getMessage());
+        $file = $exception->getFile();
+        $line = $exception->getLine();
+        $trace = str_replace(array('#', "\n"), array('<div>#', '</div>'), htmlspecialchars($exception->getTraceAsString()));
+        $html = sprintf('<h1>%s</h1>', $title);
+        $html .= '<p>The application could not run because of the following error:</p>';
+        $html .= '<h2>Details</h2>';
+        $html .= sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
+        if ($code) {
+            $html .= sprintf('<div><strong>Code:</strong> %s</div>', $code);
+        }
+        if ($message) {
+            $html .= sprintf('<div><strong>Message:</strong> %s</div>', $message);
+        }
+        if ($file) {
+            $html .= sprintf('<div><strong>File:</strong> %s</div>', $file);
+        }
+        if ($line) {
+            $html .= sprintf('<div><strong>Line:</strong> %s</div>', $line);
+        }
+        if ($trace) {
+            $html .= '<h2>Trace</h2>';
+            $html .= sprintf('<pre>%s</pre>', $trace);
+        }
+
+        return sprintf("<html><head><title>%s</title><style>body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana,sans-serif;}h1{margin:0;font-size:48px;font-weight:normal;line-height:48px;}strong{display:inline-block;width:65px;}</style></head><body>%s</body></html>", $title, $html);
+    }
+}

--- a/Slim/Middleware/PrettyExceptions.php
+++ b/Slim/Middleware/PrettyExceptions.php
@@ -72,45 +72,7 @@ class PrettyExceptions extends \Slim\Middleware
             $env['slim.log']->error($e);
             $this->app->contentType('text/html');
             $this->app->response()->status(500);
-            $this->app->response()->body($this->renderBody($env, $e));
+            $this->app->response()->body(PrettyExceptionRenderer::renderException($e));
         }
-    }
-
-    /**
-     * Render response body
-     * @param  array      $env
-     * @param  \Exception $exception
-     * @return string
-     */
-    protected function renderBody(&$env, $exception)
-    {
-        $title = 'Slim Application Error';
-        $code = $exception->getCode();
-        $message = htmlspecialchars($exception->getMessage());
-        $file = $exception->getFile();
-        $line = $exception->getLine();
-        $trace = str_replace(array('#', "\n"), array('<div>#', '</div>'), htmlspecialchars($exception->getTraceAsString()));
-        $html = sprintf('<h1>%s</h1>', $title);
-        $html .= '<p>The application could not run because of the following error:</p>';
-        $html .= '<h2>Details</h2>';
-        $html .= sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
-        if ($code) {
-            $html .= sprintf('<div><strong>Code:</strong> %s</div>', $code);
-        }
-        if ($message) {
-            $html .= sprintf('<div><strong>Message:</strong> %s</div>', $message);
-        }
-        if ($file) {
-            $html .= sprintf('<div><strong>File:</strong> %s</div>', $file);
-        }
-        if ($line) {
-            $html .= sprintf('<div><strong>Line:</strong> %s</div>', $line);
-        }
-        if ($trace) {
-            $html .= '<h2>Trace</h2>';
-            $html .= sprintf('<pre>%s</pre>', $trace);
-        }
-
-        return sprintf("<html><head><title>%s</title><style>body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana,sans-serif;}h1{margin:0;font-size:48px;font-weight:normal;line-height:48px;}strong{display:inline-block;width:65px;}</style></head><body>%s</body></html>", $title, $html);
     }
 }

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -49,7 +49,7 @@ class Router
     protected $currentRoute;
 
     /**
-     * @var array Lookup hash of all route objects
+     * @var Route[] Lookup hash of all route objects
      */
     protected $routes;
 
@@ -99,7 +99,7 @@ class Router
      * @param  string               $httpMethod   The HTTP method to match against
      * @param  string               $resourceUri  The resource URI to match against
      * @param  bool                 $reload       Should matching routes be re-parsed?
-     * @return array[\Slim\Route]
+     * @return \Slim\Route[]
      */
     public function getMatchedRoutes($httpMethod, $resourceUri, $reload = false)
     {

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -119,7 +119,6 @@ class Slim
 
         $className = ltrim($className, '\\');
         $fileName  = $baseDir;
-        $namespace = '';
         if ($lastNsPos = strripos($className, '\\')) {
             $namespace = substr($className, 0, $lastNsPos);
             $className = substr($className, $lastNsPos + 1);
@@ -350,6 +349,7 @@ class Slim
             $settings[$name] = $value;
             $c['settings'] = $settings;
         }
+        return null;
     }
 
     /********************************************************************************
@@ -1163,6 +1163,7 @@ class Slim
         if (isset($this->environment['slim.flash'])) {
             return $this->environment['slim.flash']->getMessages();
         }
+        return null;
     }
 
     /********************************************************************************
@@ -1299,7 +1300,11 @@ class Slim
         }
 
         //Invoke middleware and application stack
-        $this->middleware[0]->call();
+        $firstMiddleware = $this->middleware[0];
+        /**
+         * @var Middleware $firstMiddleware
+         */
+        $firstMiddleware->call();
 
         //Fetch status, header, and body
         list($status, $headers, $body) = $this->response->finalize();
@@ -1372,6 +1377,11 @@ class Slim
             $this->response()->write(ob_get_clean());
         } catch (\Exception $e) {
             if ($this->config('debug')) {
+                /**
+                 * Not cleaning causes a leak. Since we call ob_start at the beginning.
+                 * Also this causes the tests to fail.
+                 */
+                ob_get_clean();
                 throw $e;
             } else {
                 try {

--- a/tests/Middleware/PrettyExceptionRendererTest.php
+++ b/tests/Middleware/PrettyExceptionRendererTest.php
@@ -1,0 +1,19 @@
+<?php
+
+
+use Slim\Middleware\PrettyExceptionRenderer;
+
+class PrettyExceptionRendererTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     *
+     */
+    public function testRender()
+    {
+        $exception = new \Exception("_message_",21221);
+        $prettyPrint = PrettyExceptionRenderer::renderException($exception);
+        $this->assertContains('Slim Application Error', $prettyPrint);
+        $this->assertContains('21221', $prettyPrint);
+        $this->assertContains("_message_", $prettyPrint);
+    }
+}


### PR DESCRIPTION
Added an ob_get_clean in case of debugging. This fixes the annoying error of closed buffers mentioned in the unittests.
Extracted the rendering of Exceptions in a separate class. 
Also a few warnings were fixed.
