### PR TITLE
Refactored CallableResolver into a stateless service focused on resolving callables only

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -106,6 +106,9 @@ class App
     public function add($callable)
     {
         $callable = $this->resolveCallable($callable);
+        if ($callable instanceof Closure) {
+            $callable = $callable->bindTo($this->container);
+        }
 
         return $this->addMiddleware($callable);
     }

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -106,9 +106,6 @@ class App
     public function add($callable)
     {
         $callable = $this->resolveCallable($callable);
-        if ($callable instanceof Closure) {
-            $callable = $callable->bindTo($this->container);
-        }
 
         return $this->addMiddleware($callable);
     }

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -14,8 +14,7 @@ use Slim\Interfaces\CallableResolverInterface;
 
 /**
  * This class resolves a string of the format 'class:method' into a closure
- * that can be dispatched. It is itself invokable as it lazily resolves the string
- * when it is invoked.
+ * that can be dispatched.
  */
 final class CallableResolver implements CallableResolverInterface
 {
@@ -25,34 +24,11 @@ final class CallableResolver implements CallableResolverInterface
     private $container;
 
     /**
-     * @var string
-     */
-    private $toResolve;
-
-    /**
-     * @var callable
-     */
-    private $resolved;
-
-    /**
      * @param ContainerInterface $container
-     * @param string             $toResolve
      */
-    public function __construct(ContainerInterface $container, $toResolve = null)
+    public function __construct(ContainerInterface $container)
     {
-        $this->toResolve = $toResolve;
         $this->container = $container;
-    }
-
-
-    /**
-     * Receive a string that is to be resolved to a callable
-     *
-     * @param  string $toResolve
-     */
-    public function setToResolve($toResolve)
-    {
-        $this->toResolve = $toResolve;
     }
 
     /**
@@ -61,51 +37,45 @@ final class CallableResolver implements CallableResolverInterface
      * If toResolve is of the format 'class:method', then try to extract 'class'
      * from the container otherwise instantiate it and then dispatch 'method'.
      *
-     * @return \Closure
+     * @param mixed $toResolve
+     *
+     * @return callable
      *
      * @throws RuntimeException if the callable does not exist
      * @throws RuntimeException if the callable is not resolvable
      */
-    private function resolve()
+    public function resolve($toResolve)
     {
-        // if it's callable, then it's already resolved
-        if (is_callable($this->toResolve)) {
-            $this->resolved = $this->toResolve;
-
-        // check for slim callable as "class:method"
-        } elseif (is_string($this->toResolve)) {
-            $callable_pattern = '!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!';
-            if (preg_match($callable_pattern, $this->toResolve, $matches)) {
-                $class = $matches[1];
-                $method = $matches[2];
-
-                if ($this->container->has($class)) {
-                    $this->resolved = [$this->container->get($class), $method];
-                } else {
-                    if (!class_exists($class)) {
-                        throw new RuntimeException(sprintf('Callable %s does not exist', $class));
-                    }
-                    $this->resolved = [new $class, $method];
-                }
-                if (!is_callable($this->resolved)) {
-                    throw new RuntimeException(sprintf('%s is not resolvable', $this->toResolve));
-                }
-            } else {
-                throw new RuntimeException(sprintf('%s is not resolvable', $this->toResolve));
+        if (!is_callable($toResolve) && is_string($toResolve)) {
+            // check for slim callable as "class:method"
+            $callablePattern = '!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!';
+            if (!preg_match($callablePattern, $toResolve, $matches)) {
+                throw new RuntimeException(sprintf('%s is not resolvable', $toResolve));
             }
-        }
-    }
 
-    /**
-     * Invoke the resolved callable.
-     *
-     * @return \Psr\Http\Message\ResponseInterface
-     */
-    public function __invoke()
-    {
-        if (!isset($this->resolved)) {
-            $this->resolve();
+            $class = $matches[1];
+            $method = $matches[2];
+
+            if ($this->container->has($class)) {
+                $resolved = [$this->container->get($class), $method];
+            } else {
+                if (!class_exists($class)) {
+                    throw new RuntimeException(sprintf('Callable %s does not exist', $class));
+                }
+                $resolved = [new $class, $method];
+            }
+
+            if (!is_callable($resolved)) {
+                throw new RuntimeException(sprintf('%s is not resolvable', $toResolve));
+            }
+        } else {
+            $resolved = $toResolve;
         }
-        return call_user_func_array($this->resolved, func_get_args());
+
+        if ($resolved instanceof \Closure) {
+            $resolved = $resolved->bindTo($this->container);
+        }
+
+        return $resolved;
     }
 }

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -70,8 +70,6 @@ final class CallableResolver implements CallableResolverInterface
 
         if (!is_callable($resolved)) {
             throw new RuntimeException(sprintf('%s is not resolvable', $toResolve));
-        } elseif ($resolved instanceof \Closure) {
-            $resolved = $resolved->bindTo($this->container);
         }
 
         return $resolved;

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -64,15 +64,13 @@ final class CallableResolver implements CallableResolverInterface
                 }
                 $resolved = [new $class, $method];
             }
