### PR TITLE
Don't call errorHandler if we don't have one

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -309,6 +309,9 @@ class App
         } catch (SlimException $e) {
             $response = $e->getResponse();
         } catch (Exception $e) {
+            if (!$this->container->has('errorHandler')) {
+                throw $e;
+            }
             /** @var callable $errorHandler */
             $errorHandler = $this->container->get('errorHandler');
             $response = $errorHandler($request, $response, $e);


### PR DESCRIPTION
If the errorHandler has been unregistered, then just throw the Exception
again. This allows for completely disabling our error handling by doing:

```
unset($app->getContainer()['errorHandler']);
```
