### PR TITLE
Set router's basePath on dispatch

### DIFF
--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -150,15 +150,7 @@ final class Container extends PimpleContainer implements ContainerInterface
          */
         if (!isset($this['router'])) {
             $this['router'] = function ($c) {
-                $router = new Router();
-
-                $uri = $c['request']->getUri();
-
-                if (is_callable([$uri, 'getBasePath'])) {
-                    $router->setBasePath($uri->getBasePath());
-                }
-
-                return $router;
+                return new Router();
             };
         }
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -42,7 +42,7 @@ class Router extends RouteCollector implements RouterInterface
      *
      * @var string
      */
-    protected $basePath = '';
+    protected $basePath = null;
 
     /**
      * Routes
@@ -155,6 +155,10 @@ class Router extends RouteCollector implements RouterInterface
      */
     public function dispatch(ServerRequestInterface $request)
     {
+        if (null === $this->basePath) {
+            $this->setBasePath($request->getUri()->getBasePath());
+        }
+
         $this->finalize();
 
         $dispatcher = new GroupCountBasedDispatcher($this->getData());


### PR DESCRIPTION
Move setting of the router's basePath to dispatch() so that adding routes doesn't freeze the environment and request container items.

To allow setting of the base path prior to dispatch, we only set it if it's currently null.

This addresses #1465
