### PR TITLE
Remove run in separate process annotation

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1329,9 +1329,6 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->expectOutputString('Hello');
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testRespondNoContent()
     {
         $app = new App();
@@ -1365,9 +1362,6 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->expectOutputString('');
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testRespondWithPaddedStreamFilterOutput()
     {
         $availableFilter = stream_get_filters();
@@ -1424,9 +1418,6 @@ class AppTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testExceptionErrorHandlerDoesNotDisplayErrorDetails()
     {
         $app = new App();
@@ -1457,15 +1448,12 @@ class AppTest extends \PHPUnit_Framework_TestCase
             return $res;
         });
 
-        $resOut = $app->run();
+        $resOut = $app->run(true);
 
         $this->assertEquals(500, $resOut->getStatusCode());
-        $this->expectOutputRegex('/(?!.*middleware exception.*).*/');
+        $this->assertNotRegExp('/.*middleware exception.*/', (string)$resOut);
     }
 
-    /**
-     * @runInSeparateProcess
-     */
     public function testExceptionErrorHandlerDisplaysErrorDetails()
     {
         $app = new App([
@@ -1491,7 +1479,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $app->getContainer()['response'] = $res;
 
         $mw = function ($req, $res, $next) {
-            throw new \Exception('middleware exception');
+            throw new \RuntimeException('middleware exception');
         };
 
         $app->add($mw);
@@ -1500,10 +1488,10 @@ class AppTest extends \PHPUnit_Framework_TestCase
             return $res;
         });
 
-        $resOut = $app->run();
+        $resOut = $app->run(true);
 
         $this->assertEquals(500, $resOut->getStatusCode());
-        $this->expectOutputRegex('/.*middleware exception.*/');
+        $this->assertRegExp('/.*middleware exception.*/', (string)$resOut);
     }
 
     public function testFinalize()


### PR DESCRIPTION
Remove the `$responded` static and also update `testExceptionErrorHandlerDoesNotDisplayErrorDetails()` and `testExceptionErrorHandlerDisplaysErrorDetails()` so that they look in the response object's body.
