### PR TITLE
Converted Routable::add to allow multiple middleware via an array

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -99,18 +99,25 @@ class App
      *
      * This method prepends new middleware to the app's middleware stack.
      *
-     * @param  mixed    $callable The callback routine
+     * @param  mixed    $callable The callback routine which can be an array of multiple routines
      *
      * @return static
      */
     public function add($callable)
     {
-        $callable = $this->resolveCallable($callable);
-        if ($callable instanceof Closure) {
-            $callable = $callable->bindTo($this->container);
+        if (!is_array($callable) || is_callable($callable)) {
+            $callable = [$callable];
         }
 
-        return $this->addMiddleware($callable);
+        foreach ($callable as $closure) {
+            $closure = $this->resolveCallable($closure);
+            if ($closure instanceof Closure) {
+                $closure = $closure->bindTo($this->container);
+            }
+            $this->addMiddleware( $closure );
+        }
+
+        return $this;
     }
 
     /**

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -99,7 +99,7 @@ class App
      *
      * This method prepends new middleware to the app's middleware stack.
      *
-     * @param  mixed    $callable The callback routine which can be an array of multiple routines
+     * @param mixed $callable The callback routine or an array of callback routines
      *
      * @return static
      */

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -91,7 +91,7 @@ abstract class Routable
      */
     public function add($callable)
     {
-        foreach (func_get_args() As $callable) {
+        foreach (func_get_args() as $callable) {
             $callable = $this->resolveCallable($callable);
             if ($callable instanceof Closure) {
                 $callable = $callable->bindTo($this->container);

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -91,12 +91,14 @@ abstract class Routable
      */
     public function add($callable)
     {
-        $callable = $this->resolveCallable($callable);
-        if ($callable instanceof Closure) {
-            $callable = $callable->bindTo($this->container);
-        }
+        foreach (func_get_args() As $callable) {
+            $callable = $this->resolveCallable($callable);
+            if ($callable instanceof Closure) {
+                $callable = $callable->bindTo($this->container);
+            }
 
-        $this->middleware[] = $callable;
+            $this->middleware[] = $callable;
+        }
         return $this;
     }
 }

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -91,14 +91,22 @@ abstract class Routable
      */
     public function add($callable)
     {
-        foreach (func_get_args() as $callable) {
+        if (is_array($callable)) {
+            foreach ($callable as $closure) {
+                $closure = $this->resolveCallable($closure);
+                if ($closure instanceof Closure) {
+                    $closure = $closure->bindTo($this->container);
+                }
+                $this->middleware[] = $closure;
+            }
+        } else {
             $callable = $this->resolveCallable($callable);
             if ($callable instanceof Closure) {
                 $callable = $callable->bindTo($this->container);
             }
-
             $this->middleware[] = $callable;
         }
+        
         return $this;
     }
 }

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -91,22 +91,18 @@ abstract class Routable
      */
     public function add($callable)
     {
-        if (is_array($callable)) {
-            foreach ($callable as $closure) {
-                $closure = $this->resolveCallable($closure);
-                if ($closure instanceof Closure) {
-                    $closure = $closure->bindTo($this->container);
-                }
-                $this->middleware[] = $closure;
-            }
-        } else {
-            $callable = $this->resolveCallable($callable);
-            if ($callable instanceof Closure) {
-                $callable = $callable->bindTo($this->container);
-            }
-            $this->middleware[] = $callable;
+        if (!is_array($callable) || is_callable($callable)) {
+            $callable = [$callable];
         }
-        
+
+        foreach ($callable as $closure) {
+            $closure = $this->resolveCallable($closure);
+            if ($closure instanceof Closure) {
+                $closure = $closure->bindTo($this->container);
+            }
+            $this->middleware[] = $closure;
+        }
+
         return $this;
     }
 }

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -85,7 +85,7 @@ abstract class Routable
     /**
      * Prepend middleware to the middleware collection
      *
-     * @param mixed $callable The callback routine
+     * @param mixed $callable The callback routine or an array of callback routines
      *
      * @return static
      */


### PR DESCRIPTION
Depending on how the programmer codes this might be a nice addition to the framework, I have only done it for the add function of the Routable class for now but it can be applied to other functions throughout the framework.

Basically it will allow the framework to function as normal but also allows unlimited middleware elements to be added via one add function call.

The current way to add middleware:

``` php
$app = new \Slim\App;

$app -> get( "/", function ( $request, $response ) {
    return $response -> write( "Hello World!" );
} )
-> add( SomeClass::class )
-> add( SomeOtherClass::class )
-> add( [ 'SomeClass', 'method' ] )
-> add( [ $instance, 'method' ] );

$app -> run();
```

With my additions:

``` php
$app = new \Slim\App;

$app -> get( "/", function ( $request, $response ) {
    return $response -> write( "Hello World!" );
} ) -> add( [
    SomeClass::class,
    SomeOtherClass::class,
    [ 'SomeClass', 'method' ],
    [ $instance, 'method' ]
] );

$app -> run();
```

It isn't anything major but to me it looks cleaner and it doesn't affect how any current app code works, so all apps using v3 of Slim will still work in exactly the same way just with the added bonus of being able to use only one add function call if the developer wants to.
