### PR TITLE
Add some little `improvements` to the error handler

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -148,7 +148,7 @@ class Error
             ];
         } while ($exception = $exception->getPrevious());
 
-        return json_encode($error);
+        return json_encode($error, JSON_PRETTY_PRINT);
     }
 
     /**

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -162,21 +162,17 @@ class Error
         $xml = "<root>\n  <message>Slim Application Error</message>\n";
 
         do {
-            $type = get_class($exception);
-            $xml .= <<<EOT
-  <exception>
-    <type>{$type}</type>
-    <code>{$exception->getCode()}</code>
-    <message>{$exception->getMessage()}</message>
-    <file>{$exception->getFile()}</file>
-    <line>{$exception->getLine()}</line>
-    <trace>{$exception->getTraceAsString()}</trace>
-  </exception>
-
-EOT;
+            $xml .= "  <exception>\n";
+            $xml .= "    <type>" . get_class($exception) . "</type>\n";
+            $xml .= "    <code>" . $exception->getCode() . "</code>\n";
+            $xml .= "    <message>" . $exception->getMessage() . "</message>\n";
+            $xml .= "    <file>" . $exception->getFile() . "</file>\n";
+            $xml .= "    <line>" . $exception->getLine() . "</line>\n";
+            $xml .= "    <trace>" . $exception->getTraceAsString() . "</trace>\n";
+            $xml .= "  </exception>\n";
         } while ($exception = $exception->getPrevious());
 
-        $xml .="</root>";
+        $xml .= "<root>";
 
         return $xml;
     }

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -139,6 +139,7 @@ class Error
 
         do {
             $error['exception'][] = [
+                'type' => get_class($exception),
                 'code' => $exception->getCode(),
                 'message' => $exception->getMessage(),
                 'file' => $exception->getFile(),
@@ -161,8 +162,10 @@ class Error
         $xml = "<root>\n  <message>Slim Application Error</message>\n";
 
         do {
+            $type = get_class($exception);
             $xml .= <<<EOT
   <exception>
+    <type>{$type}</type>
     <code>{$exception->getCode()}</code>
     <message>{$exception->getMessage()}</message>
     <file>{$exception->getFile()}</file>

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -98,29 +98,29 @@ class Error
      */
     private function renderHtmlException(Exception $exception)
     {
-        $code = $exception->getCode();
-        $message = $exception->getMessage();
-        $file = $exception->getFile();
-        $line = $exception->getLine();
-        $trace = str_replace(['#', '\n'], ['<div>#', '</div>'], $exception->getTraceAsString());
-
         $html = sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
-        if ($code) {
+
+        if (($code = $exception->getCode())) {
             $html .= sprintf('<div><strong>Code:</strong> %s</div>', $code);
         }
-        if ($message) {
-            $html .= sprintf('<div><strong>Message:</strong> %s</div>', $message);
+
+        if (($message = $exception->getMessage())) {
+            $html .= sprintf('<div><strong>Message:</strong> %s</div>', htmlentities($message));
         }
-        if ($file) {
+
+        if (($file = $exception->getFile())) {
             $html .= sprintf('<div><strong>File:</strong> %s</div>', $file);
         }
-        if ($line) {
+
+        if (($line = $exception->getLine())) {
             $html .= sprintf('<div><strong>Line:</strong> %s</div>', $line);
         }
-        if ($trace) {
+
+        if (($trace = $exception->getTraceAsString())) {
             $html .= '<h2>Trace</h2>';
-            $html .= sprintf('<pre>%s</pre>', $trace);
+            $html .= sprintf('<pre>%s</pre>', htmlentities($trace));
         }
+
         return $html;
     }
 

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -165,16 +165,27 @@ class Error
             $xml .= "  <exception>\n";
             $xml .= "    <type>" . get_class($exception) . "</type>\n";
             $xml .= "    <code>" . $exception->getCode() . "</code>\n";
-            $xml .= "    <message>" . $exception->getMessage() . "</message>\n";
+            $xml .= "    <message>" . $this->createCdataSection($exception->getMessage()) . "</message>\n";
             $xml .= "    <file>" . $exception->getFile() . "</file>\n";
             $xml .= "    <line>" . $exception->getLine() . "</line>\n";
-            $xml .= "    <trace>" . $exception->getTraceAsString() . "</trace>\n";
+            $xml .= "    <trace>" . $this->createCdataSection($exception->getTraceAsString()) . "</trace>\n";
             $xml .= "  </exception>\n";
         } while ($exception = $exception->getPrevious());
 
         $xml .= "<error>";
 
         return $xml;
+    }
+
+    /**
+     * Returns a CDATA section with the given content.
+     *
+     * @param  string $content
+     * @return string
+     */
+    private function createCdataSection($content)
+    {
+        return sprintf('<![CDATA[%s]]>', str_replace(']]>', ']]]]><![CDATA[>', $content));
     }
 
     /**

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -159,7 +159,7 @@ class Error
      */
     private function renderXmlErrorMessage(Exception $exception)
     {
-        $xml = "<root>\n  <message>Slim Application Error</message>\n";
+        $xml = "<error>\n  <message>Slim Application Error</message>\n";
 
         do {
             $xml .= "  <exception>\n";
@@ -172,7 +172,7 @@ class Error
             $xml .= "  </exception>\n";
         } while ($exception = $exception->getPrevious());
 
-        $xml .= "<root>";
+        $xml .= "<error>";
 
         return $xml;
     }

--- a/tests/Handlers/ErrorTest.php
+++ b/tests/Handlers/ErrorTest.php
@@ -17,7 +17,7 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['application/json', '{'],
-            ['application/xml', '<root>'],
+            ['application/xml', '<error>'],
             ['text/html', '<html>'],
         ];
     }


### PR DESCRIPTION
Most important changes:
- add missing exception type to json/xml format (mentioned in #1498)
- renamed the root element to **error** for clarity (xml format)
- wrapped the json output in a root element like the xml format to make it more consistent

I found that heredoc, used in `renderXmlErrorMessage`, is a little bit limited to work with (calling functions for example). So I've changed the code to make it easier to work with (IMHO) for future changes.

Not sure whether we should wrap some xml elements like trace in `<![CDATA[ ]]>` tags.
