### PR TITLE
Add parameter name based invocation strategy

### DIFF
--- a/Slim/Handlers/Strategies/NameBased.php
+++ b/Slim/Handlers/Strategies/NameBased.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/codeguy/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/codeguy/Slim/blob/master/LICENSE (MIT License)
+ */
+namespace Slim\Handlers\Strategies;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionFunction;
+use ReflectionMethod;
+use RuntimeException;
+use Slim\Interfaces\InvocationStrategyInterface;
+
+/**
+ * Route callback strategy which maps the route argument names to the callable parameter names.
+ */
+class NameBased implements InvocationStrategyInterface
+{
+    /**
+     * Inspect the signature of the route callable and match the route argument names with the
+     * parameter names of the callable.
+     *
+     * @param array|callable         $callable
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface      $response
+     * @param array                  $routeArguments
+     * @throws RuntimeException
+     *
+     * @return mixed
+     */
+    public function __invoke(
+        callable $callable,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        array $routeArguments
+    ) {
+        $routeArguments['req'] = $request;
+        $routeArguments['request'] = $request;
+        $routeArguments['res'] = $response;
+        $routeArguments['response'] = $response;
+
+        $reflection = is_array($callable)
+            ? new ReflectionMethod($callable[0], $callable[1])
+            : new ReflectionFunction($callable);
+
+        $parameters = $reflection->getParameters();
+        $arguments = [];
+
+        foreach ($parameters as $parameter) {
+            $name = $parameter->getName();
+
+            if (array_key_exists($name, $routeArguments)) {
+                $value = $routeArguments[$name];
+            } elseif ($parameter->isDefaultValueAvailable()) {
+                $value = $parameter->getDefaultValue();
+            } else {
+                throw new RuntimeException(
+                    sprintf(
+                        'Could not find a value for parameter "%s" (available arguments: %s).',
+                        $name,
+                        implode(', ', array_keys($routeArguments))
+                    )
+                );
+            }
+
+            $arguments[$parameter->getPosition()] = $value;
+        }
+
+        return call_user_func_array($callable, $arguments);
+    }
+}

