### PR TITLE
Is this typos?

### DIFF
--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -105,7 +105,7 @@ class UploadedFile implements UploadedFileInterface
             if (!is_array($uploadedFile['error'])) {
                 $parsed[$field] = new static(
                     $uploadedFile['tmp_name'],
-                    isset($uploadedFile['tmp_name']) ? $uploadedFile['name'] : null,
+                    isset($uploadedFile['name']) ? $uploadedFile['name'] : null,
                     isset($uploadedFile['type']) ? $uploadedFile['type'] : null,
                     isset($uploadedFile['size']) ? $uploadedFile['size'] : null,
                     $uploadedFile['error'],
@@ -115,7 +115,7 @@ class UploadedFile implements UploadedFileInterface
                 foreach ($uploadedFile['error'] as $fileIdx => $error) {
                     $parsed[$field][] = new static(
                         $uploadedFile['tmp_name'][$fileIdx],
-                        isset($uploadedFile['tmp_name']) ? $uploadedFile['name'][$fileIdx] : null,
+                        isset($uploadedFile['name']) ? $uploadedFile['name'][$fileIdx] : null,
                         isset($uploadedFile['type']) ? $uploadedFile['type'][$fileIdx] : null,
                         isset($uploadedFile['size']) ? $uploadedFile['size'][$fileIdx] : null,
                         $uploadedFile['error'][$fileIdx],


### PR DESCRIPTION
`isset($uploadedFile['tmp_name']) ? $uploadedFile['name'] : null`
should it be
`isset($uploadedFile['name']) ? $uploadedFile['name'] : null`
