### PR TITLE
Making private methods protected

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -77,7 +77,7 @@ class Error
      * @param  Exception $exception
      * @return string
      */
-    private function renderHtmlErrorMessage(Exception $exception)
+    protected function renderHtmlErrorMessage(Exception $exception)
     {
         $title = 'Slim Application Error';
 
@@ -114,7 +114,7 @@ class Error
      *
      * @return string
      */
-    private function renderHtmlException(Exception $exception)
+    protected function renderHtmlException(Exception $exception)
     {
         $html = sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
 
@@ -148,7 +148,7 @@ class Error
      * @param  Exception $exception
      * @return string
      */
-    private function renderJsonErrorMessage(Exception $exception)
+    protected function renderJsonErrorMessage(Exception $exception)
     {
         $error = [
             'message' => 'Slim Application Error',
@@ -178,7 +178,7 @@ class Error
      * @param  Exception $exception
      * @return string
      */
-    private function renderXmlErrorMessage(Exception $exception)
+    protected function renderXmlErrorMessage(Exception $exception)
     {
         $xml = "<error>\n  <message>Slim Application Error</message>\n";
         if ($this->displayErrorDetails) {


### PR DESCRIPTION
Changing visibility of rendering methods to be protected rather than private, allowing the class to be extended for customized messages. Issue #1588 
