### PR TITLE
testing relative path in withPath generating double slashes

### DIFF
--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -570,4 +570,15 @@ class UriTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('http://josh:sekrit@example.com:8080/foo', $uri->getBaseUrl());
     }
+
+    public function testWithPathWhenBaseRootIsEmpty()
+    {
+        $environment = \Slim\Http\Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/bar',
+        ]);
+        $uri = \Slim\Http\Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('http://localhost/test', (string) $uri->withPath('test'));
+    }
 }


### PR DESCRIPTION
This is a PR to reproduce the issue #1380; relative path in withPath generates double slashes in URI. 

as such, the test should fail if merged... 
