### PR TITLE
Parse REQUEST_URI properly

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -191,7 +191,11 @@ class Uri implements UriInterface
         // Path
         $requestScriptName = parse_url($env->get('SCRIPT_NAME'), PHP_URL_PATH);
         $requestScriptDir = dirname($requestScriptName);
-        $requestUri = parse_url($env->get('REQUEST_URI'), PHP_URL_PATH);
+
+        // parse_url() requires a full URL. As we don't extract the domain name or scheme,
+        // we use a stand-in.
+        $requestUri = parse_url('http://example.com' . $env->get('REQUEST_URI'), PHP_URL_PATH);
+
         $basePath = '';
         $virtualPath = $requestUri;
         if (stripos($requestUri, $requestScriptName) === 0) {


### PR DESCRIPTION
parse_url() requires a full URL. As we don't extract the domain name
or scheme from this, we can use a stand-in. This allows the REQUEST_URI
to start with multiple forward slashes...

Fixes #1679
