### PR TITLE
Fixed log level not displaying in default log.

### DIFF
--- a/Slim/Log.php
+++ b/Slim/Log.php
@@ -319,7 +319,7 @@ class Log
                 }
                 $message = $this->interpolate($message, $context);
             }
-            return $this->writer->write($message, $level);
+            return $this->writer->write($message, self::$levels[$level]);
         } else {
             return false;
         }

--- a/Slim/LogWriter.php
+++ b/Slim/LogWriter.php
@@ -70,6 +70,7 @@ class LogWriter
      */
     public function write($message, $level = null)
     {
-        return fwrite($this->resource, (string) $message . PHP_EOL);
+        $_level = (is_null($level)) ? '':$level;
+        return fwrite($this->resource, (string) $_level . $message . PHP_EOL);
     }
 }


### PR DESCRIPTION
Hey, 

This is my first contribution to an open source project so if I'm going about this incorrectly, please let me know. 

I was trying to use the provided default logger, but even using the supplied methods, (info, debug, error,...etc) I wasn't able to see the logging threshold that I would expect to see. I seen that the $level was declared, but not used in the LogWriter class, and that in the level was being passed in the Log class, but only the Constant declaration. 

My fix was to change the level being passed to the string $levels version already present in the Log class, and to implement the level and typical ' :: ' delimiter to the LogWriter class.

Thanks
