### PR TITLE
Remove Request::isAjax()

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -409,28 +409,15 @@ class Request extends Message implements ServerRequestInterface
     }
 
     /**
-     * Is this an AJAX request?
-     *
-     * Note: This method is not part of the PSR-7 standard.
-     *
-     * @return bool
-     */
-    public function isAjax()
-    {
-        return $this->getHeaderLine('X-Requested-With') === 'XMLHttpRequest';
-    }
-
-    /**
      * Is this an XHR request?
      *
      * Note: This method is not part of the PSR-7 standard.
      *
-     * @see    isAjax()
      * @return bool
      */
     public function isXhr()
     {
-        return $this->isAjax();
+        return $this->getHeaderLine('X-Requested-With') === 'XMLHttpRequest';
     }
 
     /*******************************************************************************


### PR DESCRIPTION
Remove the `Request::isAjax()` method as it was identical to `Request::isXhr()`. 2 methods for the same check can only confuse people, so I would like to see one of them removed.

Since the check is if header `X-Requested-With` is `XMLHttpRequest` (xhr) it seems best to remove the `isAjax()` method.
