### PR TITLE
App output length equal to specified content-length (if specified explicitly)

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -370,7 +370,7 @@ class App
                 $lastChunkSize  = $contentLength % $chunkSize;
                 $currentChunk   = 0;
                 while (!$body->eof() && $currentChunk < $totalChunks) {
-                    if (++$currentChunk == $totalChunks) {
+                    if (++$currentChunk == $totalChunks && $lastChunkSize > 0) {
                         $chunkSize = $lastChunkSize;
                     }
                     echo $body->read($chunkSize);

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -496,7 +496,7 @@ class App
         }
 
         $size = $response->getBody()->getSize();
-        if ($size !== null) {
+        if ($size !== null && !$response->hasHeader('Content-Length')) {
             $response = $response->withHeader('Content-Length', (string) $size);
         }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -807,53 +807,58 @@ class AppTest extends \PHPUnit_Framework_TestCase
      */
     public function testRespondWithPaddedStreamFilterOutput()
     {
-        $app = new App();
-        $app->get('/foo', function ($req, $res) {
-            $key = base64_decode('xxxxxxxxxxxxxxxx');
-            $iv = base64_decode('Z6wNDk9LogWI4HYlRu0mng==');
+        $availableFilter = stream_get_filters();
+        if (in_array('mcrypt.*', $availableFilter) && in_array('mdecrypt.*', $availableFilter)) {
+            $app = new App();
+            $app->get('/foo', function ($req, $res) {
+                $key = base64_decode('xxxxxxxxxxxxxxxx');
+                $iv = base64_decode('Z6wNDk9LogWI4HYlRu0mng==');
 
-            $data = 'Hello';
-            $length = strlen($data);
+                $data = 'Hello';
+                $length = strlen($data);
 
-            $stream = fopen('php://temp','r+');
+                $stream = fopen('php://temp', 'r+');
 
-            $filter = stream_filter_append($stream, 'mcrypt.rijndael-128', STREAM_FILTER_WRITE, [
-                'key'   => $key,
-                'iv'    => $iv
+                $filter = stream_filter_append($stream, 'mcrypt.rijndael-128', STREAM_FILTER_WRITE, [
+                    'key' => $key,
+                    'iv' => $iv
+                ]);
+
+                fwrite($stream, $data);
+                rewind($stream);
+                stream_filter_remove($filter);
+
+                stream_filter_append($stream, 'mdecrypt.rijndael-128', STREAM_FILTER_READ, [
+                    'key' => $key,
+                    'iv' => $iv
+                ]);
+
+                return $res->withHeader('Content-Length', $length)->withBody(new Body($stream));
+            });
+
+            // Prepare request and response objects
+            $env = Environment::mock([
+                'SCRIPT_NAME' => '/index.php',
+                'REQUEST_URI' => '/foo',
+                'REQUEST_METHOD' => 'GET',
             ]);
+            $uri = Uri::createFromEnvironment($env);
+            $headers = Headers::createFromEnvironment($env);
+            $cookies = [];
+            $serverParams = $env->all();
+            $body = new RequestBody();
+            $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+            $res = new Response();
 
-            fwrite($stream, $data);
-            rewind($stream);
-            stream_filter_remove($filter);
+            // Invoke app
+            $resOut = $app($req, $res);
+            $app->respond($resOut);
 
-            stream_filter_append($stream, 'mdecrypt.rijndael-128', STREAM_FILTER_READ, [
-                'key'   => $key,
-                'iv'    => $iv
-            ]);
-
-            return $res->withHeader('Content-Length', $length)->withBody(new Body($stream));
-        });
-
-        // Prepare request and response objects
-        $env = Environment::mock([
-            'SCRIPT_NAME' => '/index.php',
-            'REQUEST_URI' => '/foo',
-            'REQUEST_METHOD' => 'GET',
-        ]);
-        $uri = Uri::createFromEnvironment($env);
-        $headers = Headers::createFromEnvironment($env);
-        $cookies = [];
-        $serverParams = $env->all();
-        $body = new RequestBody();
-        $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
-        $res = new Response();
-
-        // Invoke app
-        $resOut = $app($req, $res);
-        $app->respond($resOut);
-
-        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
-        $this->expectOutputString('Hello');
+            $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
+            $this->expectOutputString('Hello');
+        } else {
+            $this->assertTrue(true);
+        }
     }
 
     /**

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -805,6 +805,60 @@ class AppTest extends \PHPUnit_Framework_TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testRespondWithPaddedStreamFilterOutput()
+    {
+        $app = new App();
+        $app->get('/foo', function ($req, $res) {
+            $key = base64_decode('xxxxxxxxxxxxxxxx');
+            $iv = base64_decode('Z6wNDk9LogWI4HYlRu0mng==');
+
+            $data = 'Hello';
+            $length = strlen($data);
+
+            $stream = fopen('php://temp','r+');
+
+            $filter = stream_filter_append($stream, 'mcrypt.rijndael-128', STREAM_FILTER_WRITE, [
+                'key'   => $key,
+                'iv'    => $iv
+            ]);
+
+            fwrite($stream, $data);
+            rewind($stream);
+            stream_filter_remove($filter);
+
+            stream_filter_append($stream, 'mdecrypt.rijndael-128', STREAM_FILTER_READ, [
+                'key'   => $key,
+                'iv'    => $iv
+            ]);
+
+            return $res->withHeader('Content-Length', $length)->withBody(new Body($stream));
+        });
+
+        // Prepare request and response objects
+        $env = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo',
+            'REQUEST_METHOD' => 'GET',
+        ]);
+        $uri = Uri::createFromEnvironment($env);
+        $headers = Headers::createFromEnvironment($env);
+        $cookies = [];
+        $serverParams = $env->all();
+        $body = new RequestBody();
+        $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+        $res = new Response();
+
+        // Invoke app
+        $resOut = $app($req, $res);
+        $app->respond($resOut);
+
+        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
+        $this->expectOutputString('Hello');
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testExceptionErrorHandler()
     {
         $app = new App();


### PR DESCRIPTION
This feature is very important when working with external streams and stream filters. 

For example, I'm downloading encrypted file from S3 and automatically decrypt it using stream_filter. Decryptor automatically pad my output with `"\0"` statements to fit block size. This way final downloaded file is corrupted. I can not apply `trim` function, as I don't have access to the whole stream content. This way I just want my app to output exact amount of bytes, without padded elements.

I prepared special unit test, where you can see the issue.
