### PR TITLE
Current route now updated during routing and Dispatched route is stored

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -95,6 +95,15 @@ class Router
     }
 
     /**
+     * Sets the current route to the given route
+     * @param Route|null $route
+     */
+    public function setCurrentRoute(Route $route = null)
+    {
+        $this->currentRoute = $route;
+    }
+
+    /**
      * Return route objects that match the given HTTP method and URI
      * @param  string               $httpMethod   The HTTP method to match against
      * @param  string               $resourceUri  The resource URI to match against

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -49,6 +49,11 @@ class Router
     protected $currentRoute;
 
     /**
+     * @var Route The route that was dispatched
+     */
+    protected $dispatchedRoute;
+
+    /**
      * @var array Lookup hash of all route objects
      */
     protected $routes;
@@ -101,6 +106,22 @@ class Router
     public function setCurrentRoute(Route $route = null)
     {
         $this->currentRoute = $route;
+    }
+
+    /**
+     * @return Route The Route that was dispatched by Slim
+     */
+    public function getDispatchedRoute()
+    {
+        return $this->dispatchedRoute;
+    }
+
+    /**
+     * @param Route $dispatchedRoute
+     */
+    public function setDispatchedRoute($dispatchedRoute)
+    {
+        $this->dispatchedRoute = $dispatchedRoute;
     }
 
     /**

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1352,6 +1352,7 @@ class Slim
             $dispatched = false;
             $matchedRoutes = $this->router->getMatchedRoutes($this->request->getMethod(), $this->request->getResourceUri());
             foreach ($matchedRoutes as $route) {
+                $this->router->setCurrentRoute($route);
                 try {
                     $this->applyHook('slim.before.dispatch');
                     $dispatched = $route->dispatch();
@@ -1367,6 +1368,7 @@ class Slim
                 $this->notFound();
             }
             $this->applyHook('slim.after.router');
+            $this->router->setCurrentRoute(null);
             $this->stop();
         } catch (\Slim\Exception\Stop $e) {
             $this->response()->write(ob_get_clean());

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1353,6 +1353,7 @@ class Slim
             $matchedRoutes = $this->router->getMatchedRoutes($this->request->getMethod(), $this->request->getResourceUri());
             foreach ($matchedRoutes as $route) {
                 $this->router->setCurrentRoute($route);
+                $this->router->setDispatchedRoute($route);
                 try {
                     $this->applyHook('slim.before.dispatch');
                     $dispatched = $route->dispatch();
@@ -1365,6 +1366,7 @@ class Slim
                 }
             }
             if (!$dispatched) {
+                $this->router->setDispatchedRoute(null);
                 $this->notFound();
             }
             $this->applyHook('slim.after.router');

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1370,7 +1370,6 @@ class Slim
                 $this->notFound();
             }
             $this->applyHook('slim.after.router');
-            $this->router->setCurrentRoute(null);
             $this->stop();
         } catch (\Slim\Exception\Stop $e) {
             $this->response()->write(ob_get_clean());
@@ -1386,6 +1385,8 @@ class Slim
                     // Do nothing
                 }
             }
+        } finally {
+            $this->router->setCurrentRoute(null);
         }
     }
 

--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -1385,9 +1385,8 @@ class Slim
                     // Do nothing
                 }
             }
-        } finally {
-            $this->router->setCurrentRoute(null);
         }
+        $this->router->setCurrentRoute(null);
     }
 
     /********************************************************************************


### PR DESCRIPTION
Fixing bug where Router->currentRoute was not being updated during Sim run.

Bug only appears when there is more than one matching route AND the first matching route calls $app->pass().

This meant that hook functions could not accurately tell which route was about to be dispatched/had just been dispatched.
