### PR TITLE
Save request/response state in middleware exceptions

### DIFF
--- a/Slim/MiddlewareAwareTrait.php
+++ b/Slim/MiddlewareAwareTrait.php
@@ -9,11 +9,8 @@
 namespace Slim;
 
 use RuntimeException;
-use SplStack;
-use SplDoublyLinkedList;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use UnexpectedValueException;
 
 /**
  * Middleware
@@ -27,17 +24,9 @@ trait MiddlewareAwareTrait
     /**
      * Middleware call stack
      *
-     * @var  \SplStack
-     * @link http://php.net/manual/class.splstack.php
+     * @var  \Slim\Stack\Stack
      */
     protected $stack;
-
-    /**
-     * Middleware stack lock
-     *
-     * @var bool
-     */
-    protected $middlewareLock = false;
 
     /**
      * Add middleware
@@ -51,26 +40,14 @@ trait MiddlewareAwareTrait
      * @return static
      *
      * @throws RuntimeException         If middleware is added while the stack is dequeuing
-     * @throws UnexpectedValueException If the middleware doesn't return an instance of \Psr\Http\Message\ResponseInterface
      */
     protected function addMiddleware(callable $callable)
     {
-        if ($this->middlewareLock) {
-            throw new RuntimeException('Middleware can’t be added once the stack is dequeuing');
-        }
-
         if (is_null($this->stack)) {
             $this->seedMiddlewareStack();
         }
-        $next = $this->stack->top();
-        $this->stack[] = function (ServerRequestInterface $req, ResponseInterface $res) use ($callable, $next) {
-            $result = call_user_func($callable, $req, $res, $next);
-            if ($result instanceof ResponseInterface === false) {
-                throw new UnexpectedValueException('Middleware must return instance of \Psr\Http\Message\ResponseInterface');
-            }
 
-            return $result;
-        };
+        $this->stack->add($callable);
 
         return $this;
     }
@@ -90,29 +67,24 @@ trait MiddlewareAwareTrait
         if ($kernel === null) {
             $kernel = $this;
         }
-        $this->stack = new SplStack;
-        $this->stack->setIteratorMode(SplDoublyLinkedList::IT_MODE_LIFO | SplDoublyLinkedList::IT_MODE_KEEP);
-        $this->stack[] = $kernel;
+
+        $this->stack = new Stack\Stack($kernel);
     }
 
     /**
      * Call middleware stack
      *
-     * @param  ServerRequestInterface $req A request object
-     * @param  ResponseInterface      $res A response object
+     * @param  ServerRequestInterface $request A request object
+     * @param  ResponseInterface      $response A response object
      *
      * @return ResponseInterface
      */
-    public function callMiddlewareStack(ServerRequestInterface $req, ResponseInterface $res)
+    public function callMiddlewareStack(ServerRequestInterface $request, ResponseInterface $response)
     {
         if (is_null($this->stack)) {
             $this->seedMiddlewareStack();
         }
-        /** @var callable $start */
-        $start = $this->stack->top();
-        $this->middlewareLock = true;
-        $resp = $start($req, $res);
-        $this->middlewareLock = false;
-        return $resp;
+
+        return $this->stack->run($request, $response);
     }
 }

