### PR TITLE
Introduce a reusable RequestBody and ensure Body::__toString() rewinds properly

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -155,12 +155,12 @@ class Request implements ServerRequestInterface
         $headers = Headers::createFromEnvironment($environment);
         $cookies = Cookies::parseHeader($headers->get('Cookie', []));
         $serverParams = $environment->all();
-        $body = new Body(fopen('php://input', 'r'));
+        $body = new RequestBody();
         $uploadedFiles = UploadedFile::createFromEnvironment($environment);
 
         $request = new static($method, $uri, $headers, $cookies, $serverParams, $body, $uploadedFiles);
 
-        if ($request->isPost() &&
+        if ($method === 'POST' &&
             in_array($request->getMediaType(), ['application/x-www-form-urlencoded', 'multipart/form-data'])
         ) {
             // parsed body must be $_POST
@@ -302,6 +302,10 @@ class Request implements ServerRequestInterface
                     $this->method = $this->filterMethod($body->_METHOD);
                 } elseif (is_array($body) && isset($body['_METHOD'])) {
                     $this->method = $this->filterMethod($body['_METHOD']);
+                }
+
+                if ($this->getBody()->eof()) {
+                    $this->getBody()->rewind();
                 }
             }
         }

--- a/Slim/Http/RequestBody.php
+++ b/Slim/Http/RequestBody.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/codeguy/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/codeguy/Slim/blob/master/LICENSE (MIT License)
+ */
+namespace Slim\Http;
+
+/**
+ * Provides a PSR-7 implementation of a reusable raw request body
+ */
+class RequestBody extends Body
+{
+    /**
+     * Create a new RequestBody.
+     */
+    public function __construct()
+    {
+        $stream = fopen('php://temp', 'w+');
+        stream_copy_to_stream(fopen('php://input', 'r'), $stream);
+        rewind($stream);
+
+        parent::__construct($stream);
+    }
+}

--- a/Slim/Http/Stream.php
+++ b/Slim/Http/Stream.php
@@ -178,7 +178,16 @@ class Stream implements StreamInterface
      */
     public function __toString()
     {
-        return $this->isAttached() ? (string)stream_get_contents($this->stream, -1, 0) : '';
+        if (!$this->isAttached()) {
+            return '';
+        }
+
+        try {
+            $this->rewind();
+            return $this->getContents();
+        } catch (RuntimeException $e) {
+            return '';
+        }
     }
 
     /**

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -10,7 +10,7 @@
 use \Slim\App;
 use \Slim\Http\Environment;
 use \Slim\Http\Uri;
-use \Slim\Http\Body;
+use \Slim\Http\RequestBody;
 use \Slim\Http\Headers;
 use \Slim\Http\Request;
 use \Slim\Http\Response;
@@ -238,7 +238,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('POST', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -270,7 +270,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -298,7 +298,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -326,7 +326,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -354,7 +354,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -387,7 +387,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -415,7 +415,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -445,7 +445,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -468,7 +468,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -505,7 +505,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -537,7 +537,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -578,7 +578,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
@@ -605,7 +605,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $req = $req->withAttribute("one", 1);
         $res = new Response();
@@ -638,7 +638,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $req = $req->withAttribute("one", 1);
         $res = new Response();
@@ -717,7 +717,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -10,6 +10,7 @@
 use \Slim\App;
 use \Slim\Http\Environment;
 use \Slim\Http\Uri;
+use \Slim\Http\Body;
 use \Slim\Http\RequestBody;
 use \Slim\Http\Headers;
 use \Slim\Http\Request;

--- a/tests/Http/BodyTest.php
+++ b/tests/Http/BodyTest.php
@@ -51,6 +51,10 @@ class BodyTest extends PHPUnit_Framework_TestCase
      * This method creates a new resource, and it seeds
      * the resource with lorem ipsum text. The returned
      * resource is readable, writable, and seekable.
+     *
+     * @param string $mode
+     *
+     * @return resource
      */
     public function resourceFactory($mode = 'r+')
     {
@@ -153,7 +157,15 @@ class BodyTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($this->text, (string)$body);
     }
 
