### PR TITLE
Removed redundant code block in CallableResolver::resolve()

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -74,9 +74,6 @@ final class CallableResolver implements CallableResolverInterface
                     $resolved = new $class;
                 }
             }
-            if (!is_callable($resolved)) {
-                throw new RuntimeException(sprintf('%s is not resolvable', $toResolve));
-            }
         } else {
             $resolved = $toResolve;
         }


### PR DESCRIPTION
In this PR:
- Removed redundant code block in `CallableResolver::resolve()`

Sorry, my english is not good!
