### PR TITLE
Changed inline output of NotAllowed to use protected functions

### DIFF
--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -54,40 +54,18 @@ class NotAllowed
             $contentType = $this->determineContentType($request);
             switch ($contentType) {
                 case 'application/json':
-                    $output = '{"message":"Method not allowed. Must be one of: ' . $allow . '"}';
+                    $output = $this->renderJsonNotAllowedMessage($methods);
                     break;
 
                 case 'text/xml':
                 case 'application/xml':
-                    $output = "<root><message>Method not allowed. Must be one of: $allow</message></root>";
+                    $output = $this->renderXmlNotAllowedMessage($methods);
                     break;
 
                 case 'text/html':
+                default:
                     $contentType = 'text/html';
-                    $output = <<<END
-<html>
-    <head>
-        <title>Method not allowed</title>
-        <style>
-            body{
-                margin:0;
-                padding:30px;
-                font:12px/1.5 Helvetica,Arial,Verdana,sans-serif;
-            }
-            h1{
-                margin:0;
-                font-size:48px;
-                font-weight:normal;
-                line-height:48px;
-            }
-        </style>
-    </head>
-    <body>
-        <h1>Method not allowed</h1>
-        <p>Method not allowed. Must be one of: <strong>$allow</strong></p>
-    </body>
-</html>
-END;
+                    $output = $this->renderHtmlNotAllowedMessage($methods);
                     break;
             }
         }
@@ -118,5 +96,81 @@ END;
         }
 
         return 'text/html';
+    }
+
+    /**
+     * Render PLAIN not allowed message
+     *
+     * @param  array                  $methods
+     * @return string
+     */
+    protected function renderPlainNotAllowedMessage($methods)
+    {
+        $allow = implode(', ', $methods);
+
+        return 'Allowed methods: ' . $allow;
+    }
+
+    /**
+     * Render JSON not allowed message
+     *
+     * @param  array                  $methods
+     * @return string
+     */
+    protected function renderJsonNotAllowedMessage($methods)
+    {
+        $allow = implode(', ', $methods);
+
+        return '{"message":"Method not allowed. Must be one of: ' . $allow . '"}';
+    }
+
+    /**
+     * Render XML not allowed message
+     *
+     * @param  array                  $methods
+     * @return string
+     */
+    protected function renderXmlNotAllowedMessage($methods)
+    {
+        $allow = implode(', ', $methods);
+
+        return "<root><message>Method not allowed. Must be one of: $allow</message></root>";
+    }
+
+    /**
+     * Render HTML not allowed message
+     *
+     * @param  array                  $methods
+     * @return string
+     */
+    protected function renderHtmlNotAllowedMessage($methods)
+    {
+        $allow = implode(', ', $methods);
+        $output = <<<END
+<html>
+    <head>
+        <title>Method not allowed</title>
+        <style>
+            body{
+                margin:0;
+                padding:30px;
+                font:12px/1.5 Helvetica,Arial,Verdana,sans-serif;
+            }
+            h1{
+                margin:0;
+                font-size:48px;
+                font-weight:normal;
+                line-height:48px;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>Method not allowed</h1>
+        <p>Method not allowed. Must be one of: <strong>$allow</strong></p>
+    </body>
+</html>
+END;
+
+        return $output;
     }
 }

--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -43,12 +43,10 @@ class NotAllowed
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $methods)
     {
-        $allow = implode(', ', $methods);
-
         if ($request->getMethod() === 'OPTIONS') {
             $status = 200;
             $contentType = 'text/plain';
-            $output = 'Allowed methods: ' . $allow;
+            $output = $this->renderPlainNotAllowedMessage($methods);
         } else {
             $status = 405;
             $contentType = $this->determineContentType($request);
@@ -72,6 +70,7 @@ class NotAllowed
 
         $body = new Body(fopen('php://temp', 'r+'));
         $body->write($output);
+        $allow = implode(', ', $methods);
 
         return $response
                 ->withStatus($status)

--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -61,7 +61,6 @@ class NotAllowed
                     break;
 
                 case 'text/html':
-                default:
                     $contentType = 'text/html';
                     $output = $this->renderHtmlNotAllowedMessage($methods);
                     break;


### PR DESCRIPTION
This way the class can be extended and messages customized by overriding the method.

Also reintroduced 'default:', line 66, in the switch test as otherwise $output could be undefined when reaching line 74.

Discussed in issue #1588 
