### PR TITLE
Add method to get the route name

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1350,4 +1350,21 @@ class Request implements ServerRequestInterface
 
         return isset($this->serverParams['REMOTE_ADDR']) ? $this->serverParams['REMOTE_ADDR'] : null;
     }
+
+    /**
+     * Get the route name.
+     *
+     * Note: This method is not part of the PSR-7 standard.
+     *
+     * @return string|null Route name or null if none found.
+     */
+    public function getRouteName()
+    {
+        $routeInfo = $this->getAttribute('routeInfo');
+        if (is_array($routeInfo) && isset($routeInfo[1][0])) {
+            return $routeInfo[1][0]->getName();
+        }
+
+        return null;
+    }
 }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -967,4 +967,34 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('192.168.1.3', $request->getIp());
     }
+
+    /**
+     * @covers Slim\Http\Request::getRouteName
+     */
+    public function testGetRouteName()
+    {
+        $route = $this->getMockBuilder('Slim\Route')->disableOriginalConstructor()->getMock();
+        $route->expects($this->once())->method('getName')->will($this->returnValue('phpunit'));
+
+        $routeInfo = [
+            0 => 1,
+            1 => [
+                0 => $route,
+                1 => 'run',
+            ],
+            2 => [],
+            'request' => ['GET', '/foo']
+        ];
+
+        $request = $this->requestFactory()->withAttribute('routeInfo', $routeInfo);
+        $this->assertEquals('phpunit', $request->getRouteName());
+    }
+
+    /**
+     * @covers Slim\Http\Request::getRouteName
+     */
+    public function testGetRouteNameWithoutRoute()
+    {
+        $this->assertNull($this->requestFactory()->getRouteName());
+    }
 }


### PR DESCRIPTION
Added a method to the `Request` object to get the route name of the request. This is very useful if you map multiple routes to the same callback and have to decide which route was called.
