### PR TITLE
Request protocol version

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -178,6 +178,10 @@ class Request extends Message implements ServerRequestInterface
         $this->body = $body;
         $this->uploadedFiles = $uploadedFiles;
 
+        if (isset($serverParams['SERVER_PROTOCOL'])) {
+            $this->protocolVersion = str_replace('HTTP/', '', $serverParams['SERVER_PROTOCOL']);
+        }
+
         if (!$this->headers->has('Host') || $this->uri->getHost() !== '') {
             $this->headers->set('Host', $this->uri->getHost());
         }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -867,4 +867,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(['abc' => 'xyz', 'foo' => 'bar'], $request->getParams());
     }
+
+    /*******************************************************************************
+     * Protocol
+     ******************************************************************************/
+
+    public function testGetProtocolVersion()
+    {
+        $env = Environment::mock(['SERVER_PROTOCOL' => 'HTTP/1.0']);
+        $request = Request::createFromEnvironment($env);
+
+        $this->assertEquals('1.0', $request->getProtocolVersion());
+    }
 }


### PR DESCRIPTION
Property protocolVersion of Request defaults to 1.1. This change makes it change to the actual request protocol version. Is str_replace('HTTP/' sufficient?
