### PR TITLE
Fix basePath handling

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -542,6 +542,11 @@ class Uri implements UriInterface
         $clone = clone $this;
         $clone->path = $this->filterPath($path);
 
+        // if the path is absolute, then clear basePath
+        if (substr($path, 0, 1) == '/') {
+            $clone->basePath = '';
+        }
+
         return $clone;
     }
 

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -773,12 +773,7 @@ class Uri implements UriInterface
         $query = $this->getQuery();
         $fragment = $this->getFragment();
 
-        if ($authority && substr($path, 0, 1) !== '/') {
-            $path = $basePath . '/' . $path;
-        }
-        if (!$authority && substr($path, 0, 2) === '//') {
-            $path = '/' . ltrim($path, '/');
-        }
+        $path = $basePath . '/'  . ltrim($path, '/');
 
         return ($scheme ? $scheme . ':' : '')
             . ($authority ? '//' . $authority : '')

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -456,6 +456,17 @@ class UriTest extends \PHPUnit_Framework_TestCase
 
         $uri = $uri->withPath('/bar');
         $this->assertEquals('https://josh:sekrit@example.com/bar?abc=123#section3', (string) $uri);
+
+        // ensure that a Uri with just a base path correctly converts to a string
+        // (This occurs via createFromEnvironment when index.php is in a subdirectory)
+        $environment = Environment::mock([
+            'SCRIPT_NAME' => '/foo/index.php',
+            'REQUEST_URI' => '/foo/',
+            'HTTP_HOST' => 'example.com',
+        ]);
+        $uri = Uri::createFromEnvironment($environment);
+        $this->assertEquals('http://example.com/foo/', (string) $uri);
+
     }
 
     /**


### PR DESCRIPTION
This PR fixes two issues:
- The basePath isn't cleared when calling `withPath('/bar')`
- __toString doesn't take `basePath` into account every time, which results in an incorrect URI being returned in a specific situation. (test included)
