### PR TITLE
Option to send multiple response headers as comma separated single header

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -365,9 +365,16 @@ class App
             ));
 
             // Headers
-            foreach ($response->getHeaders() as $name => $values) {
-                foreach ($values as $value) {
-                    header(sprintf('%s: %s', $name, $value), false);
+            if ($this->container->get('settings')['singleHeader'] === true) {
+                foreach ($response->getHeaders() as $name => $values) {
+                    header(sprintf('%s: %s', $name, $response->getHeaderLine($name)), false);
+                }
+            }
+            else {
+                foreach ($response->getHeaders() as $name => $values) {
+                    foreach ($values as $value) {
+                        header(sprintf('%s: %s', $name, $value), false);
+                    }
                 }
             }
         }

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -68,6 +68,7 @@ class Container extends PimpleContainer implements ContainerInterface
         'outputBuffering' => 'append',
         'determineRouteBeforeAppMiddleware' => false,
         'displayErrorDetails' => false,
+        'singleHeader' => false,
     ];
 
     /**


### PR DESCRIPTION
[RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) specifies that response headers with multiple values sent as comma separated single header or as multiple headers to be the treated the same. Current implementation of Slim 3.x sends as multiple headers only.

Although this may not be an issue with modern browsers, I ran into a problem with a legacy client application that cannot handle duplicate headers. (No problem handling comma-separated values).

Adding a new container settings - `singleHeader` gives the flexibility to send response header in either format.