-
-            if (!is_callable($resolved)) {
-                throw new RuntimeException(sprintf('%s is not resolvable', $toResolve));
-            }
         } else {
             $resolved = $toResolve;
         }
 
-        if ($resolved instanceof \Closure) {
+        if (!is_callable($resolved)) {
+            throw new RuntimeException(sprintf('%s is not resolvable', $toResolve));
+        } elseif ($resolved instanceof \Closure) {
             $resolved = $resolved->bindTo($this->container);
         }
 

--- a/Slim/CallableResolverAwareTrait.php
+++ b/Slim/CallableResolverAwareTrait.php
@@ -35,7 +35,7 @@ trait CallableResolverAwareTrait
      */
     protected function resolveCallable($callable)
     {
-        if (is_callable($callable) || !$this->container instanceof ContainerInterface) {
+        if (!$this->container instanceof ContainerInterface) {
             return $callable;
         }
 

--- a/Slim/CallableResolverAwareTrait.php
+++ b/Slim/CallableResolverAwareTrait.php
@@ -10,6 +10,7 @@ namespace Slim;
 
 use RuntimeException;
 use Interop\Container\ContainerInterface;
+use Slim\Interfaces\CallableResolverInterface;
 
 /**
  * ResolveCallable
@@ -26,7 +27,7 @@ trait CallableResolverAwareTrait
      * Resolve a string of the format 'class:method' into a closure that the
      * router can dispatch.
      *
-     * @param string $callable
+     * @param mixed $callable
      *
      * @return \Closure
      *
@@ -38,10 +39,9 @@ trait CallableResolverAwareTrait
             return $callable;
         }
 
-        /** @var CallableResolver $resolver */
-        $resolver = clone($this->container->get('callableResolver')); // we need a new one each time
-        $resolver->setToResolve($callable);
+        /** @var CallableResolverInterface $resolver */
+        $resolver = $this->container->get('callableResolver');
 
-        return $resolver;
+        return $resolver->resolve($callable);
     }
 }

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -8,10 +8,8 @@
  */
 namespace Slim\Interfaces;
 
-use Psr\Http\Message\ResponseInterface;
-
 /**
- * Callable Resolver Interface
+ * Resolves a callable.
  *
  * @package Slim
  * @since 3.0.0
@@ -19,16 +17,11 @@ use Psr\Http\Message\ResponseInterface;
 interface CallableResolverInterface
 {
     /**
-     * Receive a string that is to be resolved to a callable
-     *
-     * @param string $toResolve
-     */
-    public function setToResolve($toResolve);
-
-    /**
      * Invoke the resolved callable.
      *
-     * @return ResponseInterface
+     * @param mixed $toResolve
+     *
+     * @return callable
      */
-    public function __invoke();
+    public function resolve($toResolve);
 }

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -8,6 +8,7 @@
  */
 namespace Slim;
 
