### PR TITLE
Fix route middleware stacks

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -112,9 +112,7 @@ class Route extends Routable implements RouteInterface
     {
         $groupMiddleware = [];
         foreach ($this->getGroups() as $group) {
-            foreach ($group->getMiddleware() as $middleware) {
-                array_unshift($groupMiddleware, $middleware);
-            }
+            $groupMiddleware = array_merge($group->getMiddleware(), $groupMiddleware);
         }
 
         $this->middleware = array_merge($this->middleware, $groupMiddleware);

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -110,11 +110,15 @@ class Route extends Routable implements RouteInterface
      */
     public function finalize()
     {
+        $groupMiddleware = [];
         foreach ($this->getGroups() as $group) {
             foreach ($group->getMiddleware() as $middleware) {
-                array_unshift($this->middleware, $middleware);
+                array_unshift($groupMiddleware, $middleware);
             }
         }
+
+        $this->middleware = array_merge($this->middleware, $groupMiddleware);
+
         foreach ($this->getMiddleware() as $middleware) {
             $this->addMiddleware($middleware);
         }

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -44,8 +44,7 @@ class RouteGroup extends Routable implements RouteGroupInterface
             $callable = $callable->bindTo($this->container);
         }
 
-        array_unshift($this->middleware, $callable);
-
+        $this->middleware[] = $callable;
         return $this;
     }
 


### PR DESCRIPTION
See https://github.com/slimphp/Slim/issues/1622

Removed the array_unshift from RouteGroup->add(), since Route->add() don't use it. Consistency on middleware arrays.
