### PR TITLE
Introduce common Message class

### DIFF
--- a/Slim/Http/Message.php
+++ b/Slim/Http/Message.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Http;
+
+use InvalidArgumentException;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Abstract message (base class for Request and Response)
+ *
+ * This class represents a general HTTP message. It provides common properties and methods for
+ * the HTTP request and response, as defined in the PSR-7 MessageInterface.
+ *
+ * @link https://github.com/php-fig/http-message/blob/master/src/MessageInterface.php
+ * @see Slim\Http\Request
+ * @see Slim\Http\Response
+ */
+abstract class Message implements MessageInterface
+{
+    /**
+     * Protocol version
+     *
+     * @var string
+     */
+    protected $protocolVersion = '1.1';
+
+    /**
+     * Headers
+     *
+     * @var \Slim\Interfaces\Http\HeadersInterface
+     */
+    protected $headers;
+
+    /**
+     * Body object
+     *
+     * @var \Psr\Http\Message\StreamInterface
+     */
+    protected $body;
+
+
+    /**
+     * Disable magic setter to ensure immutability
+     */
+    public function __set($name, $value)
+    {
+        // Do nothing
+    }
+
+    /*******************************************************************************
+     * Protocol
+     ******************************************************************************/
+
+    /**
+     * Retrieves the HTTP protocol version as a string.
+     *
+     * The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").
+     *
+     * @return string HTTP protocol version.
+     */
+    public function getProtocolVersion()
+    {
+        return $this->protocolVersion;
+    }
+
+    /**
+     * Return an instance with the specified HTTP protocol version.
+     *
+     * The version string MUST contain only the HTTP version number (e.g.,
+     * "1.1", "1.0").
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new protocol version.
+     *
+     * @param string $version HTTP protocol version
+     * @return static
+     * @throws InvalidArgumentException if the http version is an invalid number
+     */
+    public function withProtocolVersion($version)
+    {
+        static $valid = [
+            '1.0' => true,
+            '1.1' => true,
+            '2.0' => true,
+        ];
+        if (!isset($valid[$version])) {
+            throw new InvalidArgumentException('Invalid HTTP version. Must be one of: 1.0, 1.1, 2.0');
+        }
+        $clone = clone $this;
+        $clone->protocolVersion = $version;
+
+        return $clone;
+    }
+
+    /*******************************************************************************
+     * Headers
+     ******************************************************************************/
+
+    /**
+     * Retrieves all message header values.
+     *
+     * The keys represent the header name as it will be sent over the wire, and
+     * each value is an array of strings associated with the header.
+     *
+     *     // Represent the headers as a string
+     *     foreach ($message->getHeaders() as $name => $values) {
+     *         echo $name . ": " . implode(", ", $values);
+     *     }
+     *
+     *     // Emit headers iteratively:
+     *     foreach ($message->getHeaders() as $name => $values) {
+     *         foreach ($values as $value) {
+     *             header(sprintf('%s: %s', $name, $value), false);
+     *         }
+     *     }
+     *
+     * While header names are not case-sensitive, getHeaders() will preserve the
+     * exact case in which headers were originally specified.
+     *
+     * @return array Returns an associative array of the message's headers. Each
+     *     key MUST be a header name, and each value MUST be an array of strings
+     *     for that header.
+     */
+    public function getHeaders()
+    {
+        return $this->headers->all();
+    }
+
+    /**
+     * Checks if a header exists by the given case-insensitive name.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return bool Returns true if any header names match the given header
+     *     name using a case-insensitive string comparison. Returns false if
+     *     no matching header name is found in the message.
+     */
+    public function hasHeader($name)
+    {
+        return $this->headers->has($name);
+    }
+
+    /**
+     * Retrieves a message header value by the given case-insensitive name.
+     *
+     * This method returns an array of all the header values of the given
+     * case-insensitive header name.
+     *
+     * If the header does not appear in the message, this method MUST return an
+     * empty array.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return string[] An array of string values as provided for the given
+     *    header. If the header does not appear in the message, this method MUST
+     *    return an empty array.
+     */
+    public function getHeader($name)
+    {
+        return $this->headers->get($name, []);
+    }
+
+    /**
+     * Retrieves a comma-separated string of the values for a single header.
+     *
+     * This method returns all of the header values of the given
+     * case-insensitive header name as a string concatenated together using
+     * a comma.
+     *
+     * NOTE: Not all header values may be appropriately represented using
+     * comma concatenation. For such headers, use getHeader() instead
+     * and supply your own delimiter when concatenating.
+     *
+     * If the header does not appear in the message, this method MUST return
+     * an empty string.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @return string A string of values as provided for the given header
+     *    concatenated together using a comma. If the header does not appear in
+     *    the message, this method MUST return an empty string.
+     */
+    public function getHeaderLine($name)
+    {
+        return implode(',', $this->headers->get($name, []));
+    }
+
+    /**
+     * Return an instance with the provided value replacing the specified header.
+     *
+     * While header names are case-insensitive, the casing of the header will
+     * be preserved by this function, and returned from getHeaders().
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new and/or updated header and value.
+     *
+     * @param string $name Case-insensitive header field name.
+     * @param string|string[] $value Header value(s).
+     * @return static
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function withHeader($name, $value)
+    {
+        $clone = clone $this;
+        $clone->headers->set($name, $value);
+
+        return $clone;
+    }
+
+    /**
+     * Return an instance with the specified header appended with the given value.
+     *
+     * Existing values for the specified header will be maintained. The new
+     * value(s) will be appended to the existing list. If the header did not
+     * exist previously, it will be added.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that has the
+     * new header and/or value.
+     *
+     * @param string $name Case-insensitive header field name to add.
+     * @param string|string[] $value Header value(s).
+     * @return static
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function withAddedHeader($name, $value)
+    {
+        $clone = clone $this;
+        $clone->headers->add($name, $value);
+
+        return $clone;
+    }
+
+    /**
+     * Return an instance without the specified header.
+     *
+     * Header resolution MUST be done without case-sensitivity.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return an instance that removes
+     * the named header.
+     *
+     * @param string $name Case-insensitive header field name to remove.
+     * @return static
+     */
+    public function withoutHeader($name)
+    {
+        $clone = clone $this;
+        $clone->headers->remove($name);
+
+        return $clone;
+    }
+
+    /*******************************************************************************
+     * Body
+     ******************************************************************************/
+
+    /**
+     * Gets the body of the message.
+     *
+     * @return StreamInterface Returns the body as a stream.
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * Return an instance with the specified message body.
+     *
+     * The body MUST be a StreamInterface object.
+     *
+     * This method MUST be implemented in such a way as to retain the
+     * immutability of the message, and MUST return a new instance that has the
+     * new body stream.
+     *
+     * @param StreamInterface $body Body.
+     * @return static
+     * @throws \InvalidArgumentException When the body is not valid.
+     */
+    public function withBody(StreamInterface $body)
+    {
+        // TODO: Test for invalid body?
+        $clone = clone $this;
+        $clone->body = $body;
+
+        return $clone;
+    }
+}

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -10,12 +10,12 @@ namespace Slim\Http;
 
 use Closure;
 use InvalidArgumentException;
