### PR TITLE
Remove Pimple factories from Container

### DIFF
--- a/Slim/CallableResolverAwareTrait.php
+++ b/Slim/CallableResolverAwareTrait.php
@@ -40,7 +40,7 @@ trait CallableResolverAwareTrait
                 throw new RuntimeException('Cannot resolve callable string');
             }
             /** @var CallableResolver $resolver */
-            $resolver = $container->get('callableResolver');
+            $resolver = clone($container->get('callableResolver')); // we need a new one each time
             $resolver->setToResolve($callable);
             $callable = $resolver;
         }

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -62,11 +62,6 @@ final class Container extends PimpleContainer implements ContainerInterface
         'outputBuffering' => 'append',
     ];
 
-
-    /********************************************************************************
-     * Constructor sets up default Pimple services
-     *******************************************************************************/
-
     /**
      * Create new container
      *
@@ -76,6 +71,21 @@ final class Container extends PimpleContainer implements ContainerInterface
     {
         parent::__construct();
 
+        $this->registerDefaultServices($userSettings);
+    }
+
+    /**
+     * This function registers the default services that Slim needs to work.
+     *
+     * All services are shared - that is, they are registered such that the
+     * same instance is returned on subsequent calls.
+     *
+     * @param array $userSettings Associative array of application settings
+     *
+     * @return void
+     */
+    private function registerDefaultServices($userSettings)
+    {
         $defaultSettings = $this->defaultSettings;
 
         /**
@@ -103,37 +113,29 @@ final class Container extends PimpleContainer implements ContainerInterface
         };
 
         /**
-         * This service MUST return a NEW instance
-         * of \Psr\Http\Message\ServerRequestInterface.
+         * PSR-7 Request object
+         *
+         * @param Container $c
+         *
+         * @return ServerRequestInterface
          */
-        $this['request'] = $this->factory(
-            /**
-             * @param Container $c
-             *
-             * @return ServerRequestInterface
-             */
-            function ($c) {
-                return Request::createFromEnvironment($c['environment']);
-            }
-        );
+        $this['request'] = function ($c) {
+            return Request::createFromEnvironment($c['environment']);
+        };
 
         /**
-         * This service MUST return a NEW instance
-         * of \Psr\Http\Message\ResponseInterface.
+         * PSR-7 Response object
+         *
+         * @param Container $c
+         *
+         * @return ResponseInterface
          */
-        $this['response'] = $this->factory(
-            /**
-             * @param Container $c
-             *
-             * @return ResponseInterface
-             */
-            function ($c) {
-                $headers = new Headers(['Content-Type' => 'text/html']);
-                $response = new Response(200, $headers);
+        $this['response'] = function ($c) {
+            $headers = new Headers(['Content-Type' => 'text/html']);
+            $response = new Response(200, $headers);
 
-                return $response->withProtocolVersion($c['settings']['httpVersion']);
-            }
-        );
+            return $response->withProtocolVersion($c['settings']['httpVersion']);
+        };
 
         /**
          * This service MUST return a SHARED instance
@@ -216,19 +218,15 @@ final class Container extends PimpleContainer implements ContainerInterface
         };
 
         /**
-         * This service MUST return a NEW instance of
-         * \Slim\Interfaces\CallableResolverInterface
+         * Instance of \Slim\Interfaces\CallableResolverInterface
+         *
+         * @param Container $c
+         *
+         * @return CallableResolverInterface
          */
-        $this['callableResolver'] = $this->factory(
-            /**
-             * @param Container $c
-             *
-             * @return CallableResolverInterface
-             */
-            function ($c) {
-                return new CallableResolver($c);
-            }
-        );
+        $this['callableResolver'] = function ($c) {
+            return new CallableResolver($c);
+        };
     }
 
     /********************************************************************************


### PR DESCRIPTION
This is as per one of the comments in #1358:

> Be aware that container-interop states that a container SHOULD return always the same instance. Therefore, it is unlikely that many containers will offer the feature of creating a new instance when get is called. It means that you are restricting the type of containers that can be integrated into Slim.

I've also, moved the registration of the default Slim services to their own method as it's a bit neater that way.
