### PR TITLE
Remove checks for X-Forwarded-Proto and X-Forwarded-Host from Uri

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -158,21 +158,15 @@ class Uri implements UriInterface
     public static function createFromEnvironment(Environment $env)
     {
         // Scheme
-        if ($env->has('HTTP_X_FORWARDED_PROTO')) {
-            $scheme = $env->get('HTTP_X_FORWARDED_PROTO'); // Will be "http" or "https"
-        } else {
-            $isSecure = $env->get('HTTPS');
-            $scheme = (empty($isSecure) || $isSecure === 'off') ? 'http' : 'https';
-        }
+        $isSecure = $env->get('HTTPS');
+        $scheme = (empty($isSecure) || $isSecure === 'off') ? 'http' : 'https';
 
         // Authority: Username and password
         $username = $env->get('PHP_AUTH_USER', '');
         $password = $env->get('PHP_AUTH_PW', '');
 
         // Authority: Host
-        if ($env->has('HTTP_X_FORWARDED_HOST')) {
-            $host = trim(current(explode(',', $env->get('HTTP_X_FORWARDED_HOST'))));
-        } elseif ($env->has('HTTP_HOST')) {
+        if ($env->has('HTTP_HOST')) {
             $host = $env->get('HTTP_HOST');
         } else {
             $host = $env->get('SERVER_NAME');

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -538,36 +538,6 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $uri->getFragment());
     }
 
-    public function testCreateEnvironmentWithForwardedProto()
-    {
-        $environment = Environment::mock([
-            'SCRIPT_NAME' => '/index.php',
-            'REQUEST_URI' => '/foo/bar',
-            'HTTPS' => '',
-            'HTTP_X_FORWARDED_PROTO' => 'https'
-        ]);
-        $uri = Uri::createFromEnvironment($environment);
-
-        $this->assertEquals('https', $uri->getScheme());
-    }
-
-    public function testCreateEnvironmentWithForwardedHost()
-    {
-        $environment = Environment::mock([
-            'SCRIPT_NAME' => '/index.php',
-            'REQUEST_URI' => '/foo/bar',
-            'PHP_AUTH_USER' => 'josh',
-            'PHP_AUTH_PW' => 'sekrit',
-            'QUERY_STRING' => 'abc=123',
-            'HTTP_HOST' => 'example.com:8080',
-            'SERVER_PORT' => 8080,
-            'HTTP_X_FORWARDED_HOST' => 'example3.com, example2.com, example1.com'
-        ]);
-        $uri = Uri::createFromEnvironment($environment);
-
-        $this->assertEquals('example3.com', $uri->getHost());
-    }
-
     /**
      * @covers Slim\Http\Uri::createFromEnvironment
      * @ticket 1375


### PR DESCRIPTION
These are client-set headers and so should be tackled in middleware so that the app can implement whitelisting of proxies if it cares to.

Closes #1567
