### PR TITLE
Support text/xml

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -50,6 +50,7 @@ class Error
                 $output = $this->renderJsonErrorMessage($exception);
                 break;
 
+            case 'text/xml':
             case 'application/xml':
                 $output = $this->renderXmlErrorMessage($exception);
                 break;
@@ -218,7 +219,7 @@ class Error
     private function determineContentType($acceptHeader)
     {
         $list = explode(',', $acceptHeader);
-        $known = ['application/json', 'application/xml', 'text/html'];
+        $known = ['application/json', 'application/xml', 'text/xml', 'text/html'];
 
         foreach ($list as $type) {
             if (in_array($type, $known)) {

--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -45,6 +45,7 @@ class NotAllowed
                     $output = '{"message":"Method not allowed. Must be one of: ' . $allow . '"}';
                     break;
 
+                case 'text/xml':
                 case 'application/xml':
                     $output = "<root><message>Method not allowed. Must be one of: $allow</message></root>";
                     break;
@@ -100,7 +101,7 @@ END;
     private function determineContentType($acceptHeader)
     {
         $list = explode(',', $acceptHeader);
-        $known = ['application/json', 'application/xml', 'text/html'];
+        $known = ['application/json', 'application/xml', 'text/xml', 'text/html'];
         
         foreach ($list as $type) {
             if (in_array($type, $known)) {

--- a/Slim/Handlers/NotFound.php
+++ b/Slim/Handlers/NotFound.php
@@ -37,6 +37,7 @@ class NotFound
                 $output = '{"message":"Not found"}';
                 break;
 
+            case 'text/xml':
             case 'application/xml':
                 $output = '<root><message>Not found</message></root>';
                 break;
@@ -99,7 +100,7 @@ END;
     private function determineContentType($acceptHeader)
     {
         $list = explode(',', $acceptHeader);
-        $known = ['application/json', 'application/xml', 'text/html'];
+        $known = ['application/json', 'application/xml', 'text/xml', 'text/html'];
         
         foreach ($list as $type) {
             if (in_array($type, $known)) {

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -189,6 +189,10 @@ class Request extends Message implements ServerRequestInterface
             return simplexml_load_string($input);
         });
 
+        $this->registerMediaTypeParser('text/xml', function ($input) {
+            return simplexml_load_string($input);
+        });
+
         $this->registerMediaTypeParser('application/x-www-form-urlencoded', function ($input) {
             parse_str($input, $data);
             return $data;

--- a/tests/Handlers/ErrorTest.php
+++ b/tests/Handlers/ErrorTest.php
@@ -18,6 +18,7 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
         return [
             ['application/json', '{'],
             ['application/xml', '<error>'],
+            ['text/xml', '<error>'],
             ['text/html', '<html>'],
         ];
     }

--- a/tests/Handlers/NotAllowedTest.php
+++ b/tests/Handlers/NotAllowedTest.php
@@ -18,6 +18,7 @@ class NotAllowedTest extends \PHPUnit_Framework_TestCase
         return [
             ['application/json', '{'],
             ['application/xml', '<root>'],
+            ['text/xml', '<root>'],
             ['text/html', '<html>'],
         ];
     }

--- a/tests/Handlers/NotFoundTest.php
+++ b/tests/Handlers/NotFoundTest.php
@@ -19,6 +19,7 @@ class NotFoundTest extends \PHPUnit_Framework_TestCase
         return [
             ['application/json', '{'],
             ['application/xml', '<root>'],
+            ['text/xml', '<root>'],
             ['text/html', '<html>'],
         ];
     }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -727,6 +727,21 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Josh', $request->getParsedBody()->name);
     }
 
+    public function testGetParsedBodyXmlWithTextXMLMediaType()
+    {
+        $method = 'GET';
+        $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
+        $headers = new Headers();
+        $headers->set('Content-Type', 'text/xml');
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('<person><name>Josh</name></person>');
+        $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
+
+        $this->assertEquals('Josh', $request->getParsedBody()->name);
+    }
+
     public function testGetParsedBodyWhenAlreadyParsed()
     {
         $request = $this->requestFactory();


### PR DESCRIPTION
According to [RFC 3023](http://www.ietf.org/rfc/rfc7303.txt), text/xml and application/xml are essentially the same:

```
9.2.  text/xml Registration

   The registration information for text/xml is in all respects the same
   as that given for application/xml above (Section 9.1), except that
   the "Type name" is "text".
```
