### PR TITLE
PSR-2 code style without errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,13 @@ php:
   - hhvm
 
 before_script:
-  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls:dev-master -n ; fi
+  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls:dev-master squizlabs/php_codesniffer:2.* -n ; fi
   - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then composer install -n ; fi
 
 script:
   - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then mkdir -p build/logs && phpunit --coverage-clover build/logs/clover.xml ; fi
   - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then phpunit ; fi
+  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then vendor/bin/phpcs --standard=PSR2 --ignore=vendor/* -n -p . ; fi
 
 after_script:
   - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then php vendor/bin/coveralls -v ; fi

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -9,8 +9,8 @@
 namespace Slim\Handlers;
 
 use Exception;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Slim\Http\Body;
 
 /**
@@ -38,7 +38,6 @@ class Error
         $html .= $this->renderException($exception);
 
         while ($exception = $exception->getPrevious()) {
-
             $html .= '<h2>Previous exception</h2>';
             $html .= $this->renderException($exception);
         }

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -12,8 +12,6 @@ use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Slim\Interfaces\Http\HeadersInterface;
-use Slim\Http\Headers;
-use Slim\Http\Body;
 
 /**
  * Response
@@ -533,13 +531,13 @@ class Response implements ResponseInterface
     {
         return $this->withStatus($status)->withHeader('Location', $url);
     }
-    
+
     /**
      * Json.
      *
      * Note: This method is not part of the PSR-7 standard.
      *
-     * This method prepares the response object to return an HTTP Json 
+     * This method prepares the response object to return an HTTP Json
      * response to the client.
      *
      * @param  mixed  $data   The data
@@ -548,12 +546,12 @@ class Response implements ResponseInterface
      * @return self
      */
     public function withJson($data, $status = 200, $encodingOptions = 0)
-    {        
+    {
         $body = $this->getBody();
         $body->rewind();
-        $body->write(json_encode($data,$encodingOptions));
-        
-        return $this->withStatus($status)->withHeader('Content-Type','application/json;charset=utf-8');
+        $body->write(json_encode($data, $encodingOptions));
+
+        return $this->withStatus($status)->withHeader('Content-Type', 'application/json;charset=utf-8');
     }
 
     /**

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -54,7 +54,7 @@ class RouteGroup extends Routable implements RouteGroupInterface
      *
      * @param App $app The App to bind the callable to.
      */
-    function __invoke(App $app)
+    public function __invoke(App $app)
     {
         $callable = $this->resolveCallable($this->callable);
         if ($callable instanceof Closure) {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -543,12 +543,16 @@ class AppTest extends \PHPUnit_Framework_TestCase
     public function testInvokeFunctionName()
     {
         $app = new App();
+
+        // @codingStandardsIgnoreStart
         function handle($req, $res)
         {
             $res->write('foo');
 
             return $res;
         }
+        // @codingStandardsIgnoreEnd
+
         $app->get('/foo', __NAMESPACE__ . '\handle');
 
         // Prepare request and response objects

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -40,11 +40,14 @@ class CallableResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testFunctionName()
     {
+        // @codingStandardsIgnoreStart
         function testCallable()
         {
             static $called_count = 0;
             return $called_count++;
         };
+        // @codingStandardsIgnoreEnd
+
         $resolver = new CallableResolver($this->container, __NAMESPACE__ . '\testCallable');
         $resolver();
         $this->assertEquals(1, testCallable());

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -41,7 +41,9 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             echo sprintf('Hello %s %s', $args['first'], $args['last']);
         };
 
-        $this->router->pushGroup('/prefix', function () {});
+        $this->router->pushGroup('/prefix', function () {
+
+        });
         $route = $this->router->map($methods, $pattern, $callable);
         $this->router->popGroup();
 


### PR DESCRIPTION
Fix the remaining PSR-2 code style errors.
I also added PHP Code Sniffer to Travis. The build for PHP 5.6 will fail if errors are detected (warnings are ignored).