--- a/Slim/Stack/Stack.php
+++ b/Slim/Stack/Stack.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+namespace Slim\Stack;
+
+use Exception;
+use RuntimeException;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+* A simple middleware stack runner.
+*
+* Inspired by Relay: https://github.com/relayphp/Relay.Relay
+* Copyright (c) 2015, Paul M. Jones, MIT License
+*/
+class Stack
+{
+    const ERR_RESPONSE = 'ResponseInterface instance expected';
+    const ERR_RUNNING = 'Middleware cannot be added once the stack is running';
+    const ERR_RESOLVER = 'Stack entry is not resolvable';
+
+    /**
+    * The internal middleware queue
+    *
+    * @var callable[]
+    */
+    protected $queue = [];
+
+    /**
+    * An optional array of callables to convert queue entries
+    *
+    * @var callable[]
+    */
+    protected $resolvers = [];
+
+    /**
+    * Whether the stack is dequeuing
+    *
+    * @var bool
+    */
+    protected $locked = false;
+
+    /**
+    * Create a new Stack runner
+    *
+    * @param mixed $kernel Optional core middleware which will be run last
+    * @param callable[] $resolvers An optional array of callables to convert queue entries
+    */
+    public function __construct($kernel, array $resolvers = [])
+    {
+        if ($kernel !== null) {
+            $this->queue[] = $kernel;
+        }
+
+        foreach ($resolvers as $resolver) {
+            $this->addResolver($resolver);
+        }
+    }
+
+    /**
+    * Adds a middleware to the start of the queue
+    *
+    * @param mixed $entry A callable or entry that can be resolved
+    */
+    public function add($entry)
+    {
+        if ($this->locked) {
+            throw new RuntimeException(self::ERR_RUNNING);
+        }
+
+        array_unshift($this->queue, $entry);
+    }
+
+    /**
+    * Adds an array of middlewares to the start of the queue
+    *
+    * @param mixed[] $queue An array of callables or entries to be resolved
+    */
+    public function addQueue(array $queue)
+    {
+        foreach ($queue as $entry) {
+            $this->add($entry);
+        }
+    }
+
+    /**
+    * Adds a resolver to the end of the internal resolvers array
+    *
+    * A resolver is a callable that is used to resolve a non-callable
+    * queue entry into a middleware callable
+    *
+    * @param mixed $resolver
+    */
+    public function addResolver(callable $resolver)
+    {
+        $this->resolvers[] = $resolver;
+    }
+
+    /**
+    * Calls all the middleware on the stack
+    *
+    * @param ServerRequestInterface $request
+    * @param ResponseInterface $response
+    * @return ResponseInterface
+    */
+    public function run(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        $this->locked = true;
+        $result = $this($request, $response);
+        $this->locked = false;
+
+        return $result;
+    }
+
+    /**
+    * Calls the next entry from the start of the queue
+    *
+    * @param ServerRequestInterface $request
+    * @param ResponseInterface $response
+    * @return ResponseInterface
+    *
+    * @throws StackException
+    * @throws Exception
+    */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        if (!$this->queue) {
+            return $response;
+        }
+
+        try {
+            $next = $this->resolve(array_shift($this->queue));
+            $result = call_user_func($next, $request, $response, $this);
+
+            if ($result instanceof ResponseInterface === false) {
+                throw new RuntimeException(self::ERR_RESPONSE);
+            }
+            return $result;
+
+        } catch (StackException $e) {
+            // StackException contains the request and response, so rethrow it
+            throw $e;
+
+        } catch (Exception $e) {
+
+            // If the exception stores the request and response, rethrow it
+            if ($this->hasHttpMessage($e)) {
+                throw $e;
+            }
+
+            // Capture current state and throw a StackException
+            throw new StackException($request, $response, $e);
+        }
+    }
+
+    /**
+    * Resolves a queue entry
+    *
+    * @param mixed $entry A callable or entry to be resolved
+    * @return callable
+    *
+    * @throws RuntimeException
+    */
+    protected function resolve($entry)
+    {
+        // Return the entry if it is already callable
+        if (is_callable($entry)) {
+            return $entry;
+        }
+
+        $callable = $entry;
+
+        if ($this->resolvers) {
+            // A resolver will return null if it cannot resolve an entry
+            foreach ($this->resolvers as $resolver) {
+                $callable = call_user_func($resolver, $entry);
+                if ($callable !== null) {
+                    break;
+                }
+            }
+        }
+
+        if (is_callable($callable)) {
+            return $callable;
+        }
+
+        // Unable to resolve the entry
+        throw new RuntimeException(self::ERR_RESOLVER);
+    }
+
+    /**
+    * Checks if the exception contains accessible Psr\Http\Message objects
+    *
+    * @param Exception $e The exception to check
+    * @return bool
+    */
+    protected function hasHttpMessage(Exception $e)
+    {
+        if (!method_exists($e, 'getRequest') ||
+            $e->getRequest() instanceof ServerRequestInterface === false) {
+            return false;
+        }
+
+        if (!method_exists($e, 'getResponse') ||
+            $e->getResponse() instanceof ResponseInterface === false) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Slim/Stack/StackException.php
+++ b/Slim/Stack/StackException.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+namespace Slim\Stack;
+
+use Exception;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+* StackException
+*
+* This exception is used internally by the middleware stack runner, to capture the
+* outer request and response instances at the time of a middleware exception,
+* together with the exception itself. A StackException will bubble up if there
+* are linked stacks.
+*/
+class StackException extends Exception
+{
+    /**
+     * The original exception
+     *
+     * @var Exception
+     */
+    protected $exception;
+
+    /**
+     * The outer request object at the time of the exception
+     *
+     * @var ServerRequestInterface
+     */
+    protected $request;
+
+    /**
+     * The outer response object at the time of the exception
+     *
+     * @var ResponseInterface
+     */
+    protected $response;
+
+    /**
+     * Create new StackException
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @param Exception $source The original exception
+     */
+    public function __construct(ServerRequestInterface $request, ResponseInterface $response, Exception $exception)
+    {
+        parent::__construct();
+        $this->request = $request;
+        $this->response = $response;
+        $this->exception = $exception;
+    }
+
+    /**
+    * Get the original exception
+    *
+    * @return Exception
+    */
+    public function getException()
+    {
+        return $this->exception;
+    }
+
+    /**
+     * Get outer request object at the time of the exception
+     *
+     * @return ServerRequestInterface
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * Get outer response object at the time of the exception
+     *
+     * @return ResponseInterface
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -8,6 +8,7 @@
  */
 namespace Slim\Tests;
 
+use ReflectionProperty;
 use Slim\Container;
 use Slim\Http\Body;
 use Slim\Http\Environment;
@@ -18,6 +19,7 @@ use Slim\Http\Uri;
 use Slim\Route;
 use Slim\Tests\Mocks\CallableTest;
 use Slim\Tests\Mocks\MiddlewareStub;
+use Slim\Tests\Stack\StackUtils;
 
 class RouteTest extends \PHPUnit_Framework_TestCase
 {
@@ -89,10 +91,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route->add($mw);
         $route->finalize();
 
-        $prop = new \ReflectionProperty($route, 'stack');
-        $prop->setAccessible(true);
-
-        $this->assertEquals($route, $prop->getValue($route)->bottom());
+        $this->assertEquals($route, StackUtils::getBottom($route));
     }
 
     public function testAddMiddleware()
@@ -104,10 +103,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route->add($mw);
         $route->finalize();
 
-        $prop = new \ReflectionProperty($route, 'stack');
-        $prop->setAccessible(true);
-
-        $this->assertCount(2, $prop->getValue($route));
+        $this->assertCount(2, StackUtils::getQueue($route));
     }
 
     public function testRefinalizing()
@@ -122,10 +118,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route->finalize();
         $route->finalize();
 
-        $prop = new \ReflectionProperty($route, 'stack');
-        $prop->setAccessible(true);
-
-        $this->assertCount(2, $prop->getValue($route));
+        $this->assertCount(2, StackUtils::getQueue($route));
     }
 
 

