### PR TITLE
Fix getRequestTarget

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -461,8 +461,9 @@ class Request extends Message implements ServerRequestInterface
             return '/';
         }
 
-        $path = $this->uri->getBasePath();
-        $path .= $this->uri->getPath();
+        $basePath = $this->uri->getBasePath();
+        $path = $this->uri->getPath();
+        $path = $basePath . '/' . ltrim($path, '/');
 
         $query = $this->uri->getQuery();
         if ($query) {


### PR DESCRIPTION
As per Uri::__toString(), ensure that there is a slash between the basePath and the path.

Fixes #1587 
