### PR TITLE
Revert 1606 to allow routing of /index.php/foo again

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -194,7 +194,7 @@ class Uri implements UriInterface
         $requestUri = parse_url($env->get('REQUEST_URI'), PHP_URL_PATH);
         $basePath = '';
         $virtualPath = $requestUri;
-        if (strcasecmp($requestUri, $requestScriptName) === 0) {
+        if (stripos($requestUri, $requestScriptName) === 0) {
             $basePath = $requestScriptName;
         } elseif ($requestScriptDir !== '/' && stripos($requestUri, $requestScriptDir) === 0) {
             $basePath = $requestScriptDir;

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -616,8 +616,10 @@ class UriTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Handle case when the URL is /foo/index.php/bar/baz
-     * @ticket 1590
+     * When the URL is /foo/index.php/bar/baz, we need the baseURL to be
+     * /foo/index.php so that routing works correctly.
+     *
+     * @ticket 1639 as a fix to 1590 broke this.
      */
     public function testRequestURIContainsIndexDotPhp()
     {
@@ -629,6 +631,6 @@ class UriTest extends \PHPUnit_Framework_TestCase
                 ]
             )
         );
-        $this->assertSame('/foo', $uri->getBasePath());
+        $this->assertSame('/foo/index.php', $uri->getBasePath());
     }
 }


### PR DESCRIPTION
PR #1606 changed the way that the Uri's baseUrl was detected in order to fix #1590. However, this change meant that routing of URLs of the form `/foo/index.php/bar/baz` no longer worked.

This commit reverts #1606 so that routing works again as the stripping off of the script name  when using rewriting could be done at the web server configuration level, or via a route the redirects to the one without the script name in it.

Fixes #1639.