--- a/tests/Stack/Mocks/BadHttpException.php
+++ b/tests/Stack/Mocks/BadHttpException.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Stack\Mocks;
+
+class BadHttpException extends \Exception
+{
+    public function getRequest()
+    {
+        return 'request';
+    }
+
+    public function getResponse()
+    {
+        return 'false';
+    }
+}

--- a/tests/Stack/Mocks/GoodHttpException.php
+++ b/tests/Stack/Mocks/GoodHttpException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Stack\Mocks;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class GoodHttpException extends \Exception
+{
+    protected $request;
+    protected $response;
+
+    public function __construct(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        parent::__construct();
+        $this->request = $request;
+        $this->response = $response;
+    }
+
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/tests/Stack/Mocks/MiddlewareMethod.php
+++ b/tests/Stack/Mocks/MiddlewareMethod.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Stack\Mocks;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class MiddlewareMethod
+{
+    public function run(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        $response->write('InMethod');
+        $next($request, $response);
+        $response->write('OutMethod');
+
+        return $response;
+    }
+}

--- a/tests/Stack/Mocks/MiddlewareStatic.php
+++ b/tests/Stack/Mocks/MiddlewareStatic.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Stack\Mocks;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class MiddlewareStatic
+{
+    public static function run(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        $response->write('InStatic');
+        $next($request, $response);
+        $response->write('OutStatic');
+
+        return $response;
+    }
+}

--- a/tests/Stack/StackTest.php
+++ b/tests/Stack/StackTest.php
@@ -1,0 +1,362 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Stack;
+
+use Slim\Http\Environment;
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Slim\Stack\Stack;
+use Slim\Stack\StackException;
+
+class StackTest extends \PHPUnit_Framework_TestCase
+{
+    public function testStackExceptionReturnsException()
+    {
+        $req = Request::createFromEnvironment(Environment::mock());
+        $res = new Response;
+        $exception = new \RuntimeException();
+
+        $this->setExpectedException('RuntimeException');
+
+        try {
+            throw new StackException($req, $res, $exception);
+        } catch (StackException $e) {
+            throw $e->getException();
+        }
+    }
+
+    public function testConstructSetsValues()
+    {
+        $kernel = 'callable';
+        $resolver = function($entry) {
+            return $entry;
+        };
+
+        $stack = new Stack($kernel, [$resolver, $resolver]);
+
+        $queue = StackUtils::getQueue($stack);
+        $this->assertCount(1, $queue);
+        $this->assertSame($kernel, array_shift($queue));
+
+        $resolvers = StackUtils::getResolvers($stack);
+        $this->assertCount(2, $resolvers);
+        $this->assertSame($resolver, array_shift($resolvers));
+    }
+
+    public function testConstructDoesNotSetValues()
+    {
+        $stack = new Stack(null);
+        $this->assertCount(0, StackUtils::getQueue($stack));
+        $this->assertCount(0, StackUtils::getResolvers($stack));
+    }
+
+    public function testAddPrependsEntries()
+    {
+        $kernel = 'callable';
+        $callFirst = 'callable';
+        $callSecond = 'callable';
+
+        $stack = new Stack($kernel);
+        $stack->add($callSecond);
+        $stack->add($callFirst);
+
+        $queue = StackUtils::getQueue($stack);
+        $this->assertSame($callFirst, $queue[0]);
+        $this->assertSame($callSecond, $queue[1]);
+        $this->assertSame($kernel, $queue[2]);
+    }
+
+    public function testAddQueuePrependsEntries()
+    {
+        $kernel = 'callable';
+        $callFirst = 'callable';
+        $callSecond = 'callable';
+
+        $stack = new Stack($kernel);
+        $stack->addQueue([$callSecond, $callFirst]);
+
+        $queue = StackUtils::getQueue($stack);
+        $this->assertSame($callFirst, $queue[0]);
+        $this->assertSame($callSecond, $queue[1]);
+        $this->assertSame($kernel, $queue[2]);
+    }
+
+    public function testAddThrowsWhenRunning()
+    {
+        $this->setExpectedException('RuntimeException', Stack::ERR_RUNNING);
+
+        $stack = new Stack(null);
+
+        // This middleware adds a new entry to the stack
+        $mw = function ($req, $res, $next) use ($stack) {
+            $stack->add('callable');
+            return $res;
+        };
+
+        $stack->add($mw);
+
+        $req = Request::createFromEnvironment(Environment::mock());
+        $res = new Response;
+
+        try {
+            $stack->run($req, $res);
+        } catch (StackException $e) {
+            throw $e->getException();
+        }
+    }
+
+    public function testAddResolverAppendsItem()
+    {
+        $resolver0 = function ($entry) {
+            return $entry;
+        };
+
+        $resolver1 = function ($entry) {
+            return $entry;
+        };
+
+        $stack = new Stack(null, [$resolver0]);
+        $stack->addResolver($resolver1);
+
+        $resolvers = StackUtils::getResolvers($stack);
+        $this->assertSame($resolver1, $resolvers[1]);
+    }
+
+    public function testRun()
+    {
+        $kernel = function($req, $res, $next) {
+            $res->write('Kernel');
+            return $res;
+        };
+
+        $in1 = function($req, $res, $next) {
+            $res->write('In1');
+            $res = $next($req, $res);
+            $res->write('Out1');
+            return $res;
+        };
+
+        $in2 = function($req, $res, $next) {
+            $res->write('In2');
+            $res = $next($req, $res);
+            $res->write('Out2');
+            return $res;
+        };
+
+        $stack = new Stack($kernel);
+        $stack->add($in1);
+        $stack->add($in2);
+
+        $req = Request::createFromEnvironment(Environment::mock());
+        $res = new Response;
+
+        $response = $stack->run($req, $res);
+        $this->assertEquals('In2In1KernelOut1Out2', (string)$response->getBody());
+    }
+
+    public function testRunWithMethod()
+    {
+        $kernel = function($req, $res, $next) {
+            $res->write('Kernel');
+            return $res;
+        };
+
+        $resolver = function ($entry) {
+            return [new $entry, 'run'];
+        };
+
+        $stack = new Stack($kernel, [$resolver]);
+        $stack->add('Slim\Tests\Stack\Mocks\MiddlewareMethod');
+
+        $req = Request::createFromEnvironment(Environment::mock());
+        $res = new Response;
+
+        $response = $stack->run($req, $res);
+        $this->assertEquals('InMethodKernelOutMethod', (string)$response->getBody());
+    }
+
+    public function testRunWithStatic()
+    {
+        $kernel = function($req, $res, $next) {
+            $res->write('Kernel');
+            return $res;
+        };
+
+        $stack = new Stack($kernel);
+        $stack->add('Slim\Tests\Stack\Mocks\MiddlewareStatic::run');
+
+        $req = Request::createFromEnvironment(Environment::mock());
+        $res = new Response;
+
+        $response = $stack->run($req, $res);
+        $this->assertEquals('InStaticKernelOutStatic', (string)$response->getBody());
+    }
+
+    public function testRunWithExceptionSavesMessageState()
+    {
+        // All middleware changes the status so we get a new response object
+        $kernel = function($req, $res, $next) {
+            $res = $res->withStatus(200);
+            $res->write('Kernel');
+            throw new \RuntimeException('oops');
+            return $res;
+        };
+
+        $in1 = function($req, $res, $next) {
+            $res = $res->withStatus(201);
+            $res->write('In1');
+            $res = $next($req, $res);
+            $res->write('Out1');
+            return $res;
+        };
+
+        $in2 = function($req, $res, $next) {
+            $res = $res->withStatus(202);
+            $res->write('In2');
+            $res = $next($req, $res);
+            $res->write('Out2');
+            return $res;
+        };
+
+        $stack = new Stack($kernel);
+        $stack->add($in1);
+        $stack->add($in2);
+
+        $req = Request::createFromEnvironment(Environment::mock());
+        $res = new Response;
+
+        try {
+            $stack->run($req, $res);
+        } catch (StackException $e) {
+            $response = $e->getResponse();
+
+            // Our exception was thrown in the kernel
+            $this->assertEquals('In2In1Kernel', (string)$response->getBody());
+
+            // Our response object should be from the middleware that calls the kernel
+            $this->assertEquals(201, $response->getStatusCode());
+        }
+    }
+
+    public function testRunWithBadResponseThrowsException()
+    {
+        $this->setExpectedException('RuntimeException', Stack::ERR_RESPONSE);
+
+        // This middleware does not return a ResponseInterface instance
+        $kernel = function($req, $res, $next) {
+            return new \stdClass();
+        };
+
+        $stack = new Stack($kernel);
+
+        $req = Request::createFromEnvironment(Environment::mock());
+        $res = new Response;
+
+        try {
+            $stack->run($req, $res);
+        } catch (StackException $e) {
+            throw $e->getException();
+        }
+    }
+
+    public function testResolveReturnsCallable()
+    {
+        $kernel = function($req, $res, $next) {
+            return $res;
+        };
+
+        $stack = new Stack($kernel);
+
+        $method = StackUtils::getMethod($stack, 'resolve');
+        $queue = StackUtils::getQueue($stack);
+        $callable = $method->invoke($stack, array_shift($queue));
+
+        $this->assertSame($kernel, $callable);
+    }
+
+    public function testResolveFindsResolver()
+    {
+        // This middleware entry needs resolving
+        $kernel = 'kernel';
+
+        // This resolver will not resolve it...
+        $resolver1 = function($entry) {
+            if ($entry === 'MyMiddleware') {
+                return new $entry;
+            }
+        };
+
+        $stack = new Stack($kernel, [$resolver1]);
+
+        // ...but this resolver will
+        $resolver2 = function($entry) {
+            if ($entry === 'kernel') {
+                return function() use ($entry) {
+                    return $entry;
+                };
+            }
+        };
+
+        $stack->addResolver($resolver2);
+
+        $method = StackUtils::getMethod($stack, 'resolve');
+        $queue = StackUtils::getQueue($stack);
+        $callable = $method->invoke($stack, array_shift($queue));
+
+        $this->assertSame($kernel, $callable());
+    }
+
+    public function testResolveThrowsWithBadEntry()
+    {
+        $this->setExpectedException('RuntimeException', Stack::ERR_RESOLVER);
+
+        // This middleware entry is not callable
+        $kernel = new \stdClass();
+
+        $stack = new Stack($kernel);
+
+        $method = StackUtils::getMethod($stack, 'resolve');
+        $queue = StackUtils::getQueue($stack);
+        $callable = $method->invoke($stack, array_shift($queue));
+    }
+
+    public function testResolveThrowsWithBadResolver()
+    {
+        $this->setExpectedException('RuntimeException', Stack::ERR_RESOLVER);
+
+        // This middleware entry needs resolving...
+        $kernel = 'kernel';
+
+        // ...but this resolver does not return a callable
+        $resolver = function($entry) {
+            return new \stdClass();
+        };
+
+        $stack = new Stack($kernel, [$resolver]);
+
+        $method = StackUtils::getMethod($stack, 'resolve');
+        $queue = StackUtils::getQueue($stack);
+        $callable = $method->invoke($stack, array_shift($queue));
+    }
+
+    public function testHasHttpMessage()
+    {
+        $stack = new Stack(null);
+        $method = StackUtils::getMethod($stack, 'hasHttpMessage');
+
+        $req = Request::createFromEnvironment(Environment::mock());
+        $res = new Response;
+
+        $exception = new Mocks\GoodHttpException($req, $res);
+        $this->assertTrue($method->invoke($stack, $exception));
+
+        $exception = new Mocks\BadHttpException();
+        $this->assertFalse($method->invoke($stack, $exception));
+    }
+}

--- a/tests/Stack/StackTest.php
+++ b/tests/Stack/StackTest.php
@@ -34,7 +34,7 @@ class StackTest extends \PHPUnit_Framework_TestCase
     public function testConstructSetsValues()
     {
         $kernel = 'callable';
-        $resolver = function($entry) {
+        $resolver = function ($entry) {
             return $entry;
         };
 
@@ -130,19 +130,19 @@ class StackTest extends \PHPUnit_Framework_TestCase
 
     public function testRun()
     {
-        $kernel = function($req, $res, $next) {
+        $kernel = function ($req, $res, $next) {
             $res->write('Kernel');
             return $res;
         };
 
-        $in1 = function($req, $res, $next) {
+        $in1 = function ($req, $res, $next) {
             $res->write('In1');
             $res = $next($req, $res);
             $res->write('Out1');
             return $res;
         };
 
-        $in2 = function($req, $res, $next) {
+        $in2 = function ($req, $res, $next) {
             $res->write('In2');
             $res = $next($req, $res);
             $res->write('Out2');
@@ -162,7 +162,7 @@ class StackTest extends \PHPUnit_Framework_TestCase
 
     public function testRunWithMethod()
     {
-        $kernel = function($req, $res, $next) {
+        $kernel = function ($req, $res, $next) {
             $res->write('Kernel');
             return $res;
         };
@@ -183,7 +183,7 @@ class StackTest extends \PHPUnit_Framework_TestCase
 
     public function testRunWithStatic()
     {
-        $kernel = function($req, $res, $next) {
+        $kernel = function ($req, $res, $next) {
             $res->write('Kernel');
             return $res;
         };
@@ -201,14 +201,14 @@ class StackTest extends \PHPUnit_Framework_TestCase
     public function testRunWithExceptionSavesMessageState()
     {
         // All middleware changes the status so we get a new response object
-        $kernel = function($req, $res, $next) {
+        $kernel = function ($req, $res, $next) {
             $res = $res->withStatus(200);
             $res->write('Kernel');
             throw new \RuntimeException('oops');
             return $res;
         };
 
-        $in1 = function($req, $res, $next) {
+        $in1 = function ($req, $res, $next) {
             $res = $res->withStatus(201);
             $res->write('In1');
             $res = $next($req, $res);
@@ -216,7 +216,7 @@ class StackTest extends \PHPUnit_Framework_TestCase
             return $res;
         };
 
-        $in2 = function($req, $res, $next) {
+        $in2 = function ($req, $res, $next) {
             $res = $res->withStatus(202);
             $res->write('In2');
             $res = $next($req, $res);
@@ -249,7 +249,7 @@ class StackTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('RuntimeException', Stack::ERR_RESPONSE);
 
         // This middleware does not return a ResponseInterface instance
-        $kernel = function($req, $res, $next) {
+        $kernel = function ($req, $res, $next) {
             return new \stdClass();
         };
 
@@ -267,7 +267,7 @@ class StackTest extends \PHPUnit_Framework_TestCase
 
     public function testResolveReturnsCallable()
     {
-        $kernel = function($req, $res, $next) {
+        $kernel = function ($req, $res, $next) {
             return $res;
         };
 
@@ -286,7 +286,7 @@ class StackTest extends \PHPUnit_Framework_TestCase
         $kernel = 'kernel';
 
         // This resolver will not resolve it...
-        $resolver1 = function($entry) {
+        $resolver1 = function ($entry) {
             if ($entry === 'MyMiddleware') {
                 return new $entry;
             }
@@ -295,9 +295,9 @@ class StackTest extends \PHPUnit_Framework_TestCase
         $stack = new Stack($kernel, [$resolver1]);
 
         // ...but this resolver will
-        $resolver2 = function($entry) {
+        $resolver2 = function ($entry) {
             if ($entry === 'kernel') {
-                return function() use ($entry) {
+                return function () use ($entry) {
                     return $entry;
                 };
             }
@@ -334,7 +334,7 @@ class StackTest extends \PHPUnit_Framework_TestCase
         $kernel = 'kernel';
 
         // ...but this resolver does not return a callable
-        $resolver = function($entry) {
+        $resolver = function ($entry) {
             return new \stdClass();
         };
 

--- a/tests/Stack/StackUtils.php
+++ b/tests/Stack/StackUtils.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2015 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Stack;
+
+use ReflectionMethod;
+use ReflectionProperty;
+use Slim\Stack\Stack;
+
+class StackUtils
+{
+    public static $stackName = 'stack';
+
+    /**
+    * Returns the accessible stack instance
+    *
+    * @param mixed $instance The stack or parent instance
+    * @return Stack The accessible stack instance
+    */
+    public static function getStackInstance($instance)
+    {
+        if ($instance instanceof Stack === false) {
+            $prop = new ReflectionProperty($instance, static::$stackName);
+            $prop->setAccessible(true);
+            $stack = $prop->getValue($instance);
+        } else {
+            $stack = $instance;
+        }
+
+        return $stack;
+    }
+
+    /**
+    * Returns the internal stack queue array
+    *
+    * @param mixed $instance The stack or parent instance
+    * @return callable[] The stack queue
+    */
+    public static function getQueue($instance)
+    {
+        return static::getProperty($instance, 'queue');
+    }
+
+    /**
+    * Returns the last item in the internal queue
+    *
+    * @param mixed $instance The stack or parent instance
+    * @return callable|null The last item
+    */
+    public static function getBottom($instance)
+    {
+        $queue = static::getQueue($instance);
+
+        return array_pop($queue);
+    }
+
+    /**
+    * Returns the internal resolvers array
+    *
+    * @param mixed $instance The stack or parent instance
+    * @return callable[] The resolvers array
+    */
+    public static function getResolvers($instance)
+    {
+        return static::getProperty($instance, 'resolvers');
+    }
+
+    /**
+    * Returns an invokable stack method
+    *
+    * @param mixed $instance The stack or parent instance
+    * @param string $name The method name
+    * @return ReflectionMethod The invokable method
+    */
+    public static function getMethod($instance, $name)
+    {
+        $stack = static::getStackInstance($instance);
+        $method = new ReflectionMethod($stack, $name);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+
+    /**
+    * Returns a stack property value
+    *
+    * @param mixed $instance The stack or parent instance
+    * @param mixed $name The property name
+    * @return mixed The property value
+    */
+    public static function getProperty($instance, $name)
+    {
+        $stack = static::getStackInstance($instance);
+        $prop = new ReflectionProperty($stack, $name);
+        $prop->setAccessible(true);
+
+        return $prop->getValue($stack);
+    }
+}


### PR DESCRIPTION
I have gone about this the wrong way, in that I should have asked questions first, rather than making assumptions about certain aspects of the code. As such this PR may be completely unusable or unneeded, so feel free to close it or do with it as you wish.

The intention is to provide more consistent exception handling. For example, the `NotFound` and `MethodNotAllowed` exceptions supply the current request/response instances (which may have been modified by app middleware), whilst a general exception can only use the initial instances from the container.

The `SlimException` seems to provide a method of returning the current request/response instances, except that only the response is used (and it is expected to be the final one). Since this exception is currently undocumented (apart from being called a _Stop Exception_ in the comments), I have taken the following approach, which was inspired by which was inspired by PM Jones' https://github.com/relayphp/Relay.Relay 

**Stack**
Instead of using an SPL stack object, this PR introduces a `Slim\Stack\Stack` module that will catch an exception and wrap it in a new `StackException`, together with the last known request and response instances. This exception is then thrown and can be handled by `App::process()`. The design allows it to _bubble up_ linked stacks (like the route and the app kernels).

**BC breaks**
I have tried to keep these to zero, but there is the possibility of two edge-case breaks:
1. Code that uses a `try ... catch` block around a `next()` call to inner middleware would not be expecting a StackException.
2. Code that directly calls `App::__invoke()` may break if the route is not found or the method is not allowed because this function now throws the appropriate exception (rather than looking for and invoking an error handler).

**Tests**
The Stack module has its own independent tests. Several existing tests needed to be changed and I hope that my lack of knowledge has not resulted in any harmful oversights. Several changes deal with receiving a wrapped `StackException` and accessing items in the internal stack queue.

**Resolver**
The `Stack` class includes the functionality to resolve non-callable queue entries. This is not currently used but could be implemented in the future. The simplistic design uses an array of _resolvers_ (which should return `null` on failure) so that  user-supplied resolvers can be used in addition to the Slim `CallableResolver`. A final implementation would probably require more thought than this.

**Things I am not sure about**
1. If my changes to the tests have omitted something important in the desire to make them to work.
2. If the `Stack::hasHttpMessage()` method is needed. Its purpose is to allow user-supplied exceptions that implement  `getRequest()` and `getResponse()` methods to bypass the StackException wrapping. I am not sure if this just complicates things or not (in that it would be another exception to check for if your middleware try-catches a `next` call, if indeed this is something that would be done).
3. A general best-practice strategy for middleware exceptions using immutable PSR messages!
