### PR TITLE
Fix address truncation if IPv6 address in HTTP_HOST

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -474,10 +474,14 @@ class Request
     public function getHost()
     {
         if (isset($this->env['HTTP_HOST'])) {
-            if (strpos($this->env['HTTP_HOST'], ':') !== false) {
-                $hostParts = explode(':', $this->env['HTTP_HOST']);
+            if(preg_match('/^(\[[a-fA-F0-9:.]+\])(:\d+)?\z/', $this->env['HTTP_HOST'], $matches)) {
+                return $matches[1];
+            } else {
+                if (strpos($this->env['HTTP_HOST'], ':') !== false) {
+                    $hostParts = explode(':', $this->env['HTTP_HOST']);
 
-                return $hostParts[0];
+                    return $hostParts[0];
+                }
             }
 
             return $this->env['HTTP_HOST'];

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -672,6 +672,34 @@ class RequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test get host if HTTP_HOST is an IPv6 address.
+     */
+    public function testGetIPv6Host()
+    {
+        $env = \Slim\Environment::mock(array(
+            'SERVER_NAME' => 'slim',
+            'HTTP_HOST' => '[2001:db8::1]'
+        ));
+
+        $req = new \Slim\Http\Request($env);
+        $this->assertEquals('[2001:db8::1]', $req->getHost()); //Uses HTTP_HOST if available
+    }
+
+    /**
+     * Test get host if HTTP_HOST is an IPv6 address with appended port.
+     */
+    public function testGetIPv6HostWithoutPortIfPortAppended()
+    {
+        $env = \Slim\Environment::mock(array(
+            'SERVER_NAME' => 'slim',
+            'HTTP_HOST' => '[2001:db8::1]:80'
+        ));
+
+        $req = new \Slim\Http\Request($env);
+        $this->assertEquals('[2001:db8::1]', $req->getHost()); //Uses HTTP_HOST if available
+    }
+
+    /**
      * Test get host when it has a port number
      */
     public function testGetHostAndStripPort()


### PR DESCRIPTION
If `HTTP_HOST` contains an IPv6 address (eg `[2001:db8::1]`), the current implementation of `Request::getHost()` truncates this address after the first colon, yielding `[2001` as the host instead of `[2001:db8::1]` (see #1325).

This PR fixes the `Request::getHost()` behaviour to check if an IPv6 address is given in `HTTP_HOST` and to split only on the colon after the IPv6 address.
