### PR TITLE
Allow use of FastRoute's cachedDispatcher

### DIFF
--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -90,6 +90,19 @@ interface RouteInterface
     public function prepare(ServerRequestInterface $request, array $arguments);
 
     /**
+     * Run route
+     *
+     * This method traverses the middleware stack, including the route's callable
+     * and captures the resultant HTTP response object. It then sends the response
+     * back to the Application.
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return ResponseInterface
+     */
+    public function run(ServerRequestInterface $request, ResponseInterface $response);
+
+    /**
      * Dispatch route callable against current Request and Response objects
      *
      * This method invokes the route object's callable. If middleware is

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -65,11 +65,18 @@ interface RouterInterface
      *
      * @param string $name        Route name
      *
-     * @return Route
+     * @return \Slim\Interfaces\RouteInterface
      *
      * @throws RuntimeException   If named route does not exist
      */
     public function getNamedRoute($name);
+
+    /**
+     * @param $identifier
+     *
+     * @return \Slim\Interfaces\RouteInterface
+     */
+    public function lookupRoute($identifier);
 
     /**
      * Build the path for a named route

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -34,6 +34,13 @@ class Route extends Routable implements RouteInterface
     protected $methods = [];
 
     /**
+     * Route identifier
+     *
+     * @var string
+     */
+    protected $identifier;
+
+    /**
      * Route name
      *
      * @var null|string
@@ -71,12 +78,13 @@ class Route extends Routable implements RouteInterface
      * @param callable     $callable The route callable
      * @param RouteGroup[] $groups The parent route groups
      */
-    public function __construct($methods, $pattern, $callable, $groups = [])
+    public function __construct($methods, $pattern, $callable, $groups = [], $identifier = 0)
     {
         $this->methods  = $methods;
         $this->pattern  = $pattern;
         $this->callable = $callable;
         $this->groups   = $groups;
+        $this->identifier = 'route' . $identifier;
     }
 
     /**
@@ -152,6 +160,16 @@ class Route extends Routable implements RouteInterface
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * Get route identifier
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
     }
 
     /**

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -161,7 +161,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->getRoutes()[0]);
+        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupDefaultSlash()
@@ -175,7 +175,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/foo', 'pattern', $router->getRoutes()[0]);
+        $this->assertAttributeEquals('/foo', 'pattern', $router->lookupRoute('route0'));
         
         $app = new App();
         $app->group('/foo', function () use ($app) {
@@ -186,7 +186,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->getRoutes()[0]);
+        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->lookupRoute('route0'));
         
         $app = new App();
         $app->group('/foo', function () use ($app) {
@@ -199,7 +199,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/foo/baz', 'pattern', $router->getRoutes()[0]);
+        $this->assertAttributeEquals('/foo/baz', 'pattern', $router->lookupRoute('route0'));
         
         $app = new App();
         $app->group('/foo', function () use ($app) {
@@ -210,7 +210,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/foo/bar/', 'pattern', $router->getRoutes()[0]);
+        $this->assertAttributeEquals('/foo/bar/', 'pattern', $router->lookupRoute('route0'));
     }
 
     /********************************************************************************

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -110,6 +110,12 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $prop->getValue($route));
     }
 
+    public function testIdentifier()
+    {
+        $route = $this->routeFactory();
+        $this->assertEquals('route0', $route->getIdentifier());
+    }
+
     public function testSetName()
     {
         $route = $this->routeFactory();

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -185,10 +185,12 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $method->setAccessible(true);
         $this->assertInstanceOf('\FastRoute\Dispatcher', $method->invoke($this->router));
     }
+
     public function testSetDispatcher()
     {
         $this->router->setDispatcher(\FastRoute\simpleDispatcher(function ($r) {
-            $r->addRoute('GET', '/', function () {});
+            $r->addRoute('GET', '/', function () {
+            });
         }));
         $class = new \ReflectionClass($this->router);
         $prop = $class->getProperty('dispatcher');

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -177,4 +177,22 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     {
         $this->router->setBasePath(['invalid']);
     }
+
+    public function testCreateDispatcher()
+    {
+        $class = new \ReflectionClass($this->router);
+        $method = $class->getMethod('createDispatcher');
+        $method->setAccessible(true);
+        $this->assertInstanceOf('\FastRoute\Dispatcher', $method->invoke($this->router));
+    }
+    public function testSetDispatcher()
+    {
+        $this->router->setDispatcher(\FastRoute\simpleDispatcher(function ($r) {
+            $r->addRoute('GET', '/', function () {});
+        }));
+        $class = new \ReflectionClass($this->router);
+        $prop = $class->getProperty('dispatcher');
+        $prop->setAccessible(true);
+        $this->assertInstanceOf('\FastRoute\Dispatcher', $prop->getValue($this->router));
+    }
 }


### PR DESCRIPTION
This would allow for changing out the dispatcher to use the cachedDispatcher, however the cachedDispatcher has some issues with the way we are handling routing. We also no longer need to extend `RouteCollector` as this all happens with the FastRoute function.

Example of how you would change the dispatcher.

``` php
$app = new Slim\App();
$app->get('/', function ($req, $res) {
    $res->write('Hello World');
});

// You can only change dispatcher after all your routes are defined 
// as you will need them for the cachedDispatcher

$router = $app->getContainer()['router'];
$router->setDispatcher(\FastRoute\cachedDispatcher(function ($r) use ($router) {
  foreach ($router->getRoutes() as $route) {
    $r->addRoute($route->getMethods(), $route->getPattern(),  $route->getIdentifier());
  }
}, [
    'cacheFile' => __DIR__ . '/route.cache'
]));

$app->run();
```

You will notice this throwing an error at the moment as FastRoute is using var_export to create the cache file and by default var_export attaches __set_state to all objects it exports, so on re-import when it imports the code it will look for that method on every object and closure it exported.

There is also a secondary issue with cachedDispatcher if you add more than 1 route where we have an issue of circular referencing.
