### PR TITLE
Added HTTP 451 status code

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -98,6 +98,7 @@ class Response extends Message implements ResponseInterface
         428 => 'Precondition Required',
         429 => 'Too Many Requests',
         431 => 'Request Header Fields Too Large',
+        451 => 'Unavailable For Legal Reasons',
         //Server Error 5xx
         500 => 'Internal Server Error',
         501 => 'Not Implemented',


### PR DESCRIPTION
https://datatracker.ietf.org/doc/draft-ietf-httpbis-legally-restricted-status/?include_text=1

The HTTP 451 status code was approved by the ISG a few days ago on the 18th December '15.
