### PR TITLE
Prevent sending of default Content-Type

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -529,6 +529,9 @@ class App
      */
     protected function finalize(ResponseInterface $response)
     {
+        // stop PHP sending a Content-Type automatically
+        ini_set('default_mimetype', '');
+
         if ($this->isEmptyResponse($response)) {
             return $response->withoutHeader('Content-Type')->withoutHeader('Content-Length');
         }

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -130,7 +130,7 @@ final class Container extends PimpleContainer implements ContainerInterface
              * @return ResponseInterface
              */
             $this['response'] = function ($c) {
-                $headers = new Headers(['Content-Type' => 'text/html']);
+                $headers = new Headers(['Content-Type' => 'text/html; charset=UTF-8']);
                 $response = new Response(200, $headers);
 
                 return $response->withProtocolVersion($c->get('settings')['httpVersion']);


### PR DESCRIPTION
PHP will send a default Content-Type if the `default_mimetype` ini setting is not empty. Some status codes do not have a body and therefore a Content-Type header is not required. Therefore, we turn off this ini setting.

This PR also sets our default Content-Type to include the UTF-8 charset.

Addresses #1612 .
