### PR TITLE
Added a check to ensure that the 'determineRouteBeforeAppMiddleware' …

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -298,7 +298,9 @@ class App
 
 
         // Dispatch the Router first if the setting for this is on
-        if ($this->container->get('settings')['determineRouteBeforeAppMiddleware'] === true) {
+        if (isset($this->container->get('settings')['determineRouteBeforeAppMiddleware']) &&
+            $this->container->get('settings')['determineRouteBeforeAppMiddleware'] === true
+        ) {
             // Dispatch router (note: you won't be able to alter routes after this)
             $request = $this->dispatchRouterAndPrepareRoute($request);
         }


### PR DESCRIPTION
…settings key was set before seeing if it's set to true. This will help when using a 3rd party DI container that doesn't know to set it by default.

(I was playing around with https://github.com/akrabat/slim3-abstract-action-factory and PHP kept throwing "Notice: Undefined index: determineRouteBeforeAppMiddleware".)
