### PR TITLE
Always resolve callables through the CallableResolver

### DIFF
--- a/Slim/CallableResolverAwareTrait.php
+++ b/Slim/CallableResolverAwareTrait.php
@@ -34,18 +34,14 @@ trait CallableResolverAwareTrait
      */
     protected function resolveCallable($callable)
     {
-        if (is_string($callable) && !is_callable($callable)) {
-            if ($this->container instanceof ContainerInterface) {
-                $container = $this->container;
-            } else {
-                throw new RuntimeException('Cannot resolve callable string');
-            }
-            /** @var CallableResolver $resolver */
-            $resolver = clone($container->get('callableResolver')); // we need a new one each time
-            $resolver->setToResolve($callable);
-            $callable = $resolver;
+        if (is_callable($callable) || !$this->container instanceof ContainerInterface) {
+            return $callable;
         }
 
-        return $callable;
+        /** @var CallableResolver $resolver */
+        $resolver = clone($this->container->get('callableResolver')); // we need a new one each time
+        $resolver->setToResolve($callable);
+
+        return $resolver;
     }
 }

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -302,9 +302,7 @@ class Route extends Routable implements RouteInterface
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
-        if (is_string($this->callable)) {
-            $this->callable = $this->resolveCallable($this->callable);
-        }
+        $this->callable = $this->resolveCallable($this->callable);
 
         /** @var InvocationStrategyInterface $handler */
         $handler = isset($this->container) ? $this->container->get('foundHandler') : new RequestResponse();

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -16,6 +16,7 @@ use Slim\Http\Request;
 use Slim\Http\Response;
 use Slim\Http\Uri;
 use Slim\Route;
+use Slim\Tests\Mocks\CallableTest;
 
 class RouteTest extends \PHPUnit_Framework_TestCase
 {
@@ -172,7 +173,25 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Slim\Http\Response', $result);
     }
 
-    // TODO: Test adding controller callables with "Foo:bar" syntax
+    public function testControllerInContainer()
+    {
+        $route = new Route(['GET'], '/', 'CallableTest:toCall');
+
+        $container = new Container();
+        $container['CallableTest'] = new CallableTest;
+        $route->setContainer($container);
+
+        $uri = Uri::createFromString('https://example.com:80');
+        $body = new Body(fopen('php://temp', 'r+'));
+        $request = new Request('GET', $uri, new Headers(), [], Environment::mock()->all(), $body);
+
+        CallableTest::$CalledCount = 0;
+
+        $result = $route->callMiddlewareStack($request, new Response);
+
+        $this->assertInstanceOf('Slim\Http\Response', $result);
+        $this->assertEquals(1, CallableTest::$CalledCount);
+    }
 
     /**
      * Ensure that the response returned by a route callable is the response


### PR DESCRIPTION
Always resolve callables through the CallableResolver, **even if it's not a `foo:bar` string**.

---

In default Slim's behavior, controller like `foo:bar` go through the `CallableResolver` so that `foo` is resolved using the container.

However I would like to allow other kind of syntaxes to write controller as services, e.g. `['Foo', 'bar']` (this being **not** a static method, so `Foo` is created by the container), `'My\Invokable\Controller'`, etc (basically this https://github.com/PHP-DI/Invoker#resolving-callables-from-a-container). To achieve this, I just have to write a custom `CallableResolver`.

However `Route` will call `CallableResolver` only if the controller is a string. I've changed that so that `CallableResolver` is always called, allowing users to customize completely how controllers are located.