--- a/tests/Handlers/Strategies/NameBasedTest.php
+++ b/tests/Handlers/Strategies/NameBasedTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Handlers\Strategies;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Handlers\Strategies\NameBased;
+use Slim\Http\Request;
+use Slim\Tests\Mocks\MockAction;
+
+class NameBasedTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var NameBased
+     */
+    protected $strategy;
+
+    /**
+     * @var ServerRequestInterface
+     */
+    protected $request;
+
+    /**
+     * @var ResponseInterface
+     */
+    protected $response;
+
+
+    protected function setUp()
+    {
+        $this->strategy = new NameBased();
+        $this->request = $this->getMockBuilder('Slim\Http\Request')->disableOriginalConstructor()->getMock();
+        $this->response = $this->getMock('Slim\Http\Response');
+    }
+
+    /**
+     * @covers Slim\Handlers\Strategies\NameBased::__invoke
+     */
+    public function testWithSingleParameter()
+    {
+        $callable = function ($id) {
+            return 'PHPUnit ' . $id;
+        };
+
+        $return = $this->strategy->__invoke($callable, $this->request, $this->response, ['id' => 4]);
+        $this->assertEquals('PHPUnit 4', $return);
+    }
+
+    /**
+     * @covers Slim\Handlers\Strategies\NameBased::__invoke
+     */
+    public function testWithMultipleParameters()
+    {
+        $callable = function ($name, $color, $animal) {
+            return $name . ' likes ' . $color . ' ' . $animal . 's';
+        };
+
+        $routeArguments = [
+            'name' => 'Michel',
+            'color' => 'grizzly',
+            'animal' => 'bear',
+        ];
+
+        $return = $this->strategy->__invoke($callable, $this->request, $this->response, $routeArguments);
+        $this->assertEquals('Michel likes grizzly bears', $return);
+    }
+
+    /**
+     * @covers Slim\Handlers\Strategies\NameBased::__invoke
+     */
+    public function testWithMultipleParametersDifferentOrder()
+    {
+        $callable = function ($fruit, $nr, $name) {
+            return $name . ' ate ' . $nr . ' ' . $fruit . 's';
+        };
+
+        $routeArguments = [
+            'name' => 'Josh',
+            'fruit' => 'banana',
+            'nr' => 2,
+        ];
+
+        $return = $this->strategy->__invoke($callable, $this->request, $this->response, $routeArguments);
+        $this->assertEquals('Josh ate 2 bananas', $return);
+    }
+
+    /**
+     * @covers Slim\Handlers\Strategies\NameBased::__invoke
+     */
+    public function testWithRequest()
+    {
+        $callable = function ($id, Request $request) {
+            $this->assertEquals('9', $id);
+            $this->assertInstanceOf('Slim\Http\Request', $request);
+        };
+
+        $this->strategy->__invoke($callable, $this->request, $this->response, ['id' => '9']);
+    }
+
+    /**
+     * @covers Slim\Handlers\Strategies\NameBased::__invoke
+     */
+    public function testWithResponse()
+    {
+        $callable = function ($response) {
+            $this->assertInstanceOf('Slim\Http\Response', $response);
+        };
+
+        $this->strategy->__invoke($callable, $this->request, $this->response, []);
+    }
+
+    /**
+     * @covers Slim\Handlers\Strategies\NameBased::__invoke
+     */
+    public function testWithOptionalParameters()
+    {
+        $callable = function ($action, $name = 'Rob', $amount = 5) {
+            return $name . ' ' . $action . 's ' . $amount . ' times';
+        };
+
+        $routeArguments = [
+            'action' => 'jump',
+            'amount' => 2
+        ];
+
+        $return = $this->strategy->__invoke($callable, $this->request, $this->response, $routeArguments);
+        $this->assertEquals('Rob jumps 2 times', $return);
+    }
+
+    /**
+     * @covers Slim\Handlers\Strategies\NameBased::__invoke
+     */
+    public function testWithMissingParameter()
+    {
+        $callable = function ($id, $name, $amount) {
+            $this->fail('Callable should not be called');
+        };
+
+        $routeArguments = [
+            'id' => 5,
+            'amount' => 22,
+        ];
+
+        $this->setExpectedException(
+            'RuntimeException',
+            'Could not find a value for parameter "name" (available arguments: id, amount, req, request, res, response).'
+        );
+        $this->strategy->__invoke($callable, $this->request, $this->response, $routeArguments);
+    }
+
+    /**
+     * @covers Slim\Handlers\Strategies\NameBased::__invoke
+     */
+    public function testWithClassMethod()
+    {
+        $callable = [new MockAction(), '__call'];
+
+        $routeArguments = [
+            'name' => 'Michel',
+            'arguments' => ['', $this->response, ''],
+        ];
+
+        $return = $this->strategy->__invoke($callable, $this->request, $this->response, $routeArguments);
+        $this->assertEquals($this->response, $return);
+    }
+}


### PR DESCRIPTION
This pull request adds a parameter name based invocation strategy (comparable to Slim 2). The strategy will use Reflection to inspect the parameter names of the callable and map the argument names of the route to the parameter names. The special parameter names `request`, `req`, `response` and `res` are mapped to the `Request`/`Response` objects.

It supports both (anonymous) functions and class methods. You can order the parameters any way you like and even use optional parameters. Due to the Reflection you probably wouldn't use this in a high performance application, but it will add a nice and concise way for simpler usages.

Example:

``` php
$app->get('/hello/{name}', function ($name, $response, $from = 'Josh') {
    $greeting = sprintf('%s said: "Hello, %s!"', $from, $name);
    return $response->write($greeting);
});

// Call /hello/Michel => Josh said: "Hello, Michel!"
```
