### PR TITLE
Do not assume response body is seekable in App::respond. Fixes #1434

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -349,7 +349,9 @@ class App
             // Body
             if (!$this->isEmptyResponse($response)) {
                 $body = $response->getBody();
-                $body->rewind();
+                if ($body->isSeekable()) {
+                    $body->rewind();
+                }
                 $settings = $this->container->get('settings');
                 while (!$body->eof()) {
                     echo $body->read($settings['responseChunkSize']);


### PR DESCRIPTION
This checks to see if the Response StreamInterface body is in fact seekable before attempting to seek it.
