### PR TITLE
Various small fixes

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -10,6 +10,7 @@ namespace Slim;
 
 use Exception;
 use Closure;
+use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -70,7 +71,7 @@ class App
      * Create new application
      *
      * @param ContainerInterface|array $container Either a ContainerInterface or an associative array of application settings
-     * @throws Exception when no container is provided that implements ContainerInterface
+     * @throws InvalidArgumentException when no container is provided that implements ContainerInterface
      */
     public function __construct($container = [])
     {
@@ -78,7 +79,7 @@ class App
             $container = new Container($container);
         }
         if (!$container instanceof ContainerInterface) {
-            throw new Exception("Expected a ContainerInterface");
+            throw new InvalidArgumentException('Expected a ContainerInterface');
         }
         $this->container = $container;
     }

--- a/Slim/CallableResolverAwareTrait.php
+++ b/Slim/CallableResolverAwareTrait.php
@@ -34,7 +34,7 @@ trait CallableResolverAwareTrait
      */
     protected function resolveCallable($callable)
     {
-        if (!is_callable($callable) && is_string($callable)) {
+        if (is_string($callable) && !is_callable($callable)) {
             if ($this->container instanceof ContainerInterface) {
                 $container = $this->container;
             } else {

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -52,11 +52,13 @@ class Error
             $html
         );
 
+        $body = new Body(fopen('php://temp', 'r+'));
+        $body->write($output);
+
         return $response
                 ->withStatus(500)
                 ->withHeader('Content-type', 'text/html')
-                ->withBody(new Body(fopen('php://temp', 'r+')))
-                ->write($output);
+                ->withBody($body);
     }
 
     /**

--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -31,11 +31,13 @@ class NotAllowed
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $methods)
     {
+        $body = new Body(fopen('php://temp', 'r+'));
+        $body->write('<p>Method not allowed. Must be one of: ' . implode(', ', $methods) . '</p>');
+
         return $response
                 ->withStatus(405)
                 ->withHeader('Content-type', 'text/html')
                 ->withHeader('Allow', implode(', ', $methods))
-                ->withBody(new Body(fopen('php://temp', 'r+')))
-                ->write('<p>Method not allowed. Must be one of: ' . implode(', ', $methods) . '</p>');
+                ->withBody($body);
     }
 }

--- a/Slim/Handlers/NotFound.php
+++ b/Slim/Handlers/NotFound.php
@@ -64,9 +64,11 @@ class NotFound
 </html>
 END;
 
+        $body = new Body(fopen('php://temp', 'r+'));
+        $body->write($output);
+
         return $response->withStatus(404)
                         ->withHeader('Content-Type', 'text/html')
-                        ->withBody(new Body(fopen('php://temp', 'r+')))
-                        ->write($output);
+                        ->withBody($body);
     }
 }

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -54,7 +54,7 @@ class Headers extends Collection implements HeadersInterface
         $data = [];
         foreach ($environment as $key => $value) {
             $key = strtoupper($key);
-            if (strpos($key, 'HTTP_') === 0 || isset(static::$special[$key])) {
+            if (isset(static::$special[$key]) || strpos($key, 'HTTP_') === 0) {
                 if ($key !== 'HTTP_CONTENT_LENGTH') {
                     $data[$key] =  $value;
                 }

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -624,7 +624,7 @@ class Request implements ServerRequestInterface
                 $clone->headers->set('Host', $uri->getHost());
             }
         } else {
-            if ((!$this->hasHeader('Host') || $this->getHeader('Host') === null) && $this->uri->getHost() !== '') {
+            if ($this->uri->getHost() !== '' && (!$this->hasHeader('Host') || $this->getHeader('Host') === null)) {
                 $clone->headers->set('Host', $uri->getHost());
             }
         }

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -8,6 +8,7 @@
  */
 namespace Slim\Http;
 
+use Closure;
 use InvalidArgumentException;
 use RuntimeException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -1274,7 +1275,9 @@ class Request implements ServerRequestInterface
      */
     public function registerMediaTypeParser($mediaType, callable $callable)
     {
-        $callable = $callable->bindTo($this);
+        if ($callable instanceof Closure) {
+            $callable = $callable->bindTo($this);
+        }
         $this->bodyParsers[(string)$mediaType] = $callable;
     }
 

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -819,7 +819,7 @@ class Request implements ServerRequestInterface
             return strtolower($contentTypeParts[0]);
         }
 
-        return;
+        return null;
     }
 
     /**
@@ -859,7 +859,7 @@ class Request implements ServerRequestInterface
             return $mediaTypeParams['charset'];
         }
 
-        return;
+        return null;
     }
 
     /**

--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -75,7 +75,7 @@ class UploadedFile implements UploadedFileInterface
      */
     public static function createFromEnvironment(Environment $env)
     {
-        if ($env->has('slim.files') && is_array($env['slim.files'])) {
+        if (is_array($env['slim.files']) && $env->has('slim.files')) {
             return $env['slim.files'];
         } elseif (isset($_FILES)) {
             return static::parseUploadedFiles($_FILES);

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -105,6 +105,7 @@ class Uri implements UriInterface
      * @param int    $port     Uri port number.
      * @param string $path     Uri path.
      * @param string $query    Uri query string.
+     * @param string $fragment Uri fragment.
      * @param string $user     Uri user.
      * @param string $password Uri password.
      */

--- a/Slim/Interfaces/Http/HeadersInterface.php
+++ b/Slim/Interfaces/Http/HeadersInterface.php
@@ -16,5 +16,7 @@ namespace Slim\Interfaces\Http;
  */
 interface HeadersInterface extends CollectionInterface
 {
+    public function add($key, $value);
+
     public function normalizeKey($key);
 }


### PR DESCRIPTION
This pull request fixes some small potential issues. I used a separate commit for each type (so you have the option to cherry-pick/squash the ones you like).
- Resolved undefined method calls: There were some issues where a method of a Slim implementation was called, which would not work with another pure PSR-7 implementation. Note: The NotFoundHandler still uses the `Uri->getBasePath()`, but there is no useful equivalent in PSR-7.
- Added missing php document tag
- Used explicit `return null` statements instead of simply `return`
- Reordered checks in `if` statements to use the least expensive expression first
- Used a more explicit `InvalidArgumentException` instead of a general `Exception`
