### PR TITLE
Fix getParsedBody

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -92,7 +92,7 @@ class Request extends Message implements ServerRequestInterface
      *
      * @var null|array|object
      */
-    protected $bodyParsed;
+    protected $bodyParsed = false;
 
     /**
      * List of request body parsers (e.g., url-encoded, JSON, XML, multipart)
@@ -958,7 +958,7 @@ class Request extends Message implements ServerRequestInterface
      */
     public function getParsedBody()
     {
-        if (is_array($this->bodyParsed) || is_object($this->bodyParsed)) {
+        if ($this->bodyParsed !== false) {
             return $this->bodyParsed;
         }
 

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -958,7 +958,7 @@ class Request extends Message implements ServerRequestInterface
      */
     public function getParsedBody()
     {
-        if ($this->bodyParsed) {
+        if (is_array($this->bodyParsed) || is_object($this->bodyParsed)) {
             return $this->bodyParsed;
         }
 

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -834,6 +834,14 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->requestFactory()->withParsedBody(2);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithParsedBodyInvalidFalseValue()
+    {
+        $this->requestFactory()->withParsedBody(false);
+    }
+
     /*******************************************************************************
      * Parameters
      ******************************************************************************/

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -787,7 +787,43 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $clone = $this->requestFactory()->withParsedBody(['xyz' => '123']);
 
-        $this->assertAttributeEquals(['xyz' => '123'], 'bodyParsed', $clone);
+        $this->assertEquals(['xyz' => '123'], $clone->getParsedBody());
+    }
+
+    public function testWithParsedBodyEmptyArray()
+    {
+        $method = 'GET';
+        $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
+        $headers = new Headers();
+        $headers->set('Content-Type', 'application/x-www-form-urlencoded;charset=utf8');
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('foo=bar');
+        $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
+
+
+        $clone = $request->withParsedBody([]);
+
+        $this->assertEquals([], $clone->getParsedBody());
+    }
+
+    public function testWithParsedBodyNull()
+    {
+        $method = 'GET';
+        $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
+        $headers = new Headers();
+        $headers->set('Content-Type', 'application/x-www-form-urlencoded;charset=utf8');
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('foo=bar');
+        $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
+
+
+        $clone = $request->withParsedBody(null);
+
+        $this->assertNull($clone->getParsedBody());
     }
 
     /**


### PR DESCRIPTION
Fix a part of: https://github.com/slimphp/Slim/issues/1731

The only remaining problem is setting null to parsed body.
Using:

``` php
 $request = $request->withParsedBody(null);
```

Won't take effect.

The only way I see to fix this is setting a flag if the body is already parsed or not.
