### PR TITLE
Helper methods for request params

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1052,6 +1052,46 @@ class Request extends Message implements ServerRequestInterface
     }
 
     /**
+     * Fetch parameter value from request body.
+     *
+     * @param      $key
+     * @param null $default
+     *
+     * @return null
+     */
+    public function getParsedBodyParam($key, $default = null)
+    {
+        $postParams = $this->getParsedBody();
+        $result = $default;
+        if (is_array($postParams) && isset($postParams[$key])) {
+            $result = $postParams[$key];
+        } elseif (is_object($postParams) && property_exists($postParams, $key)) {
+            $result = $postParams->$key;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Fetch parameter value from query string.
+     *
+     * @param      $key
+     * @param null $default
+     *
+     * @return null
+     */
+    public function getQueryParam($key, $default = null)
+    {
+        $getParams = $this->getQueryParams();
+        $result = $default;
+        if (isset($getParams[$key])) {
+            $result = $getParams[$key];
+        }
+
+        return $result;
+    }
+
+    /**
      * Fetch assocative array of body and query string parameters.
      *
      * @return array

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -814,11 +814,30 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $request->getParam('foo'));
     }
 
+    public function testGetParameterFromBodyWithBodyParemeterHelper()
+    {
+        $body = new RequestBody();
+        $body->write('foo=bar');
+        $body->rewind();
+        $request = $this->requestFactory()
+            ->withBody($body)
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded');
+
+        $this->assertEquals('bar', $request->getParsedBodyParam('foo'));
+    }
+
     public function testGetParameterFromQuery()
     {
         $request = $this->requestFactory()->withHeader('Content-Type', 'application/x-www-form-urlencoded');
 
         $this->assertEquals('123', $request->getParam('abc'));
+    }
+
+    public function testGetParameterFromQueryWithQueryParemeterHelper()
+    {
+        $request = $this->requestFactory()->withHeader('Content-Type', 'application/x-www-form-urlencoded');
+
+        $this->assertEquals('123', $request->getQueryParam('abc'));
     }
 
     public function testGetParameterFromBodyOverQuery()


### PR DESCRIPTION
Added helper methods to fetch param value from just request body or query string.
