### PR TITLE
Return arrays where possible for getParsedBody()

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -182,7 +182,7 @@ class Request extends Message implements ServerRequestInterface
         }
 
         $this->registerMediaTypeParser('application/json', function ($input) {
-            return json_decode($input);
+            return json_decode($input, true);
         });
 
         $this->registerMediaTypeParser('application/xml', function ($input) {
@@ -191,7 +191,7 @@ class Request extends Message implements ServerRequestInterface
 
         $this->registerMediaTypeParser('application/x-www-form-urlencoded', function ($input) {
             parse_str($input, $data);
-            return (object)$data;
+            return $data;
         });
     }
 

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -694,7 +694,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $body = new RequestBody();
         $body->write('foo=bar');
         $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
-        $this->assertEquals((object)['foo' => 'bar'], $request->getParsedBody());
+        $this->assertEquals(['foo' => 'bar'], $request->getParsedBody());
     }
 
     public function testGetParsedBodyJson()
@@ -709,7 +709,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $body->write('{"foo":"bar"}');
         $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
 
-        $this->assertEquals((object)['foo' => 'bar'], $request->getParsedBody());
+        $this->assertEquals(['foo' => 'bar'], $request->getParsedBody());
     }
 
     public function testGetParsedBodyXml()


### PR DESCRIPTION
This fixes the weird case that if you POST, then getParsedBody() will have an array in it ($_POST), but if you PUT or have json, then getParsedBody() will have an object.

Even more weirdly, if you POST with the hidden _METHOD=PUT, you get an array in your put() handler, but if you PUT to it then your put() handler gets an object!

It's much more consistent to try to always make it an array and ensures that we can also handle keys with hyphens much more sanely as they are horrible to deal with when in a stdClass.
