### PR TITLE
Fix using CallableResolvable as group middleware

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -264,7 +264,9 @@ class App
      */
     public function group($pattern, $callable)
     {
+        /** @var RouteGroup $group */
         $group = $this->container->get('router')->pushGroup($pattern, $callable);
+        $group->setContainer($this->container);
         $group($this);
         $this->container->get('router')->popGroup();
         return $group;


### PR DESCRIPTION
The container was not available for resolving a CallableResolvable when invoking a RouteGroup

Should resolve #1377
