### PR TITLE
Add a meta tag for utf-8 content in exception page.

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -43,7 +43,8 @@ class Error
         }
 
         $output = sprintf(
-            "<html><head><title>%s</title><style>body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana," .
+            "<html><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'>" .
+            "<title>%s</title><style>body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana," .
             "sans-serif;}h1{margin:0;font-size:48px;font-weight:normal;line-height:48px;}strong{display:inline-block;" .
             "width:65px;}</style></head><body><h1>%s</h1>%s</body></html>",
             $title,


### PR DESCRIPTION
I think that the exception page needs a meta tag for utf-8 support. The desired effect can be found in the attached images.
![slim_ex_before](https://cloud.githubusercontent.com/assets/2580674/9563758/1128ee4a-4e8f-11e5-95c2-b3d84f3570a5.png)
![slim_ex_after](https://cloud.githubusercontent.com/assets/2580674/9563759/1171897a-4e8f-11e5-9494-239a1441ee7c.png)
