### PR TITLE
Fix for #1432

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -193,7 +193,7 @@ class Router
         $pattern = preg_replace($search, $params, $this->getNamedRoute($name)->getPattern());
 
         //Remove remnants of unpopulated, trailing optional pattern segments, escaped special characters
-        return preg_replace('#\(/?:.+\)|\(|\)|\\\\#', '', $pattern);
+        return preg_replace('#\((/[^/]+)*/?:.+\)|\(|\)|\\\\#', '', $pattern);
     }
 
     /**


### PR DESCRIPTION
urlFor changed to create correct urls when using fixed parts in optional route segment, e.g. /items(/page/:page) will produce /items when no parameter given, or /items/page/:10 when calling urlFor('items', [ 'page' => 10 ])