+use Psr\Http\Message\UploadedFileInterface;
 use RuntimeException;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Message\StreamInterface;
 use Slim\Interfaces\Http\HeadersInterface;
-use Slim\Http\Collection;
 
 /**
  * Request
@@ -28,15 +28,8 @@ use Slim\Http\Collection;
  * @link https://github.com/php-fig/http-message/blob/master/src/RequestInterface.php
  * @link https://github.com/php-fig/http-message/blob/master/src/ServerRequestInterface.php
  */
-class Request implements ServerRequestInterface
+class Request extends Message implements ServerRequestInterface
 {
-    /**
-     * The request protocol version
-     *
-     * @var string
-     */
-    protected $protocolVersion = '1.1';
-
     /**
      * The request method
      *
@@ -73,13 +66,6 @@ class Request implements ServerRequestInterface
     protected $queryParams;
 
     /**
-     * The request headers
-     *
-     * @var \Slim\Interfaces\Http\HeadersInterface
-     */
-    protected $headers;
-
-    /**
      * The request cookies
      *
      * @var array
@@ -101,13 +87,6 @@ class Request implements ServerRequestInterface
     protected $attributes;
 
     /**
-     * The request body object
-     *
-     * @var \Psr\Http\Message\StreamInterface
-     */
-    protected $body;
-
-    /**
      * The request body parsed (if possible) into a PHP array or object
      *
      * @var null|array|object
@@ -121,6 +100,11 @@ class Request implements ServerRequestInterface
      */
     protected $bodyParsers = [];
 
+    /**
+     * List of uploaded files
+     *
+     * @var UploadedFileInterface[]
+     */
     protected $uploadedFiles;
 
     /**
@@ -222,60 +206,6 @@ class Request implements ServerRequestInterface
         $this->headers = clone $this->headers;
         $this->attributes = clone $this->attributes;
         $this->body = clone $this->body;
-    }
-
-    /**
-     * Disable magic setter to ensure immutability
-     */
-    public function __set($name, $value)
-    {
-        // Do nothing
-    }
-
-    /*******************************************************************************
-     * Protocol
-     ******************************************************************************/
-
-    /**
-     * Retrieves the HTTP protocol version as a string.
-     *
-     * The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").
-     *
-     * @return string HTTP protocol version.
-     */
-    public function getProtocolVersion()
-    {
-        return $this->protocolVersion;
-    }
-
-    /**
-     * Return an instance with the specified HTTP protocol version.
-     *
-     * The version string MUST contain only the HTTP version number (e.g.,
-     * "1.1", "1.0").
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return an instance that has the
-     * new protocol version.
-     *
-     * @param string $version HTTP protocol version
-     * @return self
-     * @throws InvalidArgumentException if the protocol is an invalid number
-     */
-    public function withProtocolVersion($version)
-    {
-        static $valid = [
-            '1.0' => true,
-            '1.1' => true,
-            '2.0' => true,
-        ];
-        if (!isset($valid[$version])) {
-            throw new InvalidArgumentException('Protocol must be "1.0", "1.1", or "2.0"');
-        }
-        $clone = clone $this;
-        $clone->protocolVersion = $version;
-
-        return $clone;
     }
 
     /*******************************************************************************
@@ -632,163 +562,6 @@ class Request implements ServerRequestInterface
                 $clone->headers->set('Host', $uri->getHost());
             }
         }
-
-        return $clone;
-    }
-
-    /*******************************************************************************
-     * Headers
-     ******************************************************************************/
-
-    /**
-     * Retrieves all message header values.
-     *
-     * The keys represent the header name as it will be sent over the wire, and
-     * each value is an array of strings associated with the header.
-     *
-     *     // Represent the headers as a string
-     *     foreach ($message->getHeaders() as $name => $values) {
-     *         echo $name . ": " . implode(", ", $values);
-     *     }
-     *
-     *     // Emit headers iteratively:
-     *     foreach ($message->getHeaders() as $name => $values) {
-     *         foreach ($values as $value) {
-     *             header(sprintf('%s: %s', $name, $value), false);
-     *         }
-     *     }
-     *
-     * While header names are not case-sensitive, getHeaders() will preserve the
-     * exact case in which headers were originally specified.
-     *
-     * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST be an array of strings
-     *     for that header.
-     */
-    public function getHeaders()
-    {
-        return $this->headers->all();
-    }
-
-    /**
-     * Checks if a header exists by the given case-insensitive name.
-     *
-     * @param string $name Case-insensitive header field name.
-     * @return bool Returns true if any header names match the given header
-     *     name using a case-insensitive string comparison. Returns false if
-     *     no matching header name is found in the message.
-     */
-    public function hasHeader($name)
-    {
-        return $this->headers->has($name);
-    }
-
-    /**
-     * Retrieves a message header value by the given case-insensitive name.
-     *
-     * This method returns an array of all the header values of the given
-     * case-insensitive header name.
-     *
-     * If the header does not appear in the message, this method MUST return an
-     * empty array.
-     *
-     * @param string $name Case-insensitive header field name.
-     * @return string[] An array of string values as provided for the given
-     *    header. If the header does not appear in the message, this method MUST
-     *    return an empty array.
-     */
-    public function getHeader($name)
-    {
-        return $this->headers->get($name, []);
-    }
-
-    /**
-     * Retrieves a comma-separated string of the values for a single header.
-     *
-     * This method returns all of the header values of the given
-     * case-insensitive header name as a string concatenated together using
-     * a comma.
-     *
-     * NOTE: Not all header values may be appropriately represented using
-     * comma concatenation. For such headers, use getHeader() instead
-     * and supply your own delimiter when concatenating.
-     *
-     * If the header does not appear in the message, this method MUST return
-     * an empty string.
-     *
-     * @param string $name Case-insensitive header field name.
-     * @return string A string of values as provided for the given header
-     *    concatenated together using a comma. If the header does not appear in
-     *    the message, this method MUST return an empty string.
-     */
-    public function getHeaderLine($name)
-    {
-        return implode(',', $this->headers->get($name, []));
-    }
-
-    /**
-     * Return an instance with the provided value replacing the specified header.
-     *
-     * While header names are case-insensitive, the casing of the header will
-     * be preserved by this function, and returned from getHeaders().
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return an instance that has the
-     * new and/or updated header and value.
-     *
-     * @param string $name Case-insensitive header field name.
-     * @param string|string[] $value Header value(s).
-     * @return self
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function withHeader($name, $value)
-    {
-        $clone = clone $this;
-        $clone->headers->set($name, $value);
-
-        return $clone;
-    }
-
-    /**
-     * Return an instance with the specified header appended with the given value.
-     *
-     * Existing values for the specified header will be maintained. The new
-     * value(s) will be appended to the existing list. If the header did not
-     * exist previously, it will be added.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return an instance that has the
-     * new header and/or value.
-     *
-     * @param string $name Case-insensitive header field name to add.
-     * @param string|string[] $value Header value(s).
-     * @return self
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function withAddedHeader($name, $value)
-    {
-        $clone = clone $this;
-        $clone->headers->add($name, $value);
-
-        return $clone;
-    }
-
-    /**
-     * Return an instance without the specified header.
-     *
-     * Header resolution MUST be done without case-sensitivity.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return an instance that removes
-     * the named header.
-     *
-     * @param string $name Case-insensitive header field name to remove.
-     * @return self
-     */
-    public function withoutHeader($name)
-    {
-        $clone = clone $this;
-        $clone->headers->remove($name);
 
         return $clone;
     }
@@ -1154,37 +927,6 @@ class Request implements ServerRequestInterface
     /*******************************************************************************
      * Body
      ******************************************************************************/
-
-    /**
-     * Gets the body of the message.
-     *
-     * @return StreamInterface Returns the body as a stream.
-     */
-    public function getBody()
-    {
-        return $this->body;
-    }
-
-    /**
-     * Return an instance with the specified message body.
-     *
-     * The body MUST be a StreamInterface object.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
-     * new body stream.
-     *
-     * @param StreamInterface $body Body.
-     * @return self
-     * @throws \InvalidArgumentException When the body is not valid.
-     */
-    public function withBody(StreamInterface $body)
-    {
-        $clone = clone $this;
-        $clone->body = $body;
-
-        return $clone;
-    }
 
     /**
      * Retrieve any parameters provided in the request body.

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -23,15 +23,8 @@ use Slim\Interfaces\Http\HeadersInterface;
  * @link https://github.com/php-fig/http-message/blob/master/src/MessageInterface.php
  * @link https://github.com/php-fig/http-message/blob/master/src/ResponseInterface.php
  */
-class Response implements ResponseInterface
+class Response extends Message implements ResponseInterface
 {
-    /**
-     * Protocol version
-     *
-     * @var string
-     */
-    protected $protocolVersion = '1.1';
-
     /**
      * Status code
      *
@@ -45,20 +38,6 @@ class Response implements ResponseInterface
      * @var string
      */
     protected $reasonPhrase = '';
-
-    /**
-     * Headers
-     *
-     * @var \Slim\Interfaces\Http\HeadersInterface
-     */
-    protected $headers;
-
-    /**
-     * Body object
-     *
-     * @var \Psr\Http\Message\StreamInterface
-     */
-    protected $body;
 
     /**
      * Status codes and reason phrases
@@ -158,60 +137,6 @@ class Response implements ResponseInterface
         $this->body = clone $this->body;
     }
 
-    /**
-     * Disable magic setter to ensure immutability.
-     */
-    public function __set($name, $value)
-    {
-        // Do nothing
-    }
-
-    /*******************************************************************************
-     * Protocol
-     ******************************************************************************/
-
-    /**
-     * Retrieves the HTTP protocol version as a string.
-     *
-     * The string MUST contain only the HTTP version number (e.g., "1.1", "1.0").
-     *
-     * @return string HTTP protocol version.
-     */
-    public function getProtocolVersion()
-    {
-        return $this->protocolVersion;
-    }
-
-    /**
-     * Return an instance with the specified HTTP protocol version.
-     *
-     * The version string MUST contain only the HTTP version number (e.g.,
-     * "1.1", "1.0").
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return an instance that has the
-     * new protocol version.
-     *
-     * @param string $version HTTP protocol version
-     * @return self
-     * @throws InvalidArgumentException if the http version is an invalid number
-     */
-    public function withProtocolVersion($version)
-    {
-        static $valid = [
-            '1.0' => true,
-            '1.1' => true,
-            '2.0' => true,
-        ];
-        if (!isset($valid[$version])) {
-            throw new InvalidArgumentException('Invalid HTTP version. Must be one of: 1.0, 1.1, 2.0');
-        }
-        $clone = clone $this;
-        $clone->protocolVersion = $version;
-
-        return $clone;
-    }
-
     /*******************************************************************************
      * Status
      ******************************************************************************/
@@ -302,163 +227,6 @@ class Response implements ResponseInterface
     }
 
     /*******************************************************************************
-     * Headers
-     ******************************************************************************/
-
-    /**
-     * Retrieves all message header values.
-     *
-     * The keys represent the header name as it will be sent over the wire, and
-     * each value is an array of strings associated with the header.
-     *
-     *     // Represent the headers as a string
-     *     foreach ($message->getHeaders() as $name => $values) {
-     *         echo $name . ": " . implode(", ", $values);
-     *     }
-     *
-     *     // Emit headers iteratively:
-     *     foreach ($message->getHeaders() as $name => $values) {
-     *         foreach ($values as $value) {
-     *             header(sprintf('%s: %s', $name, $value), false);
-     *         }
-     *     }
-     *
-     * While header names are not case-sensitive, getHeaders() will preserve the
-     * exact case in which headers were originally specified.
-     *
-     * @return array Returns an associative array of the message's headers. Each
-     *     key MUST be a header name, and each value MUST be an array of strings
-     *     for that header.
-     */
-    public function getHeaders()
-    {
-        return $this->headers->all();
-    }
-
-    /**
-     * Checks if a header exists by the given case-insensitive name.
-     *
-     * @param string $name Case-insensitive header field name.
-     * @return bool Returns true if any header names match the given header
-     *     name using a case-insensitive string comparison. Returns false if
-     *     no matching header name is found in the message.
-     */
-    public function hasHeader($name)
-    {
-        return $this->headers->has($name);
-    }
-
-    /**
-     * Retrieves a message header value by the given case-insensitive name.
-     *
-     * This method returns an array of all the header values of the given
-     * case-insensitive header name.
-     *
-     * If the header does not appear in the message, this method MUST return an
-     * empty array.
-     *
-     * @param string $name Case-insensitive header field name.
-     * @return string[] An array of string values as provided for the given
-     *    header. If the header does not appear in the message, this method MUST
-     *    return an empty array.
-     */
-    public function getHeader($name)
-    {
-        return $this->headers->get($name, []);
-    }
-
-    /**
-     * Retrieves a comma-separated string of the values for a single header.
-     *
-     * This method returns all of the header values of the given
-     * case-insensitive header name as a string concatenated together using
-     * a comma.
-     *
-     * NOTE: Not all header values may be appropriately represented using
-     * comma concatenation. For such headers, use getHeader() instead
-     * and supply your own delimiter when concatenating.
-     *
-     * If the header does not appear in the message, this method MUST return
-     * an empty string.
-     *
-     * @param string $name Case-insensitive header field name.
-     * @return string A string of values as provided for the given header
-     *    concatenated together using a comma. If the header does not appear in
-     *    the message, this method MUST return an empty string.
-     */
-    public function getHeaderLine($name)
-    {
-        return implode(',', $this->headers->get($name, []));
-    }
-
-    /**
-     * Return an instance with the provided value replacing the specified header.
-     *
-     * While header names are case-insensitive, the casing of the header will
-     * be preserved by this function, and returned from getHeaders().
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return an instance that has the
-     * new and/or updated header and value.
-     *
-     * @param string $name Case-insensitive header field name.
-     * @param string|string[] $value Header value(s).
-     * @return self
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function withHeader($name, $value)
-    {
-        $clone = clone $this;
-        $clone->headers->set($name, $value);
-
-        return $clone;
-    }
-
-    /**
-     * Return an instance with the specified header appended with the given value.
-     *
-     * Existing values for the specified header will be maintained. The new
-     * value(s) will be appended to the existing list. If the header did not
-     * exist previously, it will be added.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return an instance that has the
-     * new header and/or value.
-     *
-     * @param string $name Case-insensitive header field name to add.
-     * @param string|string[] $value Header value(s).
-     * @return self
-     * @throws \InvalidArgumentException for invalid header names or values.
-     */
-    public function withAddedHeader($name, $value)
-    {
-        $clone = clone $this;
-        $clone->headers->add($name, $value);
-
-        return $clone;
-    }
-
-    /**
-     * Return an instance without the specified header.
-     *
-     * Header resolution MUST be done without case-sensitivity.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return an instance that removes
-     * the named header.
-     *
-     * @param string $name Case-insensitive header field name to remove.
-     * @return self
-     */
-    public function withoutHeader($name)
-    {
-        $clone = clone $this;
-        $clone->headers->remove($name);
-
-        return $clone;
-    }
-
-    /*******************************************************************************
      * Body
      ******************************************************************************/
 
@@ -477,38 +245,6 @@ class Response implements ResponseInterface
         $this->getBody()->write($data);
 
         return $this;
-    }
-
-    /**
-     * Gets the body of the message.
-     *
-     * @return StreamInterface Returns the body as a stream.
-     */
-    public function getBody()
-    {
-        return $this->body;
-    }
-
-    /**
-     * Return an instance with the specified message body.
-     *
-     * The body MUST be a StreamInterface object.
-     *
-     * This method MUST be implemented in such a way as to retain the
-     * immutability of the message, and MUST return a new instance that has the
-     * new body stream.
-     *
-     * @param StreamInterface $body Body.
-     * @return self
-     * @throws \InvalidArgumentException When the body is not valid.
-     */
-    public function withBody(StreamInterface $body)
-    {
-        // TODO: Test for invalid body?
-        $clone = clone $this;
-        $clone->body = $body;
-
-        return $clone;
     }
 
     /*******************************************************************************

--- a/tests/Http/MessageTest.php
+++ b/tests/Http/MessageTest.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Http;
+
+use Slim\Http\Headers;
+use Slim\Tests\Mocks\MessageStub;
+
+class MessageTest extends \PHPUnit_Framework_TestCase
+{
+    /*******************************************************************************
+     * Protocol
+     ******************************************************************************/
+
+    /**
+     * @covers Slim\Http\Message::getProtocolVersion
+     */
+    public function testGetProtocolVersion()
+    {
+        $message = new MessageStub();
+        $message->protocolVersion = '1.0';
+
+        $this->assertEquals('1.0', $message->getProtocolVersion());
+    }
+
+    /**
+     * @covers Slim\Http\Message::withProtocolVersion
+     */
+    public function testWithProtocolVersion()
+    {
+        $message = new MessageStub();
+        $clone = $message->withProtocolVersion('1.0');
+
+        $this->assertEquals('1.0', $clone->protocolVersion);
+    }
+
+    /**
+     * @covers Slim\Http\Message::withProtocolVersion
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithProtocolVersionInvalidThrowsException()
+    {
+        $message = new MessageStub();
+        $message->withProtocolVersion('3.0');
+    }
+
+    /*******************************************************************************
+     * Headers
+     ******************************************************************************/
+
+    /**
+     * @covers Slim\Http\Message::getHeaders
+     */
+    public function testGetHeaders()
+    {
+        $headers = new Headers();
+        $headers->add('X-Foo', 'one');
+        $headers->add('X-Foo', 'two');
+        $headers->add('X-Foo', 'three');
+
+        $message = new MessageStub();
+        $message->headers = $headers;
+
+        $shouldBe = [
+            'X-Foo' => [
+                'one',
+                'two',
+                'three',
+            ],
+        ];
+
+        $this->assertEquals($shouldBe, $message->getHeaders());
+    }
+
+    /**
+     * @covers Slim\Http\Message::hasHeader
+     */
+    public function testHasHeader()
+    {
+        $headers = new Headers();
+        $headers->add('X-Foo', 'one');
+
+        $message = new MessageStub();
+        $message->headers = $headers;
+
+        $this->assertTrue($message->hasHeader('X-Foo'));
+        $this->assertFalse($message->hasHeader('X-Bar'));
+    }
+
+    /**
+     * @covers Slim\Http\Message::getHeaderLine
+     */
+    public function testGetHeaderLine()
+    {
+        $headers = new Headers();
+        $headers->add('X-Foo', 'one');
+        $headers->add('X-Foo', 'two');
+        $headers->add('X-Foo', 'three');
+
+        $message = new MessageStub();
+        $message->headers = $headers;
+
+        $this->assertEquals('one,two,three', $message->getHeaderLine('X-Foo'));
+        $this->assertEquals('', $message->getHeaderLine('X-Bar'));
+    }
+
+    /**
+     * @covers Slim\Http\Message::getHeader
+     */
+    public function testGetHeader()
+    {
+        $headers = new Headers();
+        $headers->add('X-Foo', 'one');
+        $headers->add('X-Foo', 'two');
+        $headers->add('X-Foo', 'three');
+
+        $message = new MessageStub();
+        $message->headers = $headers;
+
+        $this->assertEquals(['one', 'two', 'three'], $message->getHeader('X-Foo'));
+        $this->assertEquals([], $message->getHeader('X-Bar'));
+    }
+
+    /**
+     * @covers Slim\Http\Message::withHeader
+     */
+    public function testWithHeader()
+    {
+        $headers = new Headers();
+        $headers->add('X-Foo', 'one');
+        $message = new MessageStub();
+        $message->headers = $headers;
+        $clone = $message->withHeader('X-Foo', 'bar');
+
+        $this->assertEquals('bar', $clone->getHeaderLine('X-Foo'));
+    }
+
+    /**
+     * @covers Slim\Http\Message::withAddedHeader
+     */
+    public function testWithAddedHeader()
+    {
+        $headers = new Headers();
+        $headers->add('X-Foo', 'one');
+        $message = new MessageStub();
+        $message->headers = $headers;
+        $clone = $message->withAddedHeader('X-Foo', 'two');
+
+        $this->assertEquals('one,two', $clone->getHeaderLine('X-Foo'));
+    }
+
+    /**
+     * @covers Slim\Http\Message::withoutHeader
+     */
+    public function testWithoutHeader()
+    {
+        $headers = new Headers();
+        $headers->add('X-Foo', 'one');
+        $headers->add('X-Bar', 'two');
+        $response = new MessageStub();
+        $response->headers = $headers;
+        $clone = $response->withoutHeader('X-Foo');
+        $shouldBe = [
+            'X-Bar' => ['two'],
+        ];
+
+        $this->assertEquals($shouldBe, $clone->getHeaders());
+    }
+
+    /*******************************************************************************
+     * Body
+     ******************************************************************************/
+
+    /**
+     * @covers Slim\Http\Message::getBody
+     */
+    public function testGetBody()
+    {
+        $body = $this->getBody();
+        $message = new MessageStub();
+        $message->body = $body;
+
+        $this->assertSame($body, $message->getBody());
+    }
+
+    /**
+     * @covers Slim\Http\Message::withBody
+     */
+    public function testWithBody()
+    {
+        $body = $this->getBody();
+        $body2 = $this->getBody();
+        $message = new MessageStub();
+        $message->body = $body;
+        $clone = $message->withBody($body2);
+
+        $this->assertSame($body, $message->body);
+        $this->assertSame($body2, $clone->body);
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Slim\Http\Body
+     */
+    protected function getBody()
+    {
+        return $this->getMockBuilder('Slim\Http\Body')->disableOriginalConstructor()->getMock();
+    }
+}

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -53,30 +53,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /*******************************************************************************
-     * Protocol
-     ******************************************************************************/
-
-    public function testGetProtocol()
-    {
-        $this->assertEquals('1.1', $this->requestFactory()->getProtocolVersion());
-    }
-
-    public function testWithProtocol()
-    {
-        $clone = $this->requestFactory()->withProtocolVersion('1.0');
-
-        $this->assertAttributeEquals('1.0', 'protocolVersion', $clone);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testWithProtocolInvalid()
-    {
-        $this->requestFactory()->withProtocolVersion('foo');
-    }
-
-    /*******************************************************************************
      * Method
      ******************************************************************************/
 
@@ -406,106 +382,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeSame($uri2, 'uri', $clone);
     }
 
