### PR TITLE
Correct path with Uri::createFromEnvironment & base path

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -195,12 +195,13 @@ class Uri implements UriInterface
         $virtualPath = $requestUri;
         if (strpos($requestUri, $requestScriptName) === 0) {
             $basePath = $requestScriptName;
-            $virtualPath = substr($requestUri, strlen($requestScriptName));
-        } elseif (strpos($requestUri, $requestScriptDir) === 0) {
+        } elseif ($requestScriptDir !== '/' && strpos($requestUri, $requestScriptDir) === 0) {
             $basePath = $requestScriptDir;
-            $virtualPath = substr($requestUri, strlen($requestScriptDir));
         }
-        $virtualPath = '/' . ltrim($virtualPath, '/');
+
+        if ($basePath) {
+            $virtualPath = ltrim(substr($requestUri, strlen($basePath)), '/');
+        }
 
         // Query string
         $queryString = $env->get('QUERY_STRING', '');
@@ -210,8 +211,11 @@ class Uri implements UriInterface
 
         // Build Uri
         $uri = new static($scheme, $host, $port, $virtualPath, $queryString, $fragment, $username, $password);
+        if ($basePath) {
+            $uri = $uri->withBasePath($basePath);
+        }
 
-        return $uri->withBasePath($basePath);
+        return $uri;
     }
 
     /********************************************************************************

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -577,7 +577,10 @@ class Uri implements UriInterface
             $basePath = '/' . trim($basePath, '/'); // <-- Trim on both sides
         }
         $clone = clone $this;
-        $clone->basePath = $this->filterPath($basePath);
+
+        if ($basePath !== '/') {
+            $clone->basePath = $this->filterPath($basePath);
+        }
 
         return $clone;
     }

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -527,6 +527,24 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('example3.com', $uri->getHost());
     }
 
+    /**
+     * @covers Slim\Http\Uri::createFromEnvironment
+     * @ticket 1375
+     */
+    public function testCreateEnvironmentWithBasePath()
+    {
+        $environment = Environment::mock([
+            'SCRIPT_NAME' => '/foo/index.php',
+            'REQUEST_URI' => '/foo/bar',
+        ]);
+        $uri = Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('/foo', $uri->getBasePath());
+        $this->assertEquals('bar', $uri->getPath());
+
+        $this->assertEquals('http://localhost/foo/bar', (string) $uri);
+    }
+
     public function testGetBaseUrl()
     {
         $environment = Environment::mock([

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -589,6 +589,10 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://josh:sekrit@example.com:8080/foo', $uri->getBaseUrl());
     }
 
+    /**
+     * @covers Slim\Http\Uri::createFromEnvironment
+     * @ticket 1380
+     */
     public function testWithPathWhenBaseRootIsEmpty()
     {
         $environment = \Slim\Http\Environment::mock([

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -301,6 +301,13 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals('/base', 'basePath', $uri);
     }
 
+    public function testWithBasePathIgnoresSlash()
+    {
+        $uri = $this->uriFactory()->withBasePath('/');
+
+        $this->assertAttributeEquals('', 'basePath', $uri);
+    }
+
     public function testGetPath()
     {
         $this->assertEquals('/foo/bar', $this->uriFactory()->getPath());


### PR DESCRIPTION
If you use `Uri::createFromEnvironment` the path is always set as an absolute path. This causes an issue if you have a base path, as the absolute path will ignore it (issue #1375).

``` php
'SCRIPT_NAME' => '/foo/index.php',
'REQUEST_URI' => '/foo/bar',
```

The current implementation creates the following values from the environment above:

```
Base: /foo
Path: /bar (absolute)
Result: /bar (wrong)
```

This pull request fixes this by using a relative path if the base path is available.

```
Base: /foo
Path: bar (relative)
Result: /foo/bar (correct)
```

Using a relative path is in line with PSR-7:

> If the path is intended to be domain-relative rather than path relative then it must begin with a slash ("/"). Paths not starting with a slash ("/") are assumed to be relative to some base path known to the application or consumer.
