### PR TITLE
Tidy up method handling

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -240,9 +240,9 @@ class Request extends Message implements ServerRequestInterface
                 $body = $this->getParsedBody();
 
                 if (is_object($body) && property_exists($body, '_METHOD')) {
-                    $this->method = $this->filterMethod($body->_METHOD);
+                    $this->method = $this->filterMethod((string)$body->_METHOD);
                 } elseif (is_array($body) && isset($body['_METHOD'])) {
-                    $this->method = $this->filterMethod($body['_METHOD']);
+                    $this->method = $this->filterMethod((string)$body['_METHOD']);
                 }
 
                 if ($this->getBody()->eof()) {

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -286,7 +286,7 @@ class Request extends Message implements ServerRequestInterface
         $method = $this->filterMethod($method);
         $clone = clone $this;
         $clone->originalMethod = $method;
-        $clone->method = null; // <-- Force method override recalculation
+        $clone->method = $method;
 
         return $clone;
     }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -70,7 +70,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $request = $this->requestFactory()->withMethod('PUT');
 
-        $this->assertAttributeEquals(null, 'method', $request);
+        $this->assertAttributeEquals('PUT', 'method', $request);
         $this->assertAttributeEquals('PUT', 'originalMethod', $request);
     }
 


### PR DESCRIPTION
A couple of bug fixes:
- Ensure that the _METHOD key is always a string so that it works with XML.
- Ensure that Request's `withMethod()` works as the user expects(!)

Fixes #1637 
