### PR TITLE
Add basePath to Router Fixes #1440

### DIFF
--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -147,7 +147,15 @@ final class Container extends PimpleContainer implements ContainerInterface
          * @return RouterInterface
          */
         $this['router'] = function ($c) {
-            return new Router();
+            $router = new Router();
+
+            $uri = $c['request']->getUri();
+
+            if (is_callable([$uri, 'getBasePath'])) {
+                $router->setBasePath($uri->getBasePath());
+            }
+
+            return $router;
         };
 
         /**

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -38,6 +38,13 @@ class Router extends RouteCollector implements RouterInterface
     private $routeParser;
 
     /**
+     * Base path used in pathFor()
+     *
+     * @var string
+     */
+    protected $basePath = '';
+
+    /**
      * Routes
      *
      * @var Route[]
@@ -72,6 +79,24 @@ class Router extends RouteCollector implements RouterInterface
         $generator = $generator ? $generator : new GroupCountBasedGenerator;
         parent::__construct($parser, $generator);
         $this->routeParser = $parser;
+    }
+
+    /**
+     * Set the base path used in pathFor()
+     *
+     * @param string $basePath
+     *
+     * @return self
+     */
+    public function setBasePath($basePath)
+    {
+        if (!is_string($basePath)) {
+            throw new InvalidArgumentException('Router basePath must be a string');
+        }
+
+        $this->basePath = $basePath;
+
+        return $this;
     }
 
     /**
@@ -263,6 +288,10 @@ class Router extends RouteCollector implements RouterInterface
             throw new InvalidArgumentException('Missing data for URL segment: ' . $segmentName);
         }
         $url = implode('', $segments);
+
+        if ($this->basePath) {
+            $url = $this->basePath . $url;
+        }
 
         if ($queryParams) {
             $url .= '?' . http_build_query($queryParams);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -760,16 +760,6 @@ class AppTest extends \PHPUnit_Framework_TestCase
     {
         $app = new App();
 
-        $mw = function ($req, $res, $next) {
-            throw new \Exception('middleware exception');
-        };
-
-        $app->add($mw);
-
-        $app->get('/foo', function ($req, $res) {
-            return $res;
-        });
-
         // Prepare request and response objects
         $env = Environment::mock([
             'SCRIPT_NAME' => '/index.php',
@@ -785,6 +775,17 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $res = new Response();
         $app->getContainer()['request'] = $req;
         $app->getContainer()['response'] = $res;
+
+        $mw = function ($req, $res, $next) {
+            throw new \Exception('middleware exception');
+        };
+
+        $app->add($mw);
+
+        $app->get('/foo', function ($req, $res) {
+            return $res;
+        });
+
         $resOut = $app->run();
 
         $this->assertEquals(500, $resOut->getStatusCode());

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -80,6 +80,23 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             $this->router->pathFor('foo', ['first' => 'josh', 'last' => 'lockhart'])
         );
     }
+    
+    public function testPathForWithBasePath()
+    {
+        $methods = ['GET'];
+        $pattern = '/hello/{first:\w+}/{last}';
+        $callable = function ($request, $response, $args) {
+            echo sprintf('Hello %s %s', $args['first'], $args['last']);
+        };
+        $this->router->setBasePath('/base/path');
+        $route = $this->router->map($methods, $pattern, $callable);
+        $route->setName('foo');
+
+        $this->assertEquals(
+            '/base/path/hello/josh/lockhart',
+            $this->router->pathFor('foo', ['first' => 'josh', 'last' => 'lockhart'])
+        );
+    }
 
     public function testPathForWithOptionalParameters()
     {
@@ -151,5 +168,13 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $route->setName('foo');
 
         $this->router->pathFor('bar', ['first' => 'josh', 'last' => 'lockhart']);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSettingInvalidBasePath()
+    {
+        $this->router->setBasePath(['invalid']);
     }
 }


### PR DESCRIPTION
After some chatting with @akrabat about #1440 this is the result.
This should now work in combination with a base path:

``` php
$app->get('/books', function () {})->setName('books');

$app->get('/test', function ($request, $response, $args) {
    $uri = $request->getUri()->withPath($this->router->pathFor('books'));

    return $response->withRedirect($uri, 307);
});
```
