### PR TITLE
Simple concatenation of route paths

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -123,19 +123,11 @@ class Router implements RouterInterface
             throw new InvalidArgumentException('Route pattern must be a string');
         }
 
-        // pattern must start with a / if not empty
-        if ($pattern) {
-            $pattern = '/' . ltrim($pattern, '/');
-        }
-
         // Prepend parent group pattern(s)
         if ($this->routeGroups) {
             $pattern = $this->processGroups() . $pattern;
         }
 
-        // Complete pattern must start with a /
-        $pattern = '/' . ltrim($pattern, '/');
-        
         // According to RFC methods are defined in uppercase (See RFC 7231)
         $methods = array_map("strtoupper", $methods);
 
@@ -243,8 +235,7 @@ class Router implements RouterInterface
     {
         $pattern = "";
         foreach ($this->routeGroups as $group) {
-            // The route group's pattern doesn't end with a /
-            $pattern .= rtrim($group->getPattern(), '/');
+            $pattern .= $group->getPattern();
         }
         return $pattern;
     }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -184,7 +184,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/foo', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('foo', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testSingleSlashRoute()
@@ -208,7 +208,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('', 'pattern', $router->lookupRoute('route0'));
     }
 
     /********************************************************************************
@@ -347,7 +347,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('/foo//bar', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSegmentWithSingleSlashGroupAndSegmentRouteWithoutLeadingSlash()
@@ -395,7 +395,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/foo/bar', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('/foobar', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithSegmentRouteThatDoesNotEndInASlash()
@@ -409,7 +409,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('//bar', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithSegmentRouteThatEndsInASlash()
@@ -423,7 +423,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/bar/', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('//bar/', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithSingleSlashRoute()
@@ -437,7 +437,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('//', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithEmptyRoute()
@@ -467,7 +467,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/baz/', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('//baz/', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithNestedGroupSegmentWithAnEmptyRoute()
@@ -483,7 +483,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/baz', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('//baz', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithNestedGroupSegmentWithSegmentRoute()
@@ -499,7 +499,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/baz/bar', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('//baz/bar', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithNestedGroupSegmentWithSegmentRouteThatHasATrailingSlash()
@@ -515,7 +515,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/baz/bar/', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('//baz/bar/', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithSingleSlashNestedGroupAndSegmentRoute()
@@ -531,7 +531,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('///bar', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithSingleSlashGroupAndSegmentRouteWithoutLeadingSlash()
@@ -547,7 +547,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('//bar', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithEmptyNestedGroupAndSegmentRoute()
@@ -563,7 +563,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('//bar', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testGroupSingleSlashWithEmptyNestedGroupAndSegmentRouteWithoutLeadingSlash()
@@ -635,7 +635,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testEmptyGroupWithNestedGroupSegmentWithSingleSlashRoute()
@@ -715,7 +715,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('//bar', 'pattern', $router->lookupRoute('route0'));
     }
 
     public function testEmptyGroupWithSingleSlashGroupAndSegmentRouteWithoutLeadingSlash()
@@ -763,7 +763,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         /** @var \Slim\Router $router */
         $router = $app->router;
         $router->finalize();
-        $this->assertAttributeEquals('/bar', 'pattern', $router->lookupRoute('route0'));
+        $this->assertAttributeEquals('bar', 'pattern', $router->lookupRoute('route0'));
     }
 
     /********************************************************************************


### PR DESCRIPTION
As per https://github.com/slimphp/Slim/pull/1597#issuecomment-160325326, Simply concatenate all route paths from the groups and the map without any massaging. This is very predictable.

Test cases are now:

Single routes:

| Route URI | Final pattern registered with router |
| --- | --- |
| `'/foo'` | `/foo` |
| `'/foo/'` | `/foo/` |
| `'foo'` | `/foo` |
| `'/'` | `/` |
| `''` | ``  {i.e. Nothing} |

Route groups:

| Group 1 | Group 2 (if exists) | Route URI | Final pattern registered with router |
| --- | --- | --- | --- |
| `'/foo'` |  | `'/bar'` | `/foo/bar` |
| `'/foo'` |  | `'/bar/'` | `/foo/bar/` |
| `'/foo'` |  | `'/'` | `/foo/` |
| `'/foo'` |  | `''` | `/foo` |
| `'/foo'` | `'/baz'` | `'/'` | `/foo/baz/` |
| `'/foo'` | `'/baz'` | `''` | `/foo/baz` |
| `'/foo'` | `'/baz'` | `'/bar'` | `/foo/baz/bar` |
| `'/foo'` | `'/baz'` | `'/bar/'` | `/foo/baz/bar/` |
| `'/foo'` | `'/'` | `'/bar'` | `/foo//bar` |
| `'/foo'` | `'/'` | `'bar'` | `/foo/bar` |
| `'/foo'` | `''` | `'/bar'` | `/foo/bar` |
| `'/foo'` | `''` | `'bar'` | `/foobar` |
| `'/'` |  | `'/bar'` | `//bar` |
| `'/'` |  | `'/bar/'` | `//bar/` |
| `'/'` |  | `'/'` | `//` |
| `'/'` |  | `''` | `/` |
| `'/'` | `'/baz'` | `'/'` | `//baz/` |
| `'/'` | `'/baz'` | `''` | `//baz` |
| `'/'` | `'/baz'` | `'/bar'` | `//baz/bar` |
| `'/'` | `'/baz'` | `'/bar/'` | `//baz/bar/` |
| `'/'` | `'/'` | `'/bar'` | `///bar` |
| `'/'` | `'/'` | `'bar'` | `//bar` |
| `'/'` | `''` | `'/bar'` | `//bar` |
| `'/'` | `''` | `'bar'` | `/bar` |
| `''` |  | `'/bar'` | `/bar` |
| `''` |  | `'/bar/'` | `/bar/` |
| `''` |  | `'/'` | `/` |
| `''` |  | `''` | ``  {i.e. Nothing} |
| `''` | `'/baz'` | `'/'` | `/baz/` |
| `''` | `'/baz'` | `''` | `/baz` |
| `''` | `'/baz'` | `'/bar'` | `/baz/bar` |
| `''` | `'/baz'` | `'/bar/'` | `/baz/bar/` |
| `''` | `'/'` | `'/bar'` | `//bar` |
| `''` | `'/'` | `'bar'` | `/bar` |
| `''` | `''` | `'/bar'` | `/bar` |
| `''` | `''` | `'bar'` | `bar` |