-    /*******************************************************************************
-     * Headers
-     ******************************************************************************/
-
-    public function testGetHeaders()
-    {
-        $headers = new Headers([
-            'X-Foo' => ['one', 'two', 'three'],
-        ]);
-        $request = $this->requestFactory();
-        $headersProp = new ReflectionProperty($request, 'headers');
-        $headersProp->setAccessible(true);
-        $headersProp->setValue($request, $headers);
-
-        $shouldBe = [
-            'X-Foo' => ['one', 'two', 'three'],
-        ];
-        $this->assertEquals($shouldBe, $request->getHeaders());
-    }
-
-    public function testHasHeader()
-    {
-        $headers = new Headers(['X-Foo' => ['one']]);
-        $request = $this->requestFactory();
-        $headersProp = new ReflectionProperty($request, 'headers');
-        $headersProp->setAccessible(true);
-        $headersProp->setValue($request, $headers);
-
-        $this->assertTrue($request->hasHeader('X-Foo'));
-        $this->assertFalse($request->hasHeader('X-Bar'));
-    }
-
-    public function testGetHeaderLine()
-    {
-        $headers = new Headers([
-            'X-Foo' => ['one', 'two', 'three'],
-        ]);
-        $request = $this->requestFactory();
-        $headersProp = new ReflectionProperty($request, 'headers');
-        $headersProp->setAccessible(true);
-        $headersProp->setValue($request, $headers);
-
-        $this->assertEquals('one,two,three', $request->getHeaderLine('X-Foo'));
-        $this->assertEquals('', $request->getHeaderLine('X-Bar'));
-    }
-
-    public function testGetHeader()
-    {
-        $headers = new Headers([
-            'X-Foo' => ['one', 'two', 'three'],
-        ]);
-        $request = $this->requestFactory();
-        $headersProp = new ReflectionProperty($request, 'headers');
-        $headersProp->setAccessible(true);
-        $headersProp->setValue($request, $headers);
-
-        $this->assertEquals(['one', 'two', 'three'], $request->getHeader('X-Foo'));
-        $this->assertEquals([], $request->getHeader('X-Bar'));
-    }
-
-    public function testWithHeader()
-    {
-        $request = $this->requestFactory();
-        $clone = $request->withHeader('X-Foo', 'bar');
-
-        $this->assertEquals('bar', $clone->getHeaderLine('X-Foo'));
-    }
-
-    public function testWithAddedHeader()
-    {
-        $headers = new Headers([
-            'X-Foo' => ['one'],
-        ]);
-        $request = $this->requestFactory();
-        $headersProp = new ReflectionProperty($request, 'headers');
-        $headersProp->setAccessible(true);
-        $headersProp->setValue($request, $headers);
-        $clone = $request->withAddedHeader('X-Foo', 'two');
-
-        $this->assertEquals('one,two', $clone->getHeaderLine('X-Foo'));
-    }
-
-    public function testWithoutHeader()
-    {
-        $headers = new Headers([
-            'X-Foo' => ['one'],
-            'X-Bar' => ['two'],
-        ]);
-        $request = $this->requestFactory();
-        $headersProp = new ReflectionProperty($request, 'headers');
-        $headersProp->setAccessible(true);
-        $headersProp->setValue($request, $headers);
-        $clone = $request->withoutHeader('X-Foo');
-        $shouldBe = [
-            'X-Bar' => ['two'],
-        ];
-
-        $this->assertEquals($shouldBe, $clone->getHeaders());
-    }
-
     public function testGetContentType()
     {
         $headers = new Headers([
@@ -806,25 +682,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     /*******************************************************************************
      * Body
      ******************************************************************************/
-
-    public function testGetBody()
-    {
-        $bodyNew = new RequestBody();
-        $request = $this->requestFactory();
-        $bodyProp = new ReflectionProperty($request, 'body');
-        $bodyProp->setAccessible(true);
-        $bodyProp->setValue($request, $bodyNew);
-
-        $this->assertSame($bodyNew, $request->getBody());
-    }
-
-    public function testWithBody()
-    {
-        $bodyNew = new RequestBody();
-        $request = $this->requestFactory()->withBody($bodyNew);
-
-        $this->assertAttributeSame($bodyNew, 'body', $request);
-    }
 
     public function testGetParsedBodyForm()
     {

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -61,37 +61,6 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     }
 
     /*******************************************************************************
-     * Protocol
-     ******************************************************************************/
-
-    public function testGetProtocolVersion()
-    {
-        $response = new Response();
-        $responseProto = new ReflectionProperty($response, 'protocolVersion');
-        $responseProto->setAccessible(true);
-        $responseProto->setValue($response, '1.0');
-
-        $this->assertEquals('1.0', $response->getProtocolVersion());
-    }
-
-    public function testWithProtocolVersion()
-    {
-        $response = new Response();
-        $clone = $response->withProtocolVersion('1.0');
-
-        $this->assertAttributeEquals('1.0', 'protocolVersion', $clone);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testWithProtocolVersionInvalidThrowsException()
-    {
-        $response = new Response();
-        $response->withProtocolVersion('3.0');
-    }
-
-    /*******************************************************************************
      * Status
      ******************************************************************************/
 
@@ -149,95 +118,6 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Custom Phrase', $clone->getReasonPhrase());
     }
 
-    /*******************************************************************************
-     * Headers
-     ******************************************************************************/
-
-    public function testGetHeaders()
-    {
-        $headers = new Headers();
-        $headers->add('X-Foo', 'one');
-        $headers->add('X-Foo', 'two');
-        $headers->add('X-Foo', 'three');
-        $response = new Response(200, $headers);
-        $shouldBe = [
-            'X-Foo' => [
-                'one',
-                'two',
-                'three',
-            ],
-        ];
-        $this->assertEquals($shouldBe, $response->getHeaders());
-    }
-
-    public function testHasHeader()
-    {
-        $headers = new Headers();
-        $headers->add('X-Foo', 'one');
-        $response = new Response(200, $headers);
-
-        $this->assertTrue($response->hasHeader('X-Foo'));
-        $this->assertFalse($response->hasHeader('X-Bar'));
-    }
-
-    public function testGetHeaderLine()
-    {
-        $headers = new Headers();
-        $headers->add('X-Foo', 'one');
-        $headers->add('X-Foo', 'two');
-        $headers->add('X-Foo', 'three');
-        $response = new Response(200, $headers);
-
-        $this->assertEquals('one,two,three', $response->getHeaderLine('X-Foo'));
-        $this->assertEquals('', $response->getHeaderLine('X-Bar'));
-    }
-
-    public function testGetHeader()
-    {
-        $headers = new Headers();
-        $headers->add('X-Foo', 'one');
-        $headers->add('X-Foo', 'two');
-        $headers->add('X-Foo', 'three');
-        $response = new Response(200, $headers);
-
-        $this->assertEquals(['one', 'two', 'three'], $response->getHeader('X-Foo'));
-        $this->assertEquals([], $response->getHeader('X-Bar'));
-    }
-
-    public function testWithHeader()
-    {
-        $headers = new Headers();
-        $headers->add('X-Foo', 'one');
-        $response = new Response(200, $headers);
-        $clone = $response->withHeader('X-Foo', 'bar');
-
-        $this->assertEquals('bar', $clone->getHeaderLine('X-Foo'));
-    }
-
-    public function testWithAddedHeader()
-    {
-        $headers = new Headers();
-        $headers->add('X-Foo', 'one');
-        $response = new Response(200, $headers);
-        $clone = $response->withAddedHeader('X-Foo', 'two');
-
-        $this->assertEquals('one,two', $clone->getHeaderLine('X-Foo'));
-    }
-
-    public function testWithoutHeader()
-    {
-        $headers = new Headers();
-        $headers->add('X-Foo', 'one');
-        $headers->add('X-Bar', 'two');
-        $response = new Response(200, $headers);
-        $clone = $response->withoutHeader('X-Foo');
-        $shouldBe = [
-            'X-Bar' => ['two'],
-        ];
-
-        $this->assertEquals($shouldBe, $clone->getHeaders());
-    }
-
     /**
      * @covers Slim\Http\Response::withRedirect
      */
@@ -252,30 +132,6 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(301, $clone->getStatusCode());
         $this->assertTrue($clone->hasHeader('Location'));
         $this->assertEquals('/foo', $clone->getHeaderLine('Location'));
-    }
-
-    /*******************************************************************************
-     * Body
-     ******************************************************************************/
-
-    public function testGetBody()
-    {
-        $headers = new Headers();
-        $body = new Body(fopen('php://temp', 'r+'));
-        $response = new Response(404, $headers, $body);
-
-        $this->assertSame($body, $response->getBody());
-    }
-
-    public function testWithBody()
-    {
-        $headers = new Headers();
-        $body = new Body(fopen('php://temp', 'r+'));
-        $body2 = new Body(fopen('php://temp', 'r+'));
-        $response = new Response(404, $headers, $body);
-        $clone = $response->withBody($body2);
-
-        $this->assertAttributeSame($body2, 'body', $clone);
     }
 
     /*******************************************************************************

--- a/tests/Mocks/MessageStub.php
+++ b/tests/Mocks/MessageStub.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Mocks;
+
+use Slim\Http\Message;
+
+/**
+ * Mock object for Slim\Http\MessageTest
+ */
+class MessageStub extends Message
+{
+    /**
+     * Protocol version
+     *
+     * @var string
+     */
+    public $protocolVersion;
+
+    /**
+     * Headers
+     *
+     * @var \Slim\Interfaces\Http\HeadersInterface
+     */
+    public $headers;
+
+    /**
+     * Body object
+     *
+     * @var \Psr\Http\Message\StreamInterface
+     */
+    public $body;
+}


### PR DESCRIPTION
The `Request` and `Response` class each implemented the methods of the `MessageInterface` on their own, resulting in many duplicated lines of code.

This pull requests extracts these methods into a common `Message` class.
