### PR TITLE
Body stream fixes

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -323,7 +323,11 @@ class App
                 $settings = $this->container->get('settings');
                 while (!$body->eof()) {
                     echo $body->read($settings['responseChunkSize']);
+                    if (connection_status() != CONNECTION_NORMAL) {
+                        break;
+                    }
                 }
+                $body->close();
             }
             $responded = true;
         }

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -327,8 +327,8 @@ class App
                         break;
                     }
                 }
-                $body->close();
             }
+
             $responded = true;
         }
     }

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -321,7 +321,7 @@ class Route extends Routable implements RouteInterface
             $response->getBody()->write($newResponse);
         }
 
-        if (isset($output)) {
+        if (!empty($output)) {
             if ($this->outputBuffering === 'prepend') {
                 // prepend output buffer content
                 $body = new Http\Body(fopen('php://temp', 'r+'));


### PR DESCRIPTION
There are few small fixes:
1. ob_start/ob_end_clean buffer now is not appended to the body if it is empty
2. stop reading body stream if connection was interrupted (important, if response body is huge)
