### PR TITLE
Fix getQueryParams

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -727,7 +727,7 @@ class Request extends Message implements ServerRequestInterface
      */
     public function getQueryParams()
     {
-        if ($this->queryParams) {
+        if (is_array($this->queryParams)) {
             return $this->queryParams;
         }
 

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -556,7 +556,17 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $cloneUri = $clone->getUri();
 
         $this->assertEquals('abc=123', $cloneUri->getQuery()); // <-- Unchanged
-        $this->assertAttributeEquals(['foo' => 'bar'], 'queryParams', $clone); // <-- Changed
+        $this->assertEquals(['foo' => 'bar'], $clone->getQueryParams()); // <-- Changed
+    }
+
+    public function testWithQueryParamsEmptyArray()
+    {
+        $request = $this->requestFactory();
+        $clone = $request->withQueryParams([]);
+        $cloneUri = $clone->getUri();
+
+        $this->assertEquals('abc=123', $cloneUri->getQuery()); // <-- Unchanged
+        $this->assertEquals([], $clone->getQueryParams()); // <-- Changed
     }
 
     public function testGetQueryParamsWithoutUri()


### PR DESCRIPTION
Empty array returns false but an empty array is valid in this case.

Fix a part of: https://github.com/slimphp/Slim/issues/1731
