### PR TITLE
Update error handlers to be content-type aware

### DIFF
--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -13,10 +13,10 @@ use Psr\Http\Message\ResponseInterface;
 use Slim\Http\Body;
 
 /**
- * Default not allowed handler
+ * Default Slim application not allowed handler
  *
- * This is the default Slim application error handler. All it does is output
- * a clean and simple HTML page with diagnostic information.
+ * It outputs a simple message in either JSON, XML or HTML based on the
+ * Accept header.
  */
 class NotAllowed
 {
@@ -32,22 +32,82 @@ class NotAllowed
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $methods)
     {
         $allow = implode(', ', $methods);
-        $body = new Body(fopen('php://temp', 'r+'));
 
         if ($request->getMethod() === 'OPTIONS') {
             $status = 200;
             $contentType = 'text/plain';
-            $body->write('Allowed methods: ' . $allow);
+            $output = 'Allowed methods: ' . $allow;
         } else {
             $status = 405;
-            $contentType = 'text/html';
-            $body->write('<p>Method not allowed. Must be one of: ' . $allow . '</p>');
+            $contentType = $this->determineContentType($request->getHeaderLine('Accept'));
+            switch ($contentType) {
+                case 'application/json':
+                    $output = '{"message":"Method not allowed. Must be one of: ' . $allow . '"}';
+                    break;
+
+                case 'application/xml':
+                    $output = "<root><message>Method not allowed. Must be one of: $allow</message></root>";
+                    break;
+
+                case 'text/html':
+                default:
+                    $contentType = 'text/html';
+                    $output = <<<END
+<html>
+    <head>
+        <title>Method not allowed</title>
+        <style>
+            body{
+                margin:0;
+                padding:30px;
+                font:12px/1.5 Helvetica,Arial,Verdana,sans-serif;
+            }
+            h1{
+                margin:0;
+                font-size:48px;
+                font-weight:normal;
+                line-height:48px;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>Method not allowed</h1>
+        <p>Method not allowed. Must be one of: <strong>$allow</strong></p>
+    </body>
+</html>
+END;
+                    break;
+            }
         }
+
+        $body = new Body(fopen('php://temp', 'r+'));
+        $body->write($output);
 
         return $response
                 ->withStatus($status)
                 ->withHeader('Content-type', $contentType)
                 ->withHeader('Allow', $allow)
                 ->withBody($body);
+    }
+
+    /**
+     * Read the accept header and determine which content type we know about
+     * is wanted.
+     *
+     * @param  string $acceptHeader Accept header from request
+     * @return string
+     */
+    private function determineContentType($acceptHeader)
+    {
+        $list = explode(',', $acceptHeader);
+        $known = ['application/json', 'application/xml', 'text/html'];
+        
+        foreach ($list as $type) {
+            if (in_array($type, $known)) {
+                return $type;
+            }
+        }
+
+        return 'text/html';
     }
 }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -279,7 +279,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
         $this->assertEquals(405, (string)$resOut->getStatusCode());
         $this->assertEquals(['GET'], $resOut->getHeader('Allow'));
-        $this->assertEquals('<p>Method not allowed. Must be one of: GET</p>', (string)$resOut->getBody());
+        $this->assertContains('<p>Method not allowed. Must be one of: <strong>GET</strong></p>', (string)$resOut->getBody());
     }
 
     public function testInvokeWithMatchingRoute()

--- a/tests/Handlers/ErrorTest.php
+++ b/tests/Handlers/ErrorTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Handlers;
+
+use Slim\Handlers\Error;
+use Slim\Http\Response;
+
+class ErrorTest extends \PHPUnit_Framework_TestCase
+{
+    public function errorProvider()
+    {
+        return [
+            ['application/json', '{'],
+            ['application/xml', '<root>'],
+            ['text/html', '<html>'],
+        ];
+    }
+
+    /**
+     * Test invalid method returns the correct code and content type
+     *
+     * @dataProvider errorProvider
+     */
+    public function testError($contentType, $startOfBody)
+    {
+        $notAllowed = new Error();
+        $e  = new \Exception("Oops");
+
+        /** @var Response $res */
+        $res = $notAllowed->__invoke($this->getRequest('GET', $contentType), new Response(), $e);
+
+        $this->assertSame(500, $res->getStatusCode());
+        $this->assertSame($contentType, $res->getHeaderLine('Content-Type'));
+        $this->assertEquals(0, strpos((string)$res->getBody(), $startOfBody));
+    }
+
+    /**
+     * @param string $method
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Slim\Http\Request
+     */
+    protected function getRequest($method, $contentType = 'text/html')
+    {
+        $req = $this->getMockBuilder('Slim\Http\Request')->disableOriginalConstructor()->getMock();
+        $req->expects($this->once())->method('getHeaderLine')->will($this->returnValue($contentType));
+
+        return $req;
+    }
+}


### PR DESCRIPTION
Ensure that Error, NotAllowed and NotFound return JSON, XML or HTML as determined by the request's Accept header. This makes Slim much more API friendly as the correct type of error will be returned without having to write three special handlers just to return JSON (or XML).
