### PR TITLE
Adds param to $router-pathFor to get fullPath or not. #1521

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -249,7 +249,7 @@ class Router extends RouteCollector implements RouterInterface
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
-    public function pathFor($name, array $data = [], array $queryParams = [])
+    public function pathFor($name, array $data = [], array $queryParams = [], $fullPath = true)
     {
         $route = $this->getNamedRoute($name);
         $pattern = $route->getPattern();
@@ -299,6 +299,11 @@ class Router extends RouteCollector implements RouterInterface
 
         if ($queryParams) {
             $url .= '?' . http_build_query($queryParams);
+        }
+
+        if(!$fullPath) {
+            $url = explode('/', $url);
+            $url = array_pop($url);
         }
 
         return $url;

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -243,6 +243,7 @@ class Router extends RouteCollector implements RouterInterface
      * @param string $name        Route name
      * @param array  $data        Named argument replacement data
      * @param array  $queryParams Optional query string parameters
+     * @param boolean $fullPath   Optional param to return the full path or the last part for subRequests
      *
      * @return string
      *


### PR DESCRIPTION
I assume with this you could do something like this:

```
$app->get('/', function ($request, $response, $args) use ($router) {
    $sub = $this->subRequest('GET', $router->pathFor('hello', [], [], false));
})->setName('home');

$app->get('/hello', function ($request, $response, $args) use ($router) {
    $response->write("hellorequest ");
    return $response;
})->setName('hello');
```

However i'm not sure $router-pathFor is expected to be used with app->subRequest, since it simply returns the path. Perhaps an owner can jump in and clarify, or maybe you can use this change.

Best.
