### PR TITLE
[3.x] Fix IPv6 address truncation in Uri factory

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -179,12 +179,19 @@ class Uri implements UriInterface
         }
 
         // Authority: Port
-        $pos = strpos($host, ':');
-        if ($pos !== false) {
-            $port = (int)substr($host, $pos + 1);
-            $host = strstr($host, ':', true);
+        $port = (int)$env->get('SERVER_PORT', 80);
+        if(preg_match('/^(\[[a-fA-F0-9:.]+\])(:\d+)?\z/', $host, $matches)) {
+            $host = $matches[1];
+
+            if($matches[2]) {
+                $port = (int) substr($matches[2], 1);
+            }
         } else {
-            $port = (int)$env->get('SERVER_PORT', 80);
+            $pos = strpos($host, ':');
+            if ($pos !== false) {
+                $port = (int) substr($host, $pos + 1);
+                $host = strstr($host, ':', true);
+            }
         }
 
         // Path

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -180,10 +180,10 @@ class Uri implements UriInterface
 
         // Authority: Port
         $port = (int)$env->get('SERVER_PORT', 80);
-        if(preg_match('/^(\[[a-fA-F0-9:.]+\])(:\d+)?\z/', $host, $matches)) {
+        if (preg_match('/^(\[[a-fA-F0-9:.]+\])(:\d+)?\z/', $host, $matches)) {
             $host = $matches[1];
 
-            if($matches[2]) {
+            if ($matches[2]) {
                 $port = (int) substr($matches[2], 1);
             }
         } else {

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -515,6 +515,29 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $uri->getFragment());
     }
 
+    public function testCreateEnvironmentWithIPv6Host()
+    {
+        $environment = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'PHP_AUTH_USER' => 'josh',
+            'PHP_AUTH_PW' => 'sekrit',
+            'QUERY_STRING' => 'abc=123',
+            'HTTP_HOST' => '[2001:db8::1]:8080',
+            'REMOTE_ADDR' => '2001:db8::1',
+            'SERVER_PORT' => 8080,
+        ]);
+
+        $uri = Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('josh:sekrit', $uri->getUserInfo());
+        $this->assertEquals('[2001:db8::1]', $uri->getHost());
+        $this->assertEquals('8080', $uri->getPort());
+        $this->assertEquals('/foo/bar', $uri->getPath());
+        $this->assertEquals('abc=123', $uri->getQuery());
+        $this->assertEquals('', $uri->getFragment());
+    }
+
     public function testCreateEnvironmentWithForwardedProto()
     {
         $environment = Environment::mock([


### PR DESCRIPTION
Fix the handling of IPv6 addresses in `HTTP_HOST` in `Uri::createFromEnvironment()`.
For details, see #1524 
