### PR TITLE
Implement internalPathFor()

### DIFF
--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -87,7 +87,21 @@ interface RouterInterface
     public function lookupRoute($identifier);
 
     /**
-     * Build the path for a named route
+     * Build the path for a named route excluding the base path
+     *
+     * @param string $name        Route name
+     * @param array  $data        Named argument replacement data
+     * @param array  $queryParams Optional query string parameters
+     *
+     * @return string
+     *
+     * @throws RuntimeException         If named route does not exist
+     * @throws InvalidArgumentException If required data not provided
+     */
+    public function relativePathFor($name, array $data = [], array $queryParams = []);
+
+    /**
+     * Build the path for a named route including the base path
      *
      * @param string $name        Route name
      * @param array  $data        Named argument replacement data

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -279,7 +279,7 @@ class Router implements RouterInterface
     }
 
     /**
-     * Build the path for a named route
+     * Build the path for a named route excluding the base path
      *
      * @param string $name        Route name
      * @param array  $data        Named argument replacement data
@@ -290,7 +290,7 @@ class Router implements RouterInterface
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
-    public function pathFor($name, array $data = [], array $queryParams = [])
+    public function relativePathFor($name, array $data = [], array $queryParams = [])
     {
         $route = $this->getNamedRoute($name);
         $pattern = $route->getPattern();
@@ -334,12 +334,32 @@ class Router implements RouterInterface
         }
         $url = implode('', $segments);
 
-        if ($this->basePath) {
-            $url = $this->basePath . $url;
-        }
-
         if ($queryParams) {
             $url .= '?' . http_build_query($queryParams);
+        }
+
+        return $url;
+    }
+
+
+    /**
+     * Build the path for a named route including the base path
+     *
+     * @param string $name        Route name
+     * @param array  $data        Named argument replacement data
+     * @param array  $queryParams Optional query string parameters
+     *
+     * @return string
+     *
+     * @throws RuntimeException         If named route does not exist
+     * @throws InvalidArgumentException If required data not provided
+     */
+    public function pathFor($name, array $data = [], array $queryParams = [])
+    {
+        $url = $this->relativePathFor($name, $data, $queryParams);
+
+        if ($this->basePath) {
+            $url = $this->basePath . $url;
         }
 
         return $url;

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -65,8 +65,32 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->router->map($methods, $pattern, $callable);
     }
 
-    public function testPathFor()
+    /**
+     * Base path is ignored by relativePathFor()
+     *
+     */
+    public function testRelativePathFor()
     {
+        $this->router->setBasePath('/base/path');
+
+        $methods = ['GET'];
+        $pattern = '/hello/{first:\w+}/{last}';
+        $callable = function ($request, $response, $args) {
+            echo sprintf('Hello %s %s', $args['first'], $args['last']);
+        };
+        $route = $this->router->map($methods, $pattern, $callable);
+        $route->setName('foo');
+
+        $this->assertEquals(
+            '/hello/josh/lockhart',
+            $this->router->relativePathFor('foo', ['first' => 'josh', 'last' => 'lockhart'])
+        );
+    }
+    
+    public function testPathForWithNoBasePath()
+    {
+        $this->router->setBasePath('');
+
         $methods = ['GET'];
         $pattern = '/hello/{first:\w+}/{last}';
         $callable = function ($request, $response, $args) {


### PR DESCRIPTION
This method is mostly useful when using `subRequest` which does not
expect the base path.

Closes #1521
