### PR TITLE
Add the method add to RouteInterface and RouteGroupInterface

### DIFF
--- a/Slim/Interfaces/RouteGroupInterface.php
+++ b/Slim/Interfaces/RouteGroupInterface.php
@@ -26,6 +26,15 @@ interface RouteGroupInterface
     public function getPattern();
 
     /**
+     * Prepend middleware to the group middleware collection
+     *
+     * @param mixed $callable The callback routine
+     *
+     * @return RouteGroupInterface
+     */
+    public function add($callable);
+
+    /**
      * Execute route group callable in the context of the Slim App
      *
      * This method invokes the route group object's callable, collecting

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -82,6 +82,17 @@ interface RouteInterface
     public function setName($name);
 
     /**
+     * Add middleware
+     *
+     * This method prepends new middleware to the route's middleware stack.
+     *
+     * @param mixed $callable The callback routine
+     *
+     * @return RouteInterface
+     */
+    public function add($callable);
+
+    /**
      * Prepare the route for use
      *
      * @param ServerRequestInterface $request

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -11,7 +11,6 @@ namespace Slim\Interfaces;
 use RuntimeException;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
-use Slim\RouteGroup;
 
 /**
  * Router Interface
@@ -57,7 +56,7 @@ interface RouterInterface
      * @param string   $pattern The group pattern
      * @param callable $callable A group callable
      *
-     * @return RouteGroup
+     * @return RouteGroupInterface
      */
     public function pushGroup($pattern, $callable);
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -16,6 +16,7 @@ use FastRoute\RouteCollector;
 use FastRoute\RouteParser;
 use FastRoute\RouteParser\Std as StdParser;
 use FastRoute\DataGenerator;
+use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouterInterface;
 use Slim\Interfaces\RouteInterface;
 
@@ -254,7 +255,7 @@ class Router implements RouterInterface
      * @param string   $pattern
      * @param callable $callable
      *
-     * @return RouteGroup
+     * @return RouteGroupInterface
      */
     public function pushGroup($pattern, $callable)
     {


### PR DESCRIPTION
A class that implements RouteInterface or RouteGroupInterface must have the method add() to prepend middlewares
