### PR TITLE
Throw an exception if calling a non-existing method on App

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -129,6 +129,8 @@ class App
                 return call_user_func_array($obj, $args);
             }
         }
+
+        throw new \BadMethodCallException("Method $method is not a valid method");
     }
 
     /********************************************************************************

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1828,4 +1828,13 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(404, $response->getStatusCode());
     }
+
+    /**
+     * @expectedException \BadMethodCallException
+     */
+    public function testCallingAnUnknownContainerCallableThrows()
+    {
+        $app = new App();
+        $app->foo('bar');
+    }
 }


### PR DESCRIPTION
I've got bitten by this with a project that was compatible with an early beta of Slim 3:

``` php
$app->addMiddleware(function (...) {
       ...
});
```

No error was thrown even though I called a non-existing method because of the specific `__call()` implementation.

With this change, an error will be thrown when calling an unknown method on `App`.
