### PR TITLE
Return successful response for OPTIONS

### DIFF
--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -31,13 +31,23 @@ class NotAllowed
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $methods)
     {
+        $allow = implode(', ', $methods);
         $body = new Body(fopen('php://temp', 'r+'));
-        $body->write('<p>Method not allowed. Must be one of: ' . implode(', ', $methods) . '</p>');
+
+        if ($request->getMethod() === 'OPTIONS') {
+            $status = 200;
+            $contentType = 'text/plain';
+            $body->write('Allowed methods: ' . $allow);
+        } else {
+            $status = 405;
+            $contentType = 'text/html';
+            $body->write('<p>Method not allowed. Must be one of: ' . $allow . '</p>');
+        }
 
         return $response
-                ->withStatus(405)
-                ->withHeader('Content-type', 'text/html')
-                ->withHeader('Allow', implode(', ', $methods))
+                ->withStatus($status)
+                ->withHeader('Content-type', $contentType)
+                ->withHeader('Allow', $allow)
                 ->withBody($body);
     }
 }

--- a/tests/Handlers/NotAllowedTest.php
+++ b/tests/Handlers/NotAllowedTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Handlers;
+
+use Slim\Handlers\NotAllowed;
+use Slim\Http\Response;
+
+class NotAllowedTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInvalidMethod()
+    {
+        $notAllowed = new NotAllowed();
+
+        /** @var Response $res */
+        $res = $notAllowed->__invoke($this->getRequest('GET'), new Response(), ['POST', 'PUT']);
+
+        $this->assertSame(405, $res->getStatusCode());
+        $this->assertTrue($res->hasHeader('Allow'));
+        $this->assertEquals('POST, PUT', $res->getHeaderLine('Allow'));
+    }
+
+    public function testOptions()
+    {
+        $notAllowed = new NotAllowed();
+
+        /** @var Response $res */
+        $res = $notAllowed->__invoke($this->getRequest('OPTIONS'), new Response(), ['POST', 'PUT']);
+
+        $this->assertSame(200, $res->getStatusCode());
+        $this->assertTrue($res->hasHeader('Allow'));
+        $this->assertEquals('POST, PUT', $res->getHeaderLine('Allow'));
+    }
+
+    /**
+     * @param string $method
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Slim\Http\Request
+     */
+    protected function getRequest($method)
+    {
+        $req = $this->getMockBuilder('Slim\Http\Request')->disableOriginalConstructor()->getMock();
+        $req->expects($this->once())->method('getMethod')->will($this->returnValue($method));
+
+        return $req;
+    }
+}


### PR DESCRIPTION
Currently, Slim responds to an OPTIONS call with an error:

```
HTTP/1.1 405 Method Not Allowed
Allow: GET, POST, PUT
Content-Type: text/html

<p>Method not allowed. Must be one of: GET, POST, PUT</p>
```

I think this is a bit weird, since you would either expect a similar response with a successful status code or a response with this status code and without information about the allowed methods.

With this pull request Slim responds with a successful status and a plain message:

```
HTTP/1.1 200 OK
Allow: GET, POST, PUT
Content-Type: text/plain

Allowed methods: GET, POST, PUT
```
