### PR TITLE
Corrected wrong getBasePath for issue #1590

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -194,7 +194,7 @@ class Uri implements UriInterface
         $requestUri = parse_url($env->get('REQUEST_URI'), PHP_URL_PATH);
         $basePath = '';
         $virtualPath = $requestUri;
-        if (stripos($requestUri, $requestScriptName) === 0) {
+        if (strcasecmp($requestUri, $requestScriptName) === 0) {
             $basePath = $requestScriptName;
         } elseif ($requestScriptDir !== '/' && stripos($requestUri, $requestScriptDir) === 0) {
             $basePath = $requestScriptDir;


### PR DESCRIPTION
Issue #1590 The following produces an incorrect output:

```
$uri = \Slim\Http\Uri::createFromEnvironment(
    \Slim\Http\Environment::mock(
        [
            'SCRIPT_NAME' => '/foo/index.php',
            'REQUEST_URI' => '/foo/index.phpXYZ',
        ])
);
print $uri->getBasePath();

// Produces /foo/index.php - correct output should be /foo/    
```

The issue is the use of stripos on line 197 in Uri.php - as long as you include the file name of the currently executing script you can add anything you like - and the file is returned.

The change is using strcasecmp instead of stripos which produces correct output

```
if (strcasecmp($requestUri, $requestScriptName) === 0) {
```
