### PR TITLE
Proxy non-existent method calls to the container

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -129,6 +129,24 @@ class App
         return $this->container->has($name);
     }
 
+    /**
+     * Calling a non-existant method on App checks to see if there's an item
+     * in the container than is callable and if so, calls it.
+     *
+     * @param  string $method
+     * @param  array $args
+     * @return mixed
+     */
+    public function __call($method, $args)
+    {
+        if ($this->container->has($method)) {
+            $obj = $this->container->get($method);
+            if (is_callable($obj)) {
+                return call_user_func_array($obj, $args);
+            }
+        }
+    }
+
     /********************************************************************************
      * Router proxy methods
      *******************************************************************************/

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -977,4 +977,28 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($response->hasHeader('Content-Length'));
         $this->assertFalse($response->hasHeader('Content-Type'));
     }
+
+    public function testCallingAContainerCallable()
+    {
+        $settings = [
+            'foo' => function ($c) {
+                return function ($a) {
+                    return $a;
+                };
+            }
+        ];
+        $app = new App($settings);
+
+        $result = $app->foo('bar');
+        $this->assertSame('bar', $result);
+
+        $headers = new Headers();
+        $body = new Body(fopen('php://temp', 'r+'));
+        $request = new Request('GET', Uri::createFromString(''), $headers, [], [], $body);
+        $response = new Response();
+
+        $response = $app->notFoundHandler($request, $response);
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
This is a convenience method that allows for calling container methods as if they were methods on App.

e.g.:

``` php
$app->get('/', function ($req, $res)
{
    return $this->notFoundHandler($request, $response);
}
```

Is this a good idea?
