### PR TITLE
Add the route to the request in the application

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -451,7 +451,11 @@ class App
             foreach ($routeInfo[2] as $k => $v) {
                 $routeArguments[$k] = urldecode($v);
             }
-            $request = $routeInfo[1][0]->prepare($request, $routeArguments);
+
+            $routeInfo[1][0]->prepare($request, $routeArguments);
+
+            // add route to the request's attributes in case a middleware or handler needs access to the route
+            $request = $request->withAttribute('route', $routeInfo[1][0]);
         }
 
         $routeInfo['request'] = [$request->getMethod(), (string) $request->getUri()];
@@ -470,7 +474,7 @@ class App
         if ($this->isEmptyResponse($response)) {
             return $response->withoutHeader('Content-Type')->withoutHeader('Content-Length');
         }
-        
+
         $size = $response->getBody()->getSize();
         if ($size !== null) {
             $response = $response->withHeader('Content-Length', (string) $size);

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -86,7 +86,6 @@ interface RouteInterface
      *
      * @param ServerRequestInterface $request
      * @param array $arguments
-     * @return ServerRequestInterface
      */
     public function prepare(ServerRequestInterface $request, array $arguments);
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -261,7 +261,6 @@ class Route extends Routable implements RouteInterface
      *
      * @param ServerRequestInterface $request
      * @param array $arguments
-     * @return ServerRequestInterface
      */
     public function prepare(ServerRequestInterface $request, array $arguments)
     {
@@ -269,11 +268,6 @@ class Route extends Routable implements RouteInterface
         foreach ($arguments as $k => $v) {
             $this->setArgument($k, $v);
         }
-
-        // add this route to the request's attributes in case route middleware needs access to route arguments
-        $request = $request->withAttribute('route', $this);
-
-        return $request;
     }
 
     /**


### PR DESCRIPTION
Currently, the `Route` object adds itself to the `Request` inside `Route:prepare`. 

This pull request moves this to the `Application` for better encapsulation.
