### PR TITLE
[HHVM] mb_parse_str() fails to parse array POST parameters

### DIFF
--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -260,6 +260,26 @@ class RequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test fetch POST params with arrays
+     */
+    public function testPostArray()
+    {
+        $env = \Slim\Environment::mock(array(
+            'REQUEST_METHOD' => 'POST',
+            'slim.input' => 'foo[]=bar&foo[]=baz&abc=123',
+            'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+            'CONTENT_LENGTH' => 27
+        ));
+        $req = new \Slim\Http\Request($env);
+
+        $this->assertEquals(2, count($req->post()));
+        $this->assertEquals(2, count($req->post('foo')));
+        $this->assertContains('bar', $req->post('foo'));
+        $this->assertContains('baz', $req->post('foo'));
+        $this->assertEquals(123, $req->post('abc'));
+    }
+
+    /**
      * Test fetch POST params without multibyte
      */
     public function testPostWithoutMultibyte()


### PR DESCRIPTION
Using HHVM 3.9.1, a POST data string of `foo[]=bar&foo[]=baz` does not parse into the correct array structure using `mb_parse_str()`. It works correctly when using `parse_str()`.

``` php
mb_parse_str('foo[]=bar&foo[]=baz&abc=123', $out)
/*
On HHVM, this produces:
array(2) {
  ["foo[]"]=>
  string(3) "baz"
  ["abc"]=>
  string(3) "123"
}

but the expected output is:
/*
array(2) {
  ["foo"]=>
  array(2) {
    [0]=>
    string(3) "bar"
    [1]=>
    string(3) "baz"
  }
  ["abc"]=>
  string(3) "123"
}
*/
```

This PR adds a failing test for this behaviour.