+    public function testToStringAttachedRewindsFirst()
+    {
+        $this->stream = $this->resourceFactory();
+        $body = new \Slim\Http\Body($this->stream);
 
+        $this->assertEquals($this->text, (string)$body);
+        $this->assertEquals($this->text, (string)$body);
+        $this->assertEquals($this->text, (string)$body);
+    }
 
     public function testToStringDetached()
     {

--- a/tests/Http/RequestBodyTest.php
+++ b/tests/Http/RequestBodyTest.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/codeguy/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/codeguy/Slim/blob/master/LICENSE (MIT License)
+ */
+class RequestBodyTest extends PHPUnit_Framework_TestCase
+{
+    /** @var string */
+    protected $text = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+    /** @var resource */
+    protected $stream;
+    /** @var \Slim\Http\RequestBody */
+    protected $body;
+
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->body = new \Slim\Http\RequestBody();
+        $this->body->write($this->text);
+        $this->body->rewind();
+    }
+
+    protected function tearDown()
+    {
+        if (is_resource($this->stream) === true) {
+            fclose($this->stream);
+        }
+        $this->body = null;
+    }
+
+    /**
+     * This method creates a new resource, and it seeds
+     * the resource with lorem ipsum text. The returned
+     * resource is readable, writable, and seekable.
+     *
+     * @param string $mode
+     *
+     * @return resource
+     */
+    public function resourceFactory($mode = 'r+')
+    {
+        $stream = fopen('php://temp', $mode);
+        fwrite($stream, $this->text);
+        rewind($stream);
+
+        return $stream;
+    }
+
+    public function testConstructorAttachesStream()
+    {
+        $bodyStream = new \ReflectionProperty($this->body, 'stream');
+        $bodyStream->setAccessible(true);
+
+        $this->assertInternalType('resource', $bodyStream->getValue($this->body));
+    }
+
+    public function testConstructorSetsMetadata()
+    {
+        $bodyMetadata = new \ReflectionProperty($this->body, 'meta');
+        $bodyMetadata->setAccessible(true);
+
+        $this->assertTrue(is_array($bodyMetadata->getValue($this->body)));
+    }
+
+    public function testGetMetadata()
+    {
+        $this->assertTrue(is_array($this->body->getMetadata()));
+    }
+
+    public function testGetMetadataKey()
+    {
+        $this->assertEquals('php://temp', $this->body->getMetadata('uri'));
+    }
+
+    public function testGetMetadataKeyNotFound()
+    {
+        $this->assertNull($this->body->getMetadata('foo'));
+    }
+
+    public function testDetach()
+    {
+        $bodyStream = new \ReflectionProperty($this->body, 'stream');
+        $bodyStream->setAccessible(true);
+
+        $bodyMetadata = new \ReflectionProperty($this->body, 'meta');
+        $bodyMetadata->setAccessible(true);
+
+        $bodyReadable = new \ReflectionProperty($this->body, 'readable');
+        $bodyReadable->setAccessible(true);
+
+        $bodyWritable = new \ReflectionProperty($this->body, 'writable');
+        $bodyWritable->setAccessible(true);
+
+        $bodySeekable = new \ReflectionProperty($this->body, 'seekable');
+        $bodySeekable->setAccessible(true);
+
+        $result = $this->body->detach();
+
+        $this->assertInternalType('resource', $result);
+        $this->assertNull($bodyStream->getValue($this->body));
+        $this->assertNull($bodyMetadata->getValue($this->body));
+        $this->assertNull($bodyReadable->getValue($this->body));
+        $this->assertNull($bodyWritable->getValue($this->body));
+        $this->assertNull($bodySeekable->getValue($this->body));
+    }
+
+    public function testToStringAttached()
+    {
+        $this->assertEquals($this->text, (string)$this->body);
+    }
+
+    public function testToStringAttachedRewindsFirst()
+    {
+        $this->assertEquals($this->text, (string)$this->body);
+        $this->assertEquals($this->text, (string)$this->body);
+        $this->assertEquals($this->text, (string)$this->body);
+    }
+
+    public function testToStringDetached()
+    {
+        $bodyStream = new \ReflectionProperty($this->body, 'stream');
+        $bodyStream->setAccessible(true);
+        $bodyStream->setValue($this->body, null);
+
+        $this->assertEquals('', (string)$this->body);
+    }
+
+    public function testClose()
+    {
+        $this->body->close();
+
+        $this->assertAttributeEquals(null, 'stream', $this->body);
+        $this->assertFalse($this->body->isReadable());
+        $this->assertFalse($this->body->isWritable());
+        $this->assertEquals('', (string)$this->body);
+
+        $this->setExpectedException('RuntimeException');
+        $this->body->tell();
+    }
+
+    public function testGetSizeAttached()
+    {
+        $this->assertEquals(mb_strlen($this->text), $this->body->getSize());
+    }
+
+    public function testGetSizeDetached()
+    {
+        $bodyStream = new \ReflectionProperty($this->body, 'stream');
+        $bodyStream->setAccessible(true);
+        $bodyStream->setValue($this->body, null);
+
+        $this->assertNull($this->body->getSize());
+    }
+
+    public function testTellAttached()
+    {
+        $this->body->seek(10);
+
+        $this->assertEquals(10, $this->body->tell());
+    }
+
+    public function testTellDetachedThrowsRuntimeException()
+    {
+        $bodyStream = new \ReflectionProperty($this->body, 'stream');
+        $bodyStream->setAccessible(true);
+        $bodyStream->setValue($this->body, null);
+
+        $this->setExpectedException('\RuntimeException');
+        $this->body->tell();
+    }
+
+    public function testEofAttachedFalse()
+    {
+        $this->body->seek(10);
+
+        $this->assertFalse($this->body->eof());
+    }
+
+    public function testEofAttachedTrue()
+    {
+        while ($this->body->eof() === false) {
+            $this->body->read(1024);
+        }
+
+        $this->assertTrue($this->body->eof());
+    }
+
+    public function testEofDetached()
+    {
+        $bodyStream = new \ReflectionProperty($this->body, 'stream');
+        $bodyStream->setAccessible(true);
+        $bodyStream->setValue($this->body, null);
+
+        $this->assertTrue($this->body->eof());
+    }
+
+    public function testIsReadableAttachedTrue()
+    {
+        $this->assertTrue($this->body->isReadable());
+    }
+
+    public function testIsReadableDetached()
+    {
+        $this->body->detach();
+
+        $this->assertFalse($this->body->isReadable());
+    }
+
+    public function testIsWritableAttachedTrue()
+    {
+        $this->assertTrue($this->body->isWritable());
+    }
+
+    public function testIsWritableDetached()
+    {
+        $this->body->detach();
+
+        $this->assertFalse($this->body->isWritable());
+    }
+
+    public function isSeekableAttachedTrue()
+    {
+        $this->assertTrue($this->body->isSeekable());
+    }
+
+    // TODO: Is seekable is false when attached... how?
+
+    public function testIsSeekableDetached()
+    {
+        $this->body->detach();
+
+        $this->assertFalse($this->body->isSeekable());
+    }
+
+    public function testSeekAttached()
+    {
+        $this->body->seek(10);
+
+        $this->assertEquals(10, $this->body->tell());
+    }
+
+    public function testSeekDetachedThrowsRuntimeException()
+    {
+        $this->body->detach();
+
+        $this->setExpectedException('\RuntimeException');
+        $this->body->seek(10);
+    }
+
+    public function testRewindAttached()
+    {
+        $this->body->seek(10);
+        $this->body->rewind();
+
+        $this->assertEquals(0, $this->body->tell());
+    }
+
+    public function testRewindDetachedThrowsRuntimeException()
+    {
+        $this->body->detach();
+
+        $this->setExpectedException('\RuntimeException');
+        $this->body->rewind();
+    }
+
+    public function testReadAttached()
+    {
+        $this->assertEquals(substr($this->text, 0, 10), $this->body->read(10));
+    }
+
+    public function testReadDetachedThrowsRuntimeException()
+    {
+        $this->body->detach();
+
+        $this->setExpectedException('\RuntimeException');
+        $this->body->read(10);
+    }
+
+    public function testWriteAttached()
+    {
+        while ($this->body->eof() === false) {
+            $this->body->read(1024);
+        }
+        $this->body->write('foo');
+
+        $this->assertEquals($this->text . 'foo', (string)$this->body);
+    }
+
+    public function testWriteDetachedThrowsRuntimeException()
+    {
+        $this->body->detach();
+
+        $this->setExpectedException('\RuntimeException');
+        $this->body->write('foo');
+    }
+
+    public function testGetContentsAttached()
+    {
+        $this->body->seek(10);
+
+        $this->assertEquals(substr($this->text, 10), $this->body->getContents());
+    }
+
+    public function testGetContentsDetachedThrowsRuntimeException()
+    {
+        $this->body->detach();
+
+        $this->setExpectedException('\RuntimeException');
+        $this->body->getContents();
+    }
+}

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -32,7 +32,7 @@
 use \Slim\Http\Uri;
 use \Slim\Http\Headers;
 use \Slim\Http\Collection;
