### PR TITLE
Addressed https://github.com/slimphp/Slim/issues/1613 - Slim3: Unable t…

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -185,6 +185,9 @@ class Response extends Message implements ResponseInterface
 
         $clone = clone $this;
         $clone->status = $code;
+        if ($reasonPhrase === '' && isset(static::$messages[$code])) {
+            $reasonPhrase = static::$messages[$code];
+        }
         $clone->reasonPhrase = $reasonPhrase;
 
         return $clone;
@@ -199,7 +202,7 @@ class Response extends Message implements ResponseInterface
      */
     protected function filterStatus($status)
     {
-        if (!is_integer($status) || !isset(static::$messages[$status])) {
+        if (!is_integer($status) || $status<100 || $status>599) {
             throw new InvalidArgumentException('Invalid HTTP status code');
         }
 
@@ -224,7 +227,10 @@ class Response extends Message implements ResponseInterface
         if ($this->reasonPhrase) {
             return $this->reasonPhrase;
         }
-        return static::$messages[$this->status];
+        if (isset(static::$messages[$this->status])) {
+            return static::$messages[$this->status];
+        }
+        return '';
     }
 
     /*******************************************************************************

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -100,6 +100,16 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response->withStatus(200, null);
     }
 
+    public function testWithStatusEmptyReasonPhrase()
+    {
+        $response = new Response();
+        $clone = $response->withStatus(207);
+        $responsePhrase = new ReflectionProperty($response, 'reasonPhrase');
+        $responsePhrase->setAccessible(true);
+
+        $this->assertEquals('Multi-Status', $responsePhrase->getValue($clone));
+    }
+
     public function testGetReasonPhrase()
     {
         $response = new Response();
@@ -108,6 +118,16 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $responseStatus->setValue($response, '404');
 
         $this->assertEquals('Not Found', $response->getReasonPhrase());
+    }
+
+    public function testGetReasonPhraseForUnrecognisedCode()
+    {
+        $response = new Response();
+        $responseStatus = new ReflectionProperty($response, 'status');
+        $responseStatus->setAccessible(true);
+        $responseStatus->setValue($response, '499');
+
+        $this->assertEquals('', $response->getReasonPhrase());
     }
 
     public function testGetCustomReasonPhrase()


### PR DESCRIPTION
Addresses https://github.com/slimphp/Slim/issues/1613 - Slim3: Unable to set unrecognised response codes.

Only adds status phrases if empty string is passed, will not error if not status phrase is set and only status codes less than 100 or greater than 599 will be rejected - the remainder is free for usage.
