### PR TITLE
Added App::process() to expose Request -> Response functionality

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -297,12 +297,38 @@ class App
         $request = $this->container->get('request');
         $response = $this->container->get('response');
 
+        $response = $this->process($request, $response);
+
+        $response = $this->finalize($response);
+
+        if (!$silent) {
+            $this->respond($response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Process a request
+     *
+     * This method traverses the application middleware stack and then returns the
+     * resultant Response object.
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return ResponseInterface
+     *
+     * @throws Exception
+     * @throws MethodNotAllowedException
+     * @throws NotFoundException
+     */
+    public function process(ServerRequestInterface $request, ResponseInterface $response)
+    {
         // Ensure basePath is set
         $router = $this->container->get('router');
         if (is_callable([$request->getUri(), 'getBasePath']) && is_callable([$router, 'setBasePath'])) {
             $router->setBasePath($request->getUri()->getBasePath());
         }
-
 
         // Dispatch the Router first if the setting for this is on
         if ($this->container->get('settings')['determineRouteBeforeAppMiddleware'] === true) {
@@ -336,12 +362,6 @@ class App
             /** @var callable $errorHandler */
             $errorHandler = $this->container->get('errorHandler');
             $response = $errorHandler($request, $response, $e);
-        }
-
-        $response = $this->finalize($response);
-
-        if (!$silent) {
-            $this->respond($response);
         }
 
         return $response;

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -299,8 +299,6 @@ class App
 
         $response = $this->process($request, $response);
 
-        $response = $this->finalize($response);
-
         if (!$silent) {
             $this->respond($response);
         }
@@ -363,6 +361,8 @@ class App
             $errorHandler = $this->container->get('errorHandler');
             $response = $errorHandler($request, $response, $e);
         }
+
+        $response = $this->finalize($response);
 
         return $response;
     }


### PR DESCRIPTION
### The Problem

It's currently very difficult to give the application a request and retrieve a response. To have a request that isn't created from the PHP super globals you need to patch the container.

A project of mine ([PHPFastCGI](http://github.com/PHPFastCGI/FastCGIDaemon)) has struggled to provide a clean adapter to the Slim framework for this reason.
### The Solution

Split `App::run()` into two methods by creating `App::process()`. The latter acts as a simple map from request to response. 
### Downsides

The are two that I can think of:
1. It adds a new method to the public API that needs to be maintained and supported.
2. Confusion over the difference between `App:process()` and `App::__invoke()`. Both have the same signature and do similar things, but ultimately at a different level.

---
### Questions

Assuming that people think this is a good idea:
- How would you like me to test this? I haven't really added any features. Any test of `App::run()` now covers `App:process()`. I'm not adverse to adding unit tests, I just thought it was worth asking here what people think they should look like rather than just adding something pointless for the sake of it.
- Would you like me to add documentation (and where)?

Interested to hear thoughts :)
