### PR TITLE
Use Response::isEmpty() if possible

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -555,6 +555,9 @@ class App
      */
     protected function isEmptyResponse(ResponseInterface $response)
     {
+        if (method_exists($response, 'isEmpty')) {
+            return $response->isEmpty();
+        }
         return in_array($response->getStatusCode(), [204, 205, 304]);
     }
 }


### PR DESCRIPTION
When seeing if the response is empty, check if it implements `isEmpty()` first and use that if we can.

Fixes #1614
