### PR TITLE
router->pathfor fullpath param for subRequests. #1521

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -243,13 +243,14 @@ class Router extends RouteCollector implements RouterInterface
      * @param string $name        Route name
      * @param array  $data        Named argument replacement data
      * @param array  $queryParams Optional query string parameters
+     * @param boolean $fullPath   Optional param to return the full path or the last part for subRequests
      *
      * @return string
      *
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
-    public function pathFor($name, array $data = [], array $queryParams = [])
+    public function pathFor($name, array $data = [], array $queryParams = [], $fullPath = true)
     {
         $route = $this->getNamedRoute($name);
         $pattern = $route->getPattern();
@@ -299,6 +300,11 @@ class Router extends RouteCollector implements RouterInterface
 
         if ($queryParams) {
             $url .= '?' . http_build_query($queryParams);
+        }
+
+        if(!$fullPath) {
+            $url = explode('/', $url);
+            $url = array_pop($url);
         }
 
         return $url;

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -80,6 +80,22 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             $this->router->pathFor('foo', ['first' => 'josh', 'last' => 'lockhart'])
         );
     }
+
+    public function testPathForFullPathParam()
+    {
+        $methods = ['GET'];
+        $pattern = '/hello/{first:\w+}/{last}';
+        $callable = function ($request, $response, $args) {
+            echo sprintf('Hello %s %s', $args['first'], $args['last']);
+        };
+        $route = $this->router->map($methods, $pattern, $callable);
+        $route->setName('foo');
+
+        $this->assertEquals(
+            'lockhart',
+            $this->router->pathFor('foo', ['first' => 'josh', 'last' => 'lockhart'], [], false)
+        );
+    }
     
     public function testPathForWithBasePath()
     {


### PR DESCRIPTION
I assume with this you could do something like this:

```
$app->get('/', function ($request, $response, $args) use ($router) {
    $sub = $this->subRequest('GET', $router->pathFor('hello', [], [], false));
})->setName('home');

$app->get('/hello', function ($request, $response, $args) use ($router) {
    $response->write("hellorequest ");
    return $response;
})->setName('hello');
```

However i'm not sure $router-pathFor is expected to be used with app->subRequest, since it simply returns the path. Perhaps an owner can jump in and clarify, or maybe you can use this change.

Best.
