### PR TITLE
Set router's basePath when App::run() is called

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -292,7 +292,7 @@ class App
         // Finalize routes here for middleware stack & ensure basePath is set
         $router = $this->container->get('router');
         $router->finalize();
-        if (is_callable([$request->getUri(), 'getBasePath'])) {
+        if (is_callable([$request->getUri(), 'getBasePath']) && is_callable([$router, 'setBasePath'])) {
             $router->setBasePath($request->getUri()->getBasePath());
         }
 

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -286,11 +286,16 @@ class App
      */
     public function run($silent = false)
     {
-        // Finalize routes here for middleware stack
-        $this->container->get('router')->finalize();
-
         $request = $this->container->get('request');
         $response = $this->container->get('response');
+
+        // Finalize routes here for middleware stack & ensure basePath is set
+        $router = $this->container->get('router');
+        $router->finalize();
+        if (is_callable([$request->getUri(), 'getBasePath'])) {
+            $router->setBasePath($request->getUri()->getBasePath());
+        }
+
 
         // Dispatch the Router first if the setting for this is on
         if ($this->container->get('settings')['determineRouteBeforeAppMiddleware'] === true) {

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -150,15 +150,7 @@ final class Container extends PimpleContainer implements ContainerInterface
          */
         if (!isset($this['router'])) {
             $this['router'] = function ($c) {
-                $router = new Router();
-
-                $uri = $c['request']->getUri();
-
-                if (is_callable([$uri, 'getBasePath'])) {
-                    $router->setBasePath($uri->getBasePath());
-                }
-
-                return $router;
+                return new Router();
             };
         }
 


### PR DESCRIPTION
Move setting of the router's basePath to App::run() so that adding routes doesn't freeze the environment and request container items.

I've moved the setting to `run()` so that middleware is able to call the router's `pathFor`.

This addresses #1465