+use Closure;
 use Exception;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -90,6 +91,9 @@ class Route extends Routable implements RouteInterface
     public function add($callable)
     {
         $callable = $this->resolveCallable($callable);
+        if ($callable instanceof Closure) {
+            $callable = $callable->bindTo($this->container);
+        }
 
         $this->middleware[] = $callable;
         return $this;

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -8,7 +8,6 @@
  */
 namespace Slim;
 
-use Closure;
 use Exception;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -84,16 +83,13 @@ class Route extends Routable implements RouteInterface
      *
      * This method prepends new middleware to the route's middleware stack.
      *
-     * @param  mixed    $callable The callback routine
+     * @param mixed $callable The callback routine
      *
      * @return RouteInterface
      */
     public function add($callable)
     {
         $callable = $this->resolveCallable($callable);
-        if ($callable instanceof Closure) {
-            $callable = $callable->bindTo($this->container);
-        }
 
         $this->middleware[] = $callable;
         return $this;

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -14,12 +14,10 @@ use Slim\Tests\Mocks\CallableTest;
 
 class CallableResolverTest extends \PHPUnit_Framework_TestCase
 {
-
     /**
      * @var Container
      */
     private $container;
-
 
     public function setUp()
     {
@@ -29,13 +27,14 @@ class CallableResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testClosure()
     {
-        $test_callable = function () {
+        $test = function () {
             static $called_count = 0;
             return $called_count++;
         };
-        $resolver = new CallableResolver($this->container, $test_callable);
-        $resolver();
-        $this->assertEquals(1, $test_callable());
+        $resolver = new CallableResolver($this->container);
+        $callable = $resolver->resolve($test);
+        $callable();
+        $this->assertEquals(1, $callable());
     }
 
     public function testFunctionName()
@@ -48,53 +47,57 @@ class CallableResolverTest extends \PHPUnit_Framework_TestCase
         };
         // @codingStandardsIgnoreEnd
 
-        $resolver = new CallableResolver($this->container, __NAMESPACE__ . '\testCallable');
-        $resolver();
-        $this->assertEquals(1, testCallable());
+        $resolver = new CallableResolver($this->container);
+        $callable = $resolver->resolve(__NAMESPACE__ . '\testCallable');
+        $callable();
+        $this->assertEquals(1, $callable());
     }
 
     public function testObjMethodArray()
     {
         $obj = new CallableTest();
-        $resolver = new CallableResolver($this->container, [$obj, 'toCall']);
-        $resolver();
+        $resolver = new CallableResolver($this->container);
+        $callable = $resolver->resolve([$obj, 'toCall']);
+        $callable();
         $this->assertEquals(1, CallableTest::$CalledCount);
     }
 
     public function testSlimCallable()
     {
-        $resolver = new CallableResolver($this->container, 'Slim\Tests\Mocks\CallableTest:toCall');
-        $resolver();
+        $resolver = new CallableResolver($this->container);
+        $callable = $resolver->resolve('Slim\Tests\Mocks\CallableTest:toCall');
+        $callable();
         $this->assertEquals(1, CallableTest::$CalledCount);
     }
 
     public function testContainer()
     {
         $this->container['callable_service'] = new CallableTest();
-        $resolver = new CallableResolver($this->container, 'callable_service:toCall');
-        $resolver();
+        $resolver = new CallableResolver($this->container);
+        $callable = $resolver->resolve('callable_service:toCall');
+        $callable();
         $this->assertEquals(1, CallableTest::$CalledCount);
     }
 
     public function testMethodNotFoundThrowException()
     {
         $this->container['callable_service'] = new CallableTest();
-        $resolver = new CallableResolver($this->container, 'callable_service:noFound');
+        $resolver = new CallableResolver($this->container);
         $this->setExpectedException('\RuntimeException');
-        $resolver();
+        $resolver->resolve('callable_service:noFound');
     }
 
     public function testFunctionNotFoundThrowException()
     {
-        $resolver = new CallableResolver($this->container, 'noFound');
+        $resolver = new CallableResolver($this->container);
         $this->setExpectedException('\RuntimeException');
-        $resolver();
+        $resolver->resolve('noFound');
     }
 
     public function testClassNotFoundThrowException()
     {
-        $resolver = new CallableResolver($this->container, 'Unknown:notFound');
+        $resolver = new CallableResolver($this->container);
         $this->setExpectedException('\RuntimeException', 'Callable Unknown does not exist');
-        $resolver();
+        $resolver->resolve('Unknown:notFound');
     }
 }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -17,6 +17,7 @@ use Slim\Http\Response;
 use Slim\Http\Uri;
 use Slim\Route;
 use Slim\Tests\Mocks\CallableTest;
+use Slim\Tests\Mocks\MiddlewareStub;
 
 class RouteTest extends \PHPUnit_Framework_TestCase
 {
@@ -153,6 +154,8 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route = $this->routeFactory();
 
         $container = new Container();
+        $container['MiddlewareStub'] = new MiddlewareStub();
+
         $route->setContainer($container);
         $route->add('MiddlewareStub:run');
 

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -196,28 +196,6 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, CallableTest::$CalledCount);
     }
 
-    public function testControllerIsBoundToContainer()
-    {
-        $route = new Route(['GET'], '/', function () {
-            return $this['CallableTest']->toCall();
-        });
-
-        $container = new Container();
-        $container['CallableTest'] = new CallableTest;
-        $route->setContainer($container);
-
-        $uri = Uri::createFromString('https://example.com:80');
-        $body = new Body(fopen('php://temp', 'r+'));
-        $request = new Request('GET', $uri, new Headers(), [], Environment::mock()->all(), $body);
-
-        CallableTest::$CalledCount = 0;
-
-        $result = $route->callMiddlewareStack($request, new Response);
-
-        $this->assertInstanceOf('Slim\Http\Response', $result);
-        $this->assertEquals(1, CallableTest::$CalledCount);
-    }
-
     /**
      * Ensure that the response returned by a route callable is the response
      * object that is returned by __invoke().

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -196,6 +196,28 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, CallableTest::$CalledCount);
     }
 
+    public function testControllerIsBoundToContainer()
+    {
+        $route = new Route(['GET'], '/', function () {
+            return $this['CallableTest']->toCall();
+        });
+
+        $container = new Container();
+        $container['CallableTest'] = new CallableTest;
+        $route->setContainer($container);
+
+        $uri = Uri::createFromString('https://example.com:80');
+        $body = new Body(fopen('php://temp', 'r+'));
+        $request = new Request('GET', $uri, new Headers(), [], Environment::mock()->all(), $body);
+
+        CallableTest::$CalledCount = 0;
+
+        $result = $route->callMiddlewareStack($request, new Response);
+
+        $this->assertInstanceOf('Slim\Http\Response', $result);
+        $this->assertEquals(1, CallableTest::$CalledCount);
+    }
+
     /**
      * Ensure that the response returned by a route callable is the response
      * object that is returned by __invoke().


### PR DESCRIPTION
Per discussions on IRC, I refactored CallableResolver into a stateless service focused on resolving callables only (not wrapping and invoking them).

This will lead to less object instantiations (since the service is now stateless instead of wrapping every middleware/controller callable), as well as better separation of concerns since the class' responsibility is now only to resolve callables. It isn't responsible of invoking callables anymore (responsibility which was spread between here and also the invokation strategy and middleware stack too IIRC).

One detail is that I have moved the `$callable->bindTo($container)` calls into the CallableResolver itself since it belongs there IMO (because it's about preparing callables for being invokable correctly). That avoids having "callable resolution" code all over the place (App and Route).

Feedback welcome. I'll probably be able to answer and update the PR in 2 days.
