### PR TITLE
Questions about Container-interop integration

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -35,10 +35,10 @@ final class CallableResolver implements CallableResolverInterface
     protected $resolved;
 
     /**
-     * @param ContainerInterface $container
+     * @param ContainerInterface|null $container
      * @param string             $toResolve
      */
-    public function __construct(ContainerInterface $container, $toResolve = null)
+    public function __construct(ContainerInterface $container = null, $toResolve = null)
     {
         $this->toResolve = $toResolve;
         $this->container = $container;
@@ -79,7 +79,7 @@ final class CallableResolver implements CallableResolverInterface
                 $class = $matches[1];
                 $method = $matches[2];
 
-                if ($this->container->has($class)) {
+                if ($this->container && $this->container->has($class)) {
                     $this->resolved = [$this->container->get($class), $method];
                 } else {
                     if (!class_exists($class)) {

--- a/Slim/CallableResolverAwareTrait.php
+++ b/Slim/CallableResolverAwareTrait.php
@@ -35,13 +35,8 @@ trait CallableResolverAwareTrait
     protected function resolveCallable($callable)
     {
         if (!is_callable($callable) && is_string($callable)) {
-            if ($this->container instanceof ContainerInterface) {
-                $container = $this->container;
-            } else {
-                throw new RuntimeException('Cannot resolve callable string');
-            }
             /** @var CallableResolver $resolver */
-            $resolver = clone($container->get('callableResolver')); // we need a new one each time
+            $resolver = clone($this->getCallableResolver()); // we need a new one each time
             $resolver->setToResolve($callable);
             $callable = $resolver;
         }

--- a/Slim/Configuration.php
+++ b/Slim/Configuration.php
@@ -1,0 +1,336 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/codeguy/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/codeguy/Slim/blob/master/LICENSE (MIT License)
+ */
+namespace Slim;
+
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Pimple\Container as PimpleContainer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Exception\NotFoundException;
+use Slim\Handlers\Error;
+use Slim\Handlers\NotFound;
+use Slim\Handlers\NotAllowed;
+use Slim\Handlers\Strategies\RequestResponse;
+use Slim\Http\Environment;
+use Slim\Http\Headers;
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\Http\EnvironmentInterface;
+use Slim\Interfaces\InvocationStrategyInterface;
+use Slim\Interfaces\RouterInterface;
+
+/**
+ * Slim's class referencing configurable services.
+ *
+ * You can use this class to pass special services to Slim\App. If you do not set special services,
+ * those services will be used instead:
+ *
+ *  - settings: an array or instance of \ArrayAccess
+ *  - environment: an instance of \Slim\Interfaces\Http\EnvironmentInterface
+ *  - request: an instance of \Psr\Http\Message\ServerRequestInterface
+ *  - response: an instance of \Psr\Http\Message\ResponseInterface
+ *  - router: an instance of \Slim\Interfaces\RouterInterface
+ *  - foundHandler: an instance of \Slim\Interfaces\InvocationStrategyInterface
+ *  - errorHandler: a callable with the signature: function($request, $response, $exception)
+ *  - notFoundHandler: a callable with the signature: function($request, $response)
+ *  - notAllowedHandler: a callable with the signature: function($request, $response, $allowedHttpMethods)
+ *  - callableResolver: an instance of \Slim\Interfaces\CallableResolverInterface
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * Default settings
+     *
+     * @var array
+     */
+    private $defaultSettings = [
+        'cookieLifetime' => '20 minutes',
+        'cookiePath' => '/',
+        'cookieDomain' => null,
+        'cookieSecure' => false,
+        'cookieHttpOnly' => false,
+        'httpVersion' => '1.1',
+        'responseChunkSize' => 4096,
+        'outputBuffering' => 'append',
+    ];
+
+    /**
+     * @var array $userSettings Associative array of application settings
+     */
+    private $userSettings;
+
+    /**
+     * @var EnvironmentInterface
+     */
+    private $environment;
+
+    /**
+     * @var ServerRequestInterface
+     */
+    private $request;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var InvocationStrategyInterface
+     */
+    private $foundHandler;
+
+    /**
+     * @var callable
+     */
+    private $errorHandler;
+
+    /**
+     * @var callable
+     */
+    private $notFoundHandler;
+
+    /**
+     * @var callable
+     */
+    private $notAllowedHandler;
+
+    /**
+     * @var CallableResolverInterface
+     */
+    private $callableResolver;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * Create new container
+     *
+     * @param array $userSettings Associative array of application settings
+     */
+    public function __construct(array $userSettings = [])
+    {
+        $this->setSettings($userSettings);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSettings()
+    {
+        return $this->userSettings;
+    }
+
+    /**
+     * @param mixed $userSettings
+     */
+    public function setSettings($userSettings)
+    {
+        $this->userSettings = array_merge($this->defaultSettings, $userSettings);
+    }
+
+    /**
+     * @return EnvironmentInterface
+     */
+    public function getEnvironment()
+    {
+        if ($this->environment === null) {
+            $this->environment = new Environment($_SERVER);
+        }
+        return $this->environment;
+    }
+
+    /**
+     * @param EnvironmentInterface $environment
+     */
+    public function setEnvironment(EnvironmentInterface $environment)
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * @return ServerRequestInterface
+     */
+    public function getRequest()
+    {
+        if ($this->request === null) {
+            $this->request = Request::createFromEnvironment($this->getEnvironment());
+        }
+        return $this->request;
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     */
+    public function setRequest($request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getResponse()
+    {
+        if ($this->response === null) {
+            $headers = new Headers(['Content-Type' => 'text/html']);
+            $this->response = new Response(200, $headers);
+            $this->response->withProtocolVersion($this->getSettings()['httpVersion']);
+        }
+        return $this->response;
+    }
+
+    /**
+     * @param mixed $response
+     */
+    public function setResponse($response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getRouter()
+    {
+        if ($this->router === null) {
+            $this->router = new Router();
+        }
+        return $this->router;
+    }
+
+    /**
+     * @param mixed $router
+     */
+    public function setRouter($router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @return InvocationStrategyInterface
+     */
+    public function getFoundHandler()
+    {
+        if ($this->foundHandler === null) {
+            $this->foundHandler = new RequestResponse();
+        }
+        return $this->foundHandler;
+    }
+
+    /**
+     * @param InvocationStrategyInterface $foundHandler
+     */
+    public function setFoundHandler($foundHandler)
+    {
+        $this->foundHandler = $foundHandler;
+    }
+
+    /**
+     * @return callable
+     */
+    public function getErrorHandler()
+    {
+        if ($this->errorHandler === null) {
+            $this->errorHandler = new Error();
+        }
+        return $this->errorHandler;
+    }
+
+    /**
+     * @param callable $errorHandler
+     */
+    public function setErrorHandler($errorHandler)
+    {
+        $this->errorHandler = $errorHandler;
+    }
+
+    /**
+     * @return callable
+     */
+    public function getNotFoundHandler()
+    {
+        if ($this->notFoundHandler === null) {
+            $this->notFoundHandler = new NotFound();
+        }
+        return $this->notFoundHandler;
+    }
+
+    /**
+     * @param callable $notFoundHandler
+     */
+    public function setNotFoundHandler($notFoundHandler)
+    {
+        $this->notFoundHandler = $notFoundHandler;
+    }
+
+    /**
+     * @return callable
+     */
+    public function getNotAllowedHandler()
+    {
+        if ($this->notAllowedHandler === null) {
+            $this->notAllowedHandler = new NotAllowed();
+        }
+        return $this->notAllowedHandler;
+    }
+
+    /**
+     * @param callable $notAllowedHandler
+     */
+    public function setNotAllowedHandler($notAllowedHandler)
+    {
+        $this->notAllowedHandler = $notAllowedHandler;
+    }
+
+    /**
+     * @return CallableResolverInterface
+     */
+    public function getCallableResolver()
+    {
+        if ($this->callableResolver === null) {
+            $this->callableResolver = new CallableResolver($this->getContainer());
+        }
+        return $this->callableResolver;
+    }
+
+    /**
+     * @param CallableResolverInterface $callableResolver
+     */
+    public function setCallableResolver($callableResolver)
+    {
+        $this->callableResolver = $callableResolver;
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * @param ContainerInterface $container
+     * @return Configuration
+     */
+    public function setContainer($container)
+    {
+        $this->container = $container;
+        return $this;
+    }
+}

--- a/Slim/ConfigurationInterface.php
+++ b/Slim/ConfigurationInterface.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: david
+ * Date: 16/07/15
+ * Time: 18:08
+ */
+namespace Slim;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\Http\EnvironmentInterface;
+use Slim\Interfaces\InvocationStrategyInterface;
+
+
+/**
+ * Slim's interface referencing configurable services.
+ *
+ * You can use classes implementing this interface to pass special services to Slim\App.
+ */
+interface ConfigurationInterface
+{
+    /**
+     * @return mixed
+     */
+    public function getSettings();
+
+    /**
+     * @return EnvironmentInterface
+     */
+    public function getEnvironment();
+
+    /**
+     * @return ServerRequestInterface
+     */
+    public function getRequest();
+
+    /**
+     * @return mixed
+     */
+    public function getResponse();
+
+    /**
+     * @return mixed
+     */
+    public function getRouter();
+
+    /**
+     * @return InvocationStrategyInterface
+     */
+    public function getFoundHandler();
+
+    /**
+     * @return callable
+     */
+    public function getErrorHandler();
+
+    /**
+     * @return callable
+     */
+    public function getNotFoundHandler();
+
+    /**
+     * @return callable
+     */
+    public function getNotAllowedHandler();
+
+    /**
+     * @return CallableResolverInterface
+     */
+    public function getCallableResolver();
+
+    /**
+     * @return ContainerInterface
+     */
+    public function getContainer();
+}

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -9,6 +9,8 @@
 namespace Slim;
 
 use Interop\Container\ContainerInterface;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\InvocationStrategyInterface;
 
 /**
  * A routable, middleware-aware object
@@ -33,6 +35,16 @@ abstract class Routable
      * @var ContainerInterface
      */
     protected $container;
+
+    /**
+     * @var InvocationStrategyInterface
+     */
+    protected $foundHandler;
+
+    /**
+     * @var CallableResolverInterface
+     */
+    protected $callableResolver;
 
     /**
      * Route middleware
@@ -79,5 +91,39 @@ abstract class Routable
     {
         $this->container = $container;
         return $this;
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    /**
+     * Set the foundHandler for use
+     *
+     * @param InvocationStrategyInterface $foundHandler
+     *
+     * @return self
+     */
+    public function setFoundHandler(InvocationStrategyInterface $foundHandler)
+    {
+        $this->foundHandler = $foundHandler;
+        return $this;
+    }
+
+    /**
+     * @param CallableResolverInterface $callableResolver
+     * @return $this
+     */
+    public function setCallableResolver(CallableResolverInterface $callableResolver) {
+        $this->callableResolver = $callableResolver;
+        return $this;
+    }
+
+    protected function getCallableResolver() {
+        return $this->callableResolver;
     }
 }

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -307,7 +307,7 @@ class Route extends Routable implements RouteInterface
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
         /** @var InvocationStrategyInterface $handler */
-        $handler = isset($this->container) ? $this->container->get('foundHandler') : new RequestResponse();
+        $handler = isset($this->foundHandler) ? $this->foundHandler : new RequestResponse();
 
         // invoke route callable
         if ($this->outputBuffering === false) {

--- a/composer.json
+++ b/composer.json
@@ -29,15 +29,16 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "pimple/pimple": "3.*",
         "psr/http-message": "1.0",
+        "pimple/pimple": "~3.0",
         "nikic/fast-route": "^0.6",
         "container-interop/container-interop": "~1.1"
     },
     "require-dev": {
         "mockery/mockery": "dev-master@dev",
         "phpunit/phpunit": "*",
-        "satooshi/php-coveralls": "dev-master"
+        "satooshi/php-coveralls": "dev-master",
+        "mouf/picotainer" : "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -176,6 +176,7 @@ class RouteTest extends PHPUnit_Framework_TestCase
 
         $container = new Container();
         $route->setContainer($container);
+        $route->setCallableResolver(new \Slim\CallableResolver($container));
         $route->add('MiddlewareStub:run');
 
         $env = \Slim\Http\Environment::mock();


### PR DESCRIPTION
Hi guys,

Sorry to open the thread about DIC independence again, container-interop and PSR-11 editor here :)

I was aware Slim was using ContainerInterop but until recently, I did not have time to get a good look at it.

I'm sorry I did not step up earlier, but I have some kind of a weird feeling. I saw you have developed a `Container` class that extends Pimple and adds 9 services to it. Anyone willing to add its own container should configure it with those exact nine services.

To me, it looks like you are using containers as service locators. Let me explain:
- Slim expects the services to have some name (`request`, `environment`, `router`...)
- It means that rather than having the container configuring Slim, it is Slim that puts expectations on the container
- It might seem strange, but having expectations on how things are named in a container is a strong assertion. For containers based
  on autowiring, it is customary to name an entry in the container by the name of the class or interface it represents rather than
  by an identifier.

Also, I see you have expectations about whether an entry should return always the same instance or a new instance (the 'factory' method of Pimple). For instance, the `request` entry should always be a new instance.

``` php
/**
 * This service MUST return a NEW instance
 * of \Psr\Http\Message\ServerRequestInterface.
 */
$this['request'] = $this->factory( //...
```

Be aware that container-interop states that a container **SHOULD return always the same instance**. Therefore, it is unlikely that many containers will offer the feature of creating a new instance when `get` is called. It means that you are restricting the type of containers that can be integrated into Slim.

I'm starting to wonder if Slim as any need for a container. If you really want to make Slim container independent, shouldn't you rather remove all containers from Slim (and design Slim so that it can be easily configured by an external container?)

Let me explain:

The App constuctor might look like this:

``` php
class App {
    function __construct(Configuration $conf) {
        $this->conf = $conf;
    }
}
```

You could have a simple `Configuration` class that is in charge of the services used by Slim.

``` php
class Configuration {
    // getEnvironment
    // setEnvironment

    // getRequest
    // setRequest

    // getResponse
    // setResponse

    // getRouter
    // setRouter

    //...
}
```

Of course, if no setter is called, the getter is returning the "default" value for Slim.

Now, from the container point-of-view, it is easy to have an "App" instance that binds to a "Configuration" instance. In this "Configuration",
it is easy to overload any parameter used by Slim.

This way, Slim is both container independent AND container friendly. No need for container-interop, nor PSR-11, nor Pimple!

I'm by no means a Slim expert, so I'm probably overlooking several problems, but I'd be curious to know what you think about it.

**Important**: I'm not saying that Slim should not rely on container-interop or PSR-11. There are plenty of very good use cases for using
container-interop, but I'm not sure the usage I see today in the code is the best one. Have a look at mnapoli's [Invoker](https://github.com/PHP-DI/Invoker) project. It makes use 
of container-interop in a special way (resolving function parameters based on type-hint or parameter name, just like in AngularJS).
Actually, the more I think about it, the more I'd like to see such a feature in Slim :) But that's a completely different issue.

@mnapoli, I'd be curious to know what you think about my proposal here. Do you think using Container-interop the way it is used today makes sense?
