### PR TITLE
array specialization in phpdoc

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -776,7 +776,7 @@ class Request extends Message implements ServerRequestInterface
      * These values MAY be prepared from $_FILES or the message body during
      * instantiation, or MAY be injected via withUploadedFiles().
      *
-     * @return array An array tree of UploadedFileInterface instances; an empty
+     * @return UploadedFileInterface[] An array tree of UploadedFileInterface instances; an empty
      *     array MUST be returned if no data is present.
      */
     public function getUploadedFiles()


### PR DESCRIPTION
If this is in line with Slim's codebase philosophy, here is a minor change (phpdoc comments) about the returning type of `Request`'s `getUploadedFiles()` method. Since this method always returns an array (possibly empty) of `UploadedFileInterface` instances, this phpdoc change enables IDE analysis and auto-complete in call chaining.
Thanks.
