### PR TITLE
Add custom HTTP method implementation.

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -223,7 +223,9 @@ class App
      */
     public function any($pattern, $callable)
     {
-        return $this->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], $pattern, $callable);
+        // Make sure that both default and custom HTTP methods are included
+        $allMethods = array_merge(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], Request::getCustomMethods());
+        return $this->map($allMethods, $pattern, $callable);
     }
 
     /**
@@ -251,6 +253,17 @@ class App
         }
 
         return $route;
+    }
+
+
+    /**
+     * Add a custom HTTP method to Request
+     *
+     * @param string $method
+     */
+    public function addMethod($method)
+    {
+        Request::addCustomMethod($method);
     }
 
     /**

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -126,6 +126,13 @@ class Request extends Message implements ServerRequestInterface
     ];
 
     /**
+     * Custom added HTTP valid methods in addition to $validMethods
+     *
+     * @var string[]
+     */
+    protected static $customMethods = [];
+
+    /**
      * Create new HTTP request with data extracted from the application
      * Environment object
      *
@@ -267,6 +274,30 @@ class Request extends Message implements ServerRequestInterface
     }
 
     /**
+     * Add a custom HTTP method other than default valid methods
+     *
+     * Custom methods are checked against supplied method while
+     * validating it in filterMethod()
+     *
+     * @param string $method
+     */
+    public static function addCustomMethod($method)
+    {
+        array_push(self::$customMethods, strtoupper($method));
+    }
+
+
+    /**
+     * Return custom defined HTTP methods
+     *
+     * @return string[]
+     */
+    public static function getCustomMethods()
+    {
+        return self::$customMethods;
+    }
+
+    /**
      * Return an instance with the provided HTTP method.
      *
      * While HTTP method names are typically all uppercase characters, HTTP
@@ -312,7 +343,7 @@ class Request extends Message implements ServerRequestInterface
         }
 
         $method = strtoupper($method);
-        if (!isset($this->validMethods[$method])) {
+        if (!(isset($this->validMethods[$method]) || isset(self::$customMethods[$method]))) {
             throw new InvalidArgumentException(sprintf(
                 'Unsupported HTTP method "%s" provided',
                 $method

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -42,6 +42,15 @@ class AppTest extends \PHPUnit_Framework_TestCase
      * Router proxy methods
      *******************************************************************************/
 
+    public function testAddMethod()
+    {
+        $app = new App();
+        $app->addMethod('FOO');
+
+        $customMethods = Request::getCustomMethods();
+        $this->assertContains('FOO', $customMethods);
+    }
+
     public function testGetRoute()
     {
         $path = '/foo';
@@ -127,6 +136,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             // Do something
         };
         $app = new App();
+        $app->addMethod('BAR');
         $route = $app->any($path, $callable);
 
         $this->assertInstanceOf('\Slim\Route', $route);
@@ -136,6 +146,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeContains('PATCH', 'methods', $route);
         $this->assertAttributeContains('DELETE', 'methods', $route);
         $this->assertAttributeContains('OPTIONS', 'methods', $route);
+        $this->assertAttributeContains('BAR', 'methods', $route);
     }
 
     public function testMapRoute()
@@ -145,11 +156,13 @@ class AppTest extends \PHPUnit_Framework_TestCase
             // Do something
         };
         $app = new App();
-        $route = $app->map(['GET', 'POST'], $path, $callable);
+        $app->addMethod('BAR');
+        $route = $app->map(['GET', 'POST', 'BAR'], $path, $callable);
 
         $this->assertInstanceOf('\Slim\Route', $route);
         $this->assertAttributeContains('GET', 'methods', $route);
         $this->assertAttributeContains('POST', 'methods', $route);
+        $this->assertAttributeContains('BAR', 'methods', $route);
     }
 
     /********************************************************************************

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -74,6 +74,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals('PUT', 'originalMethod', $request);
     }
 
+    public function testAddCustomMethod()
+    {
+        Request::addCustomMethod('FOO');
+        Request::addCustomMethod('bar');
+
+        $customMethods = Request::getCustomMethods();
+        $this->assertContains('FOO', $customMethods);
+        $this->assertContains('BAR', $customMethods);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */


### PR DESCRIPTION
In case a custom HTTP method is needed, it can be added by calling:

$app->addMethod('foo');

After that, it can be mapped just as any other standard HTTP method.
