### PR TITLE
determineContentType to use array_intersect

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -24,6 +24,18 @@ class Error
     protected $displayErrorDetails;
 
     /**
+     * Known handled content types
+     *
+     * @var array
+     */
+    protected $knownContentTypes = [
+        'application/json',
+        'application/xml',
+        'text/xml',
+        'text/html',
+    ];
+
+    /**
      * Constructor
      *
      * @param boolean $displayErrorDetails Set to true to display full details
@@ -56,8 +68,6 @@ class Error
                 break;
 
             case 'text/html':
-            default:
-                $contentType = 'text/html';
                 $output = $this->renderHtmlErrorMessage($exception);
                 break;
         }
@@ -97,8 +107,8 @@ class Error
         $output = sprintf(
             "<html><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'>" .
             "<title>%s</title><style>body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana," .
-            "sans-serif;}h1{margin:0;font-size:48px;font-weight:normal;line-height:48px;}strong{display:inline-block;" .
-            "width:65px;}</style></head><body><h1>%s</h1>%s</body></html>",
+            "sans-serif;}h1{margin:0;font-size:48px;font-weight:normal;line-height:48px;}strong{" .
+            "display:inline-block;width:65px;}</style></head><body><h1>%s</h1>%s</body></html>",
             $title,
             $title,
             $html
@@ -210,21 +220,17 @@ class Error
     }
 
     /**
-     * Read the accept header and determine which content type we know about
-     * is wanted.
+     * Determine which content type we know about is wanted using Accept header
+     * content.
      *
      * @param  string $acceptHeader Accept header from request
      * @return string
      */
     private function determineContentType($acceptHeader)
     {
-        $list = explode(',', $acceptHeader);
-        $known = ['application/json', 'application/xml', 'text/xml', 'text/html'];
-
-        foreach ($list as $type) {
-            if (in_array($type, $known)) {
-                return $type;
-            }
+        $selectedContentTypes = array_intersect(explode(',', $acceptHeader), $this->knownContentTypes);
+        if (count($selectedContentTypes)) {
+            return $selectedContentTypes[0];
         }
 
         return 'text/html';

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -56,7 +56,7 @@ class Error
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, Exception $exception)
     {
-        $contentType = $this->determineContentType($request->getHeaderLine('Accept'));
+        $contentType = $this->determineContentType($request);
         switch ($contentType) {
             case 'application/json':
                 $output = $this->renderJsonErrorMessage($exception);
@@ -221,14 +221,15 @@ class Error
 
     /**
      * Determine which content type we know about is wanted using Accept header
-     * content.
      *
-     * @param  string $acceptHeader Accept header from request
+     * @param ServerRequestInterface $request
      * @return string
      */
-    private function determineContentType($acceptHeader)
+    private function determineContentType(ServerRequestInterface $request)
     {
+        $acceptHeader = $request->getHeaderLine('Accept');
         $selectedContentTypes = array_intersect(explode(',', $acceptHeader), $this->knownContentTypes);
+
         if (count($selectedContentTypes)) {
             return $selectedContentTypes[0];
         }

--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -51,7 +51,7 @@ class NotAllowed
             $output = 'Allowed methods: ' . $allow;
         } else {
             $status = 405;
-            $contentType = $this->determineContentType($request->getHeaderLine('Accept'));
+            $contentType = $this->determineContentType($request);
             switch ($contentType) {
                 case 'application/json':
                     $output = '{"message":"Method not allowed. Must be one of: ' . $allow . '"}';
@@ -104,14 +104,15 @@ END;
 
     /**
      * Determine which content type we know about is wanted using Accept header
-     * content.
      *
-     * @param  string $acceptHeader Accept header from request
+     * @param ServerRequestInterface $request
      * @return string
      */
-    private function determineContentType($acceptHeader)
+    private function determineContentType(ServerRequestInterface $request)
     {
+        $acceptHeader = $request->getHeaderLine('Accept');
         $selectedContentTypes = array_intersect(explode(',', $acceptHeader), $this->knownContentTypes);
+
         if (count($selectedContentTypes)) {
             return $selectedContentTypes[0];
         }

--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -21,6 +21,18 @@ use Slim\Http\Body;
 class NotAllowed
 {
     /**
+     * Known handled content types
+     *
+     * @var array
+     */
+    protected $knownContentTypes = [
+        'application/json',
+        'application/xml',
+        'text/xml',
+        'text/html',
+    ];
+
+    /**
      * Invoke error handler
      *
      * @param  ServerRequestInterface $request  The most recent Request object
@@ -51,7 +63,6 @@ class NotAllowed
                     break;
 
                 case 'text/html':
-                default:
                     $contentType = 'text/html';
                     $output = <<<END
 <html>
@@ -92,21 +103,17 @@ END;
     }
 
     /**
-     * Read the accept header and determine which content type we know about
-     * is wanted.
+     * Determine which content type we know about is wanted using Accept header
+     * content.
      *
      * @param  string $acceptHeader Accept header from request
      * @return string
      */
     private function determineContentType($acceptHeader)
     {
-        $list = explode(',', $acceptHeader);
-        $known = ['application/json', 'application/xml', 'text/xml', 'text/html'];
-        
-        foreach ($list as $type) {
-            if (in_array($type, $known)) {
-                return $type;
-            }
+        $selectedContentTypes = array_intersect(explode(',', $acceptHeader), $this->knownContentTypes);
+        if (count($selectedContentTypes)) {
+            return $selectedContentTypes[0];
         }
 
         return 'text/html';

--- a/Slim/Handlers/NotFound.php
+++ b/Slim/Handlers/NotFound.php
@@ -21,6 +21,18 @@ use Slim\Http\Body;
 class NotFound
 {
     /**
+     * Known handled content types
+     *
+     * @var array
+     */
+    protected $knownContentTypes = [
+        'application/json',
+        'application/xml',
+        'text/xml',
+        'text/html',
+    ];
+
+    /**
      * Invoke not found handler
      *
      * @param  ServerRequestInterface $request  The most recent Request object
@@ -43,7 +55,6 @@ class NotFound
                 break;
 
             case 'text/html':
-            default:
                 $homeUrl = (string)($request->getUri()->withPath('')->withQuery('')->withFragment(''));
                 $contentType = 'text/html';
                 $output = <<<END
@@ -91,21 +102,17 @@ END;
     }
 
     /**
-     * Read the accept header and determine which content type we know about
-     * is wanted.
+     * Determine which content type we know about is wanted using Accept header
+     * content.
      *
      * @param  string $acceptHeader Accept header from request
      * @return string
      */
     private function determineContentType($acceptHeader)
     {
-        $list = explode(',', $acceptHeader);
-        $known = ['application/json', 'application/xml', 'text/xml', 'text/html'];
-        
-        foreach ($list as $type) {
-            if (in_array($type, $known)) {
-                return $type;
-            }
+        $selectedContentTypes = array_intersect(explode(',', $acceptHeader), $this->knownContentTypes);
+        if (count($selectedContentTypes)) {
+            return $selectedContentTypes[0];
         }
 
         return 'text/html';

--- a/Slim/Handlers/NotFound.php
+++ b/Slim/Handlers/NotFound.php
@@ -43,7 +43,7 @@ class NotFound
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
 
-        $contentType = $this->determineContentType($request->getHeaderLine('Accept'));
+        $contentType = $this->determineContentType($request);
         switch ($contentType) {
             case 'application/json':
                 $output = '{"message":"Not found"}';
@@ -103,14 +103,15 @@ END;
 
     /**
      * Determine which content type we know about is wanted using Accept header
-     * content.
      *
-     * @param  string $acceptHeader Accept header from request
+     * @param ServerRequestInterface $request
      * @return string
      */
-    private function determineContentType($acceptHeader)
+    private function determineContentType(ServerRequestInterface $request)
     {
+        $acceptHeader = $request->getHeaderLine('Accept');
         $selectedContentTypes = array_intersect(explode(',', $acceptHeader), $this->knownContentTypes);
+
         if (count($selectedContentTypes)) {
             return $selectedContentTypes[0];
         }


### PR DESCRIPTION
In case the first 'Accept' content type on the list is not in the known content types array using array_intersect improves speed in comparison with traversing the list

By the way, couldn't determineContentType be placed on `Slim\Handlers\AbstractHandler` and use $request as parameter instead? this way it can be used by users as a base to extend their handlers upon. Just a thought