-use \Slim\Http\Body;
+use \Slim\Http\RequestBody;
 use \Slim\Http\Request;
 
 class RequestTest extends PHPUnit_Framework_TestCase
@@ -48,7 +48,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
             'id' => '123',
         ];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $uploadedFiles = \Slim\Http\UploadedFile::createFromEnvironment($env);
         $request = new Request('GET', $uri, $headers, $cookies, $serverParams, $body, $uploadedFiles);
 
@@ -62,7 +62,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse(property_exists($request, 'foo'));
     }
-    
+
     public function testAddsHostHeaderFromUri()
     {
         $request = $this->requestFactory();
@@ -138,7 +138,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         ]);
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $request = new Request('POST', $uri, $headers, $cookies, $serverParams, $body);
 
         $this->assertEquals('PUT', $request->getMethod());
@@ -153,7 +153,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         ]);
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('_METHOD=PUT');
         $body->rewind();
         $request = new Request('POST', $uri, $headers, $cookies, $serverParams, $body);
@@ -170,7 +170,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         ]);
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('_METHOD=PUT');
         $body->rewind();
         $request = new Request('POST', $uri, $headers, $cookies, $serverParams, $body);
@@ -191,7 +191,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $headers = new Headers();
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $request = new Request('FOO', $uri, $headers, $cookies, $serverParams, $body);
     }
 
