### PR TITLE
Simplify check if response is empty

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -565,7 +565,7 @@ class Response implements ResponseInterface
      */
     public function isEmpty()
     {
-        return in_array($this->getStatusCode(), [201, 204, 304]);
+        return in_array($this->getStatusCode(), [204, 205, 304]);
     }
 
     /**

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -786,4 +786,29 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(500, $resOut->getStatusCode());
         $this->expectOutputRegex('/.*middleware exception.*/');
     }
+
+    public function testFinalize()
+    {
+        $method = new \ReflectionMethod('Slim\App', 'finalize');
+        $method->setAccessible(true);
+
+        $response = new Response();
+        $response->write('foo');
+
+        $response = $method->invoke(new App(), $response);
+
+        $this->assertTrue($response->hasHeader('Content-Length'));
+        $this->assertEquals('3', $response->getHeaderLine('Content-Length'));
+    }
+
+    public function testFinalizeWithoutBody()
+    {
+        $method = new \ReflectionMethod('Slim\App', 'finalize');
+        $method->setAccessible(true);
+
+        $response = $method->invoke(new App(), new Response(304));
+
+        $this->assertFalse($response->hasHeader('Content-Length'));
+        $this->assertFalse($response->hasHeader('Content-Type'));
+    }
 }

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -271,7 +271,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response = new Response();
         $prop = new ReflectionProperty($response, 'status');
         $prop->setAccessible(true);
-        $prop->setValue($response, 201);
+        $prop->setValue($response, 204);
 
         $this->assertTrue($response->isEmpty());
     }


### PR DESCRIPTION
Removed code duplication to check if the response must not have a body by adding a helper method to the `App` class.

I also added status `205 Reset Content` to the list of response codes without a body (see https://tools.ietf.org/html/rfc7231#section-6.3.2).

In the `Response` class I removed status `201 Created` from the list of empty responses, since this response can have a body describing the representation just created.
