### PR TITLE
Update the meta information when getMetadata() is called

### DIFF
--- a/Slim/Http/Stream.php
+++ b/Slim/Http/Stream.php
@@ -100,6 +100,7 @@ class Stream implements StreamInterface
      */
     public function getMetadata($key = null)
     {
+        $this->meta = stream_get_meta_data($this->stream);
         if (is_null($key) === true) {
             return $this->meta;
         }
@@ -139,7 +140,6 @@ class Stream implements StreamInterface
         }
 
         $this->stream = $newStream;
-        $this->meta = stream_get_meta_data($newStream);
     }
 
     /**
@@ -253,8 +253,9 @@ class Stream implements StreamInterface
         if ($this->readable === null) {
             $this->readable = false;
             if ($this->isAttached()) {
+                $meta = $this->getMetadata();
                 foreach (self::$modes['readable'] as $mode) {
-                    if (strpos($this->meta['mode'], $mode) === 0) {
+                    if (strpos($meta['mode'], $mode) === 0) {
                         $this->readable = true;
                         break;
                     }
@@ -275,8 +276,9 @@ class Stream implements StreamInterface
         if ($this->writable === null) {
             $this->writable = false;
             if ($this->isAttached()) {
+                $meta = $this->getMetadata();
                 foreach (self::$modes['writable'] as $mode) {
-                    if (strpos($this->meta['mode'], $mode) === 0) {
+                    if (strpos($meta['mode'], $mode) === 0) {
                         $this->writable = true;
                         break;
                     }
@@ -297,7 +299,8 @@ class Stream implements StreamInterface
         if ($this->seekable === null) {
             $this->seekable = false;
             if ($this->isAttached()) {
-                $this->seekable = $this->meta['seekable'];
+                $meta = $this->getMetadata();
+                $this->seekable = $meta['seekable'];
             }
         }
 

--- a/Slim/Http/Stream.php
+++ b/Slim/Http/Stream.php
@@ -384,6 +384,9 @@ class Stream implements StreamInterface
             throw new RuntimeException('Could not write to stream');
         }
 
+        // reset size so that it will be recalculated on next call to getSize()
+        $this->size = null;
+
         return $written;
     }
 

--- a/tests/Http/BodyTest.php
+++ b/tests/Http/BodyTest.php
@@ -66,17 +66,6 @@ class BodyTest extends \PHPUnit_Framework_TestCase
         $body = new Body($this->stream);
     }
 
-    public function testConstructorSetsMetadata()
-    {
-        $this->stream = $this->resourceFactory();
-        $body = new Body($this->stream);
-
-        $bodyMetadata = new ReflectionProperty($body, 'meta');
-        $bodyMetadata->setAccessible(true);
-
-        $this->assertTrue(is_array($bodyMetadata->getValue($body)));
-    }
-
     public function testGetMetadata()
     {
         $this->stream = $this->resourceFactory();


### PR DESCRIPTION
This ensures that the metadata isn't stale if the stream has changed.
Also remove test for setting metadata in constructor as we no longer do this.

Fixes #1399