@@ -204,7 +204,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $headers = new Headers();
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $request = new Request(10, $uri, $headers, $cookies, $serverParams, $body);
     }
 
@@ -287,7 +287,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         ]);
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $request = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
 
         $this->assertTrue($request->isXhr());
@@ -343,7 +343,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $headers = new Headers();
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $request = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
 
         $this->assertSame($uri, $request->getUri());
@@ -359,7 +359,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $headers = new Headers();
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $request = new Request('GET', $uri1, $headers, $cookies, $serverParams, $body);
         $clone = $request->withUri($uri2);
 
@@ -742,7 +742,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     public function testGetBody()
     {
-        $bodyNew = new Body(fopen('php://temp', 'r+'));
+        $bodyNew = new RequestBody(fopen('php://temp', 'r+'));
         $request = $this->requestFactory();
         $bodyProp = new \ReflectionProperty($request, 'body');
         $bodyProp->setAccessible(true);
@@ -753,7 +753,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     public function testWithBody()
     {
-        $bodyNew = new Body(fopen('php://temp', 'r+'));
+        $bodyNew = new RequestBody(fopen('php://temp', 'r+'));
         $request = $this->requestFactory()->withBody($bodyNew);
 
         $this->assertAttributeSame($bodyNew, 'body', $request);
@@ -767,7 +767,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $headers->set('Content-Type', 'application/x-www-form-urlencoded;charset=utf8');
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('foo=bar');
         $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
         $this->assertEquals((object)['foo' => 'bar'], $request->getParsedBody());
@@ -781,7 +781,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $headers->set('Content-Type', 'application/json;charset=utf8');
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('{"foo":"bar"}');
         $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
 
@@ -796,7 +796,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $headers->set('Content-Type', 'application/xml;charset=utf8');
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('<person><name>Josh</name></person>');
         $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
 
@@ -834,7 +834,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         ]);
         $cookies = [];
         $serverParams = [];
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('{"foo": "bar"}');
         $body->rewind();
         $request = new Request('POST', $uri, $headers, $cookies, $serverParams, $body);
@@ -865,7 +865,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     public function testGetParameterFromBody()
     {
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('foo=bar');
         $body->rewind();
         $request = $this->requestFactory()
@@ -884,7 +884,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     public function testGetParameterFromBodyOverQuery()
     {
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('abc=xyz');
         $body->rewind();
         $request = $this->requestFactory()
@@ -895,7 +895,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     public function testGetParameterWithDefaultFromBodyOverQuery()
     {
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('abc=xyz');
         $body->rewind();
         $request = $this->requestFactory()
@@ -907,7 +907,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     public function testGetParameters()
     {
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('foo=bar');
         $body->rewind();
         $request = $this->requestFactory()
@@ -919,7 +919,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
 
     public function testGetParametersWithBodyPriority()
     {
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $body->write('foo=bar&abc=xyz');
         $body->rewind();
         $request = $this->requestFactory()
@@ -942,7 +942,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
             'REMOTE_ADDR' => '192.168.1.1'
         ]);
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $request = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
 
         $this->assertEquals('192.168.1.1', $request->getIp());
@@ -956,7 +956,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $env = Slim\Http\Environment::mock();
         $serverParams = $env->all();
         unset($serverParams['REMOTE_ADDR']);
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $request = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
 
         $this->assertNull($request->getIp());
@@ -971,7 +971,7 @@ class RequestTest extends PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody(fopen('php://temp', 'r+'));
         $request = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
 
         $this->assertEquals('192.168.1.3', $request->getIp());

--- a/tests/Http/UploadedFilesTest.php
+++ b/tests/Http/UploadedFilesTest.php
@@ -8,7 +8,7 @@
  */
 namespace Slim\Tests\Http;
 
-use Slim\Http\Body;
+use Slim\Http\RequestBody;
 use Slim\Http\Environment;
 use Slim\Http\Headers;
 use Slim\Http\Request;
@@ -184,7 +184,7 @@ class UploadedFilesTest extends \PHPUnit_Framework_TestCase
         $headers = Headers::createFromEnvironment($env);
         $cookies = [];
         $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
+        $body = new RequestBody();
         $uploadedFiles = UploadedFile::createFromEnvironment($env);
         $request = new Request('GET', $uri, $headers, $cookies, $serverParams, $body, $uploadedFiles);
 


### PR DESCRIPTION
This introduces a reusable RequestBody implementation that by default copies the `php://input` stream, which can only be read one time, to a `php://temp` stream that can be re-wound and re-read.

Also makes sure `Body::__toString()` does not throw any exceptions.

This should address issue #1386.
