### PR TITLE
runtime exception when responding with json fails to encode

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -301,7 +301,7 @@ class Response extends Message implements ResponseInterface
         $body->write(json_encode($data, $encodingOptions));
 
         // Ensure that the json encoding passed successfully
-        if( ($jsonLastError = json_last_error()) != JSON_ERROR_NONE ) {
+        if (($jsonLastError = json_last_error()) != JSON_ERROR_NONE) {
             throw new \RuntimeException(json_last_error_msg(), $jsonLastError);
         }
 

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -291,6 +291,7 @@ class Response extends Message implements ResponseInterface
      * @param  mixed  $data   The data
      * @param  int    $status The HTTP status code.
      * @param  int    $encodingOptions Json encoding options
+     * @throws \RuntimeException
      * @return self
      */
     public function withJson($data, $status = 200, $encodingOptions = 0)
@@ -298,6 +299,11 @@ class Response extends Message implements ResponseInterface
         $body = $this->getBody();
         $body->rewind();
         $body->write(json_encode($data, $encodingOptions));
+
+        // Ensure that the json encoding passed successfully
+        if ( ($jsonLastError = json_last_error()) != JSON_ERROR_NONE ) {
+            throw new \RuntimeException(json_last_error_msg(), $jsonLastError);
+        }
 
         return $this->withStatus($status)->withHeader('Content-Type', 'application/json;charset=utf-8');
     }

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -298,11 +298,11 @@ class Response extends Message implements ResponseInterface
     {
         $body = $this->getBody();
         $body->rewind();
-        $body->write(json_encode($data, $encodingOptions));
+        $body->write($json = json_encode($data, $encodingOptions));
 
         // Ensure that the json encoding passed successfully
-        if (($jsonLastError = json_last_error()) != JSON_ERROR_NONE) {
-            throw new \RuntimeException(json_last_error_msg(), $jsonLastError);
+        if ($json === false) {
+            throw new \RuntimeException(json_last_error_msg(), json_last_error());
         }
 
         return $this->withStatus($status)->withHeader('Content-Type', 'application/json;charset=utf-8');

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -301,7 +301,7 @@ class Response extends Message implements ResponseInterface
         $body->write(json_encode($data, $encodingOptions));
 
         // Ensure that the json encoding passed successfully
-        if ( ($jsonLastError = json_last_error()) != JSON_ERROR_NONE ) {
+        if( ($jsonLastError = json_last_error()) != JSON_ERROR_NONE ) {
             throw new \RuntimeException(json_last_error_msg(), $jsonLastError);
         }
 

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -306,4 +306,20 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('{"foo":"bar1\u0026bar2"}', $dataJson);
         $this->assertEquals($data['foo'], json_decode($dataJson, true)['foo']);
     }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testWithInvalidJsonThrowsException()
+    {
+        $data = ['foo' => 'bar'.chr(233)];
+        $this->assertEquals('bar'.chr(233), $data['foo']);
+        
+        $response = new Response();
+        $response->withJson($data, 200);
+
+        // Safety net: this assertion should not occur, since the RuntimeException
+        // must have been caught earlier by the test framework
+        $this->assertFalse(true);
+    }
 }


### PR DESCRIPTION
Sometimes you need to respond `->withJson($data)` where `$data` is obtained from a source (database for example) containing characters that he PHP json lib fails to encode.

For example, the **é** symbol is very basic in French (_liberté, égalité, fraternité_ ;) ), and legacy data sources may contain this letter in the form of `chr(233)` character code. (This is not the case if the data source is utf8-encoded of course).

`json_encode` silently fails when the `$data` contains this char code (as well as many other diacritics). The result is an empty string in the `Response` body.

I thought that it is important to raise an exception when this occurs.
