### PR TITLE
Removed redundant code block in CallableResolver::resolve()

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -74,9 +74,6 @@ final class CallableResolver implements CallableResolverInterface
                     $resolved = new $class;
                 }
             }
-            if (!is_callable($resolved)) {
-                throw new RuntimeException(sprintf('%s is not resolvable', $toResolve));
-            }
         } else {
             $resolved = $toResolve;
         }


### PR DESCRIPTION
In this PR: 
- Removed redundant code block in `CallableResolver::resolve()`

I think this block is unnecessary.

```
if ($conditions) {
    // to do something
    check();
} else {
    // to do something
}
check();
```

Function `check()` will be executed double if `$conditions` is true.
