### PR TITLE
Added cast to string on Response::withHeader() call

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -287,7 +287,7 @@ class App
             if ($hasBody) {
                 $size = $response->getBody()->getSize();
                 if ($size !== null) {
-                    $response = $response->withHeader('Content-Length', $size);
+                    $response = $response->withHeader('Content-Length', (string) $size);
                 }
             } else {
                 $response = $response->withoutHeader('Content-Type')->withoutHeader('Content-Length');


### PR DESCRIPTION
With the a zend-diactoros response object, the Response::withHeader() method will fail unless it's given a string.

https://github.com/zendframework/zend-diactoros/blob/master/src/MessageTrait.php (Line 191)

Not sure if you want to accept this change (or if there are other similar issues) - but I had to change this to get it to work with my project.
