### PR TITLE
Clean up composer dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,7 @@
         "container-interop/container-interop": "~1.1"
     },
     "require-dev": {
-        "mockery/mockery": "dev-master@dev",
-        "phpunit/phpunit": "*",
-        "satooshi/php-coveralls": "dev-master"
+        "phpunit/phpunit": "^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Removed mockery (not used) and coveralls (only used by Travis, which installs the package in the build script anyway).

I also added a version constraint to PHPUnit, to avoid potential issues in the future.
