### PR TITLE
App responder fix and logic separation (alternative solution)

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -17,7 +17,6 @@ use Psr\Http\Message\ResponseInterface;
 use Interop\Container\ContainerInterface;
 use FastRoute\Dispatcher;
 use Slim\Exception\Exception as SlimException;
-use Slim\Http\Response;
 use Slim\Http\Uri;
 use Slim\Http\Headers;
 use Slim\Http\Body;

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -145,34 +145,6 @@ class App
     }
 
     /**
-     * Add route with multiple methods
-     *
-     * @param  string[] $methods  Numeric array of HTTP method names
-     * @param  string   $pattern  The route URI pattern
-     * @param  mixed    $callable The route callback routine
-     *
-     * @return RouteInterface
-     */
-    public function map(array $methods, $pattern, $callable)
-    {
-        $callable = is_string($callable) ? $this->resolveCallable($callable) : $callable;
-        if ($callable instanceof Closure) {
-            $callable = $callable->bindTo($this);
-        }
-
-        $route = $this->container->get('router')->map($methods, $pattern, $callable);
-        if (is_callable([$route, 'setContainer'])) {
-            $route->setContainer($this->container);
-        }
-
-        if (is_callable([$route, 'setOutputBuffering'])) {
-            $route->setOutputBuffering($this->container->get('settings')['outputBuffering']);
-        }
-
-        return $route;
-    }
-
-    /**
      * Add POST route
      *
      * @param  string $pattern  The route URI pattern
@@ -248,6 +220,34 @@ class App
     public function any($pattern, $callable)
     {
         return $this->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], $pattern, $callable);
+    }
+
+    /**
+     * Add route with multiple methods
+     *
+     * @param  string[] $methods  Numeric array of HTTP method names
+     * @param  string   $pattern  The route URI pattern
+     * @param  mixed    $callable The route callback routine
+     *
+     * @return RouteInterface
+     */
+    public function map(array $methods, $pattern, $callable)
+    {
+        $callable = is_string($callable) ? $this->resolveCallable($callable) : $callable;
+        if ($callable instanceof Closure) {
+            $callable = $callable->bindTo($this);
+        }
+
+        $route = $this->container->get('router')->map($methods, $pattern, $callable);
+        if (is_callable([$route, 'setContainer'])) {
+            $route->setContainer($this->container);
+        }
+
+        if (is_callable([$route, 'setOutputBuffering'])) {
+            $route->setOutputBuffering($this->container->get('settings')['outputBuffering']);
+        }
+
+        return $route;
     }
 
     /**


### PR DESCRIPTION
Alternative solution for my PR #1384 

I guess this one is much better for many reasons:
1. Good logic separation: `respond()` method should not modify Response object, it should just output headers and body. Instead I've added `finalize()` method, which finalizes response and returns finalized value.
2. Good for Unit testing of `run()` function, where you don't need `respond` method in most cases.
3. Now App itself is "reusable" in Unit tests. For huge projects it is critical. For example unit tests for my project run almost for 40 minutes if I create App object from scratch all the time (with all Middleware, Redis/ElasticSearch/Doctrine/Acl/S3/etc settings). But if I make App object static and reusable for all my Test Cases and only inject new response/request objects - unit tests run only 15 minutes. Before it was not possible to "reuse" App because of static variable `$responded = true` inside `respond()` method.
