### PR TITLE
Better handling of slash in routegroup patterns

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -122,14 +122,18 @@ class Router implements RouterInterface
             throw new InvalidArgumentException('Route pattern must be a string');
         }
 
+        // pattern must start with a / if not empty
+        if ($pattern) {
+            $pattern = '/' . ltrim($pattern, '/');
+        }
+
         // Prepend parent group pattern(s)
         if ($this->routeGroups) {
-            // If any route in the group only has / we remove it
-            if ($pattern === '/') {
-                $pattern = '';
-            }
             $pattern = $this->processGroups() . $pattern;
         }
+
+        // Complete pattern must start with a /
+        $pattern = '/' . ltrim($pattern, '/');
 
         // Add route
         $route = new Route($methods, $pattern, $handler, $this->routeGroups, $this->routeCounter);
@@ -235,7 +239,8 @@ class Router implements RouterInterface
     {
         $pattern = "";
         foreach ($this->routeGroups as $group) {
-            $pattern .= $group->getPattern();
+            // The route group's pattern doesn't end with a /
+            $pattern .= rtrim($group->getPattern(), '/');
         }
         return $pattern;
     }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -582,7 +582,6 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
     }
 
-//HERE
     public function testEmptyGroupWithSegmentRouteThatDoesNotEndInASlash()
     {
         $app = new App();

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -149,6 +149,69 @@ class AppTest extends \PHPUnit_Framework_TestCase
     }
 
     /********************************************************************************
+     * Route Patterns
+     *******************************************************************************/
+    public function testSegmentRouteThatDoesNotEndInASlash()
+    {
+        $app = new App();
+        $app->get('/foo', function ($req, $res) {
+            // Do something
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testSegmentRouteThatEndsInASlash()
+    {
+        $app = new App();
+        $app->get('/foo/', function ($req, $res) {
+            // Do something
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testSegmentRouteThatDoesNotStartWithASlash()
+    {
+        $app = new App();
+        $app->get('foo', function ($req, $res) {
+            // Do something
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testSingleSlashRoute()
+    {
+        $app = new App();
+        $app->get('/', function ($req, $res) {
+            // Do something
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyRoute()
+    {
+        $app = new App();
+        $app->get('', function ($req, $res) {
+            // Do something
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    /********************************************************************************
      * Route Groups
      *******************************************************************************/
     public function testGroupSegmentWithSegmentRouteThatDoesNotEndInASlash()

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -148,35 +148,11 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeContains('POST', 'methods', $route);
     }
 
-    public function testGroup()
+    /********************************************************************************
+     * Route Groups
+     *******************************************************************************/
+    public function testGroupSegmentWithSegmentRouteThatDoesNotEndInASlash()
     {
-        $app = new App();
-        $app->group('/foo', function () use ($app) {
-            $route = $app->get('/bar', function ($req, $res) {
-                // Do something
-            });
-
-        });
-
-        /** @var \Slim\Router $router */
-        $router = $app->router;
-        $router->finalize();
-        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->lookupRoute('route0'));
-    }
-
-    public function testGroupDefaultSlash()
-    {
-        $app = new App();
-        $app->group('/foo', function () use ($app) {
-            $app->get('/', function ($req, $res) {
-                // Do something
-            });
-        });
-        /** @var \Slim\Router $router */
-        $router = $app->router;
-        $router->finalize();
-        $this->assertAttributeEquals('/foo', 'pattern', $router->lookupRoute('route0'));
-        
         $app = new App();
         $app->group('/foo', function () use ($app) {
             $app->get('/bar', function ($req, $res) {
@@ -187,7 +163,52 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $router = $app->router;
         $router->finalize();
         $this->assertAttributeEquals('/foo/bar', 'pattern', $router->lookupRoute('route0'));
-        
+    }
+
+    public function testGroupSegmentWithSegmentRouteThatEndsInASlash()
+    {
+        $app = new App();
+        $app->group('/foo', function () use ($app) {
+            $app->get('/bar/', function ($req, $res) {
+                // Do something
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/bar/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSegmentWithSingleSlashRoute()
+    {
+        $app = new App();
+        $app->group('/foo', function () use ($app) {
+            $app->get('/', function ($req, $res) {
+                // Do something
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSegmentWithEmptyRoute()
+    {
+        $app = new App();
+        $app->group('/foo', function () use ($app) {
+            $app->get('', function ($req, $res) {
+                // Do something
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testTwoGroupSegmentsWithSingleSlashRoute()
+    {
         $app = new App();
         $app->group('/foo', function () use ($app) {
             $app->group('/baz', function () use ($app) {
@@ -199,10 +220,139 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/foo/baz', 'pattern', $router->lookupRoute('route0'));
-        
+        $this->assertAttributeEquals('/foo/baz/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testTwoGroupSegmentsWithAnEmptyRoute()
+    {
         $app = new App();
         $app->group('/foo', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/baz', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testTwoGroupSegmentsWithSegmentRoute()
+    {
+        $app = new App();
+        $app->group('/foo', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('/bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/baz/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testTwoGroupSegmentsWithSegmentRouteThatHasATrailingSlash()
+    {
+        $app = new App();
+        $app->group('/foo', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('/bar/', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/baz/bar/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSegmentWithSingleSlashNestedGroupAndSegmentRoute()
+    {
+        $app = new App();
+        $app->group('/foo', function () use ($app) {
+            $app->group('/', function () use ($app) {
+                $app->get('/bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSegmentWithSingleSlashGroupAndSegmentRouteWithoutLeadingSlash()
+    {
+        $app = new App();
+        $app->group('/foo', function () use ($app) {
+            $app->group('/', function () use ($app) {
+                $app->get('bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSegmentWithEmptyNestedGroupAndSegmentRoute()
+    {
+        $app = new App();
+        $app->group('/foo', function () use ($app) {
+            $app->group('', function () use ($app) {
+                $app->get('/bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSegmentWithEmptyNestedGroupAndSegmentRouteWithoutLeadingSlash()
+    {
+        $app = new App();
+        $app->group('/foo', function () use ($app) {
+            $app->group('', function () use ($app) {
+                $app->get('bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithSegmentRouteThatDoesNotEndInASlash()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->get('/bar', function ($req, $res) {
+                // Do something
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithSegmentRouteThatEndsInASlash()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
             $app->get('/bar/', function ($req, $res) {
                 // Do something
             });
@@ -210,7 +360,348 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/foo/bar/', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('/bar/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithSingleSlashRoute()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->get('/', function ($req, $res) {
+                // Do something
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithEmptyRoute()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->get('', function ($req, $res) {
+                // Do something
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithNestedGroupSegmentWithSingleSlashRoute()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('/', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/baz/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithNestedGroupSegmentWithAnEmptyRoute()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/baz', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithNestedGroupSegmentWithSegmentRoute()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('/bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/baz/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithNestedGroupSegmentWithSegmentRouteThatHasATrailingSlash()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('/bar/', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/baz/bar/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithSingleSlashNestedGroupAndSegmentRoute()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->group('/', function () use ($app) {
+                $app->get('/bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithSingleSlashGroupAndSegmentRouteWithoutLeadingSlash()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->group('/', function () use ($app) {
+                $app->get('bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithEmptyNestedGroupAndSegmentRoute()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->group('', function () use ($app) {
+                $app->get('/bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testGroupSingleSlashWithEmptyNestedGroupAndSegmentRouteWithoutLeadingSlash()
+    {
+        $app = new App();
+        $app->group('/', function () use ($app) {
+            $app->group('', function () use ($app) {
+                $app->get('bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+//HERE
+    public function testEmptyGroupWithSegmentRouteThatDoesNotEndInASlash()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->get('/bar', function ($req, $res) {
+                // Do something
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithSegmentRouteThatEndsInASlash()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->get('/bar/', function ($req, $res) {
+                // Do something
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithSingleSlashRoute()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->get('/', function ($req, $res) {
+                // Do something
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithEmptyRoute()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->get('', function ($req, $res) {
+                // Do something
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithNestedGroupSegmentWithSingleSlashRoute()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('/', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/baz/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithNestedGroupSegmentWithAnEmptyRoute()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/baz', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithNestedGroupSegmentWithSegmentRoute()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('/bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/baz/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithNestedGroupSegmentWithSegmentRouteThatHasATrailingSlash()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->group('/baz', function () use ($app) {
+                $app->get('/bar/', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/baz/bar/', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithSingleSlashNestedGroupAndSegmentRoute()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->group('/', function () use ($app) {
+                $app->get('/bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithSingleSlashGroupAndSegmentRouteWithoutLeadingSlash()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->group('/', function () use ($app) {
+                $app->get('bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithEmptyNestedGroupAndSegmentRoute()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->group('', function () use ($app) {
+                $app->get('/bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+    }
+
+    public function testEmptyGroupWithEmptyNestedGroupAndSegmentRouteWithoutLeadingSlash()
+    {
+        $app = new App();
+        $app->group('', function () use ($app) {
+            $app->group('', function () use ($app) {
+                $app->get('bar', function ($req, $res) {
+                    // Do something
+                });
+            });
+        });
+        /** @var \Slim\Router $router */
+        $router = $app->router;
+        $router->finalize();
+        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
     }
 
     /********************************************************************************


### PR DESCRIPTION
This PR handles route group patterns and slashes between them in a better manner. See issue #1577

When processing route groups, ensure that each group pattern is separated by a slash. However also ensure that there is never a double slash between groups and also that we never end up with an empty
pattern.

**Note**
This also means that a route with a trailing slash is different from a route without one. If we want `/foo` and `/foo/` to route to the same place, then I can update, or the route can be defined as:

``` php
$app->get('/foo[/]', function($request, $response, $args){/*...*/});
```

I have also significantly updated the [tests](https://github.com/akrabat/Slim/blob/better-handling-of-slash-in-routegroup-patterns/tests/AppTest.php#L151-L767) to cover all the cases I could think of:

Single routes:

| Route URI | Final pattern registered with router |
| --- | --- |
| `'/foo'` | `/foo` |
| `'/foo/'` | `/foo/` |
| `'foo'` | `/foo` |
| `'/'` | `/` |
| `''` | `/` |

Route groups:

| Group 1 | Group 2 (if exists) | Route URI | Final pattern registered with router |
| --- | --- | --- | --- |
| `'/foo'` |  | `'/bar'` | `/foo/bar` |
| `'/foo'` |  | `'/bar/'` | `/foo/bar/` |
| `'/foo'` |  | `'/'` | `/foo/` |
| `'/foo'` |  | `''` | `/foo` |
| `'/foo'` | `'/baz'` | `'/'` | `/foo/baz/` |
| `'/foo'` | `'/baz'` | `''` | `/foo/baz` |
| `'/foo'` | `'/baz'` | `'/bar'` | `/foo/baz/bar` |
| `'/foo'` | `'/baz'` | `'/bar/'` | `/foo/baz/bar/` |
| `'/foo'` | `'/'` | `'/bar'` | `/foo/bar` |
| `'/foo'` | `'/'` | `'bar'` | `/foo/bar` |
| `'/foo'` | `''` | `'/bar'` | `/foo/bar` |
| `'/foo'` | `''` | `'bar'` | `/foo/bar` |
| `'/'` |  | `'/bar'` | `/bar` |
| `'/'` |  | `'/bar/'` | `/bar/` |
| `'/'` |  | `'/'` | `/` |
| `'/'` |  | `''` | `/` |
| `'/'` | `'/baz'` | `'/'` | `/baz/` |
| `'/'` | `'/baz'` | `''` | `/baz` |
| `'/'` | `'/baz'` | `'/bar'` | `/baz/bar` |
| `'/'` | `'/baz'` | `'/bar/'` | `/baz/bar/` |
| `'/'` | `'/'` | `'/bar'` | `/bar` |
| `'/'` | `'/'` | `'bar'` | `/bar` |
| `'/'` | `''` | `'/bar'` | `/bar` |
| `'/'` | `''` | `'bar'` | `/bar` |
| `''` |  | `'/bar'` | `/bar` |
| `''` |  | `'/bar/'` | `/bar/` |
| `''` |  | `'/'` | `/` |
| `''` |  | `''` | `/` |
| `''` | `'/baz'` | `'/'` | `/baz/` |
| `''` | `'/baz'` | `''` | `/baz` |
| `''` | `'/baz'` | `'/bar'` | `/baz/bar` |
| `''` | `'/baz'` | `'/bar/'` | `/baz/bar/` |
| `''` | `'/'` | `'/bar'` | `/bar` |
| `''` | `'/'` | `'bar'` | `/bar` |
| `''` | `''` | `'/bar'` | `/bar` |
| `''` | `''` | `'bar'` | `/bar` |
