### PR TITLE
Typehints for callables

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -99,7 +99,7 @@ class App
      *
      * This method prepends new middleware to the app's middleware stack.
      *
-     * @param  mixed    $callable The callback routine
+     * @param  callable|string    $callable The callback routine
      *
      * @return static
      */
@@ -141,7 +141,7 @@ class App
      * Add GET route
      *
      * @param  string $pattern  The route URI pattern
-     * @param  mixed  $callable The route callback routine
+     * @param  callable|string  $callable The route callback routine
      *
      * @return \Slim\Interfaces\RouteInterface
      */
@@ -154,7 +154,7 @@ class App
      * Add POST route
      *
      * @param  string $pattern  The route URI pattern
-     * @param  mixed  $callable The route callback routine
+     * @param  callable|string  $callable The route callback routine
      *
      * @return \Slim\Interfaces\RouteInterface
      */
@@ -167,7 +167,7 @@ class App
      * Add PUT route
      *
      * @param  string $pattern  The route URI pattern
-     * @param  mixed  $callable The route callback routine
+     * @param  callable|string  $callable The route callback routine
      *
      * @return \Slim\Interfaces\RouteInterface
      */
@@ -180,7 +180,7 @@ class App
      * Add PATCH route
      *
      * @param  string $pattern  The route URI pattern
-     * @param  mixed  $callable The route callback routine
+     * @param  callable|string  $callable The route callback routine
      *
      * @return \Slim\Interfaces\RouteInterface
      */
@@ -193,7 +193,7 @@ class App
      * Add DELETE route
      *
      * @param  string $pattern  The route URI pattern
-     * @param  mixed  $callable The route callback routine
+     * @param  callable|string  $callable The route callback routine
      *
      * @return \Slim\Interfaces\RouteInterface
      */
@@ -206,7 +206,7 @@ class App
      * Add OPTIONS route
      *
      * @param  string $pattern  The route URI pattern
-     * @param  mixed  $callable The route callback routine
+     * @param  callable|string  $callable The route callback routine
      *
      * @return \Slim\Interfaces\RouteInterface
      */
@@ -219,7 +219,7 @@ class App
      * Add route for any HTTP method
      *
      * @param  string $pattern  The route URI pattern
-     * @param  mixed  $callable The route callback routine
+     * @param  callable|string  $callable The route callback routine
      *
      * @return \Slim\Interfaces\RouteInterface
      */
@@ -233,7 +233,7 @@ class App
      *
      * @param  string[] $methods  Numeric array of HTTP method names
      * @param  string   $pattern  The route URI pattern
-     * @param  mixed    $callable The route callback routine
+     * @param  callable|string    $callable The route callback routine
      *
      * @return RouteInterface
      */

--- a/Slim/CallableResolverAwareTrait.php
+++ b/Slim/CallableResolverAwareTrait.php
@@ -27,7 +27,7 @@ trait CallableResolverAwareTrait
      * Resolve a string of the format 'class:method' into a closure that the
      * router can dispatch.
      *
-     * @param mixed $callable
+     * @param callable|string $callable
      *
      * @return \Closure
      *

--- a/Slim/Interfaces/RouteGroupInterface.php
+++ b/Slim/Interfaces/RouteGroupInterface.php
@@ -28,7 +28,7 @@ interface RouteGroupInterface
     /**
      * Prepend middleware to the group middleware collection
      *
-     * @param mixed $callable The callback routine
+     * @param callable|string $callable The callback routine
      *
      * @return RouteGroupInterface
      */

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -86,7 +86,7 @@ interface RouteInterface
      *
      * This method prepends new middleware to the route's middleware stack.
      *
-     * @param mixed $callable The callback routine
+     * @param callable|string $callable The callback routine
      *
      * @return RouteInterface
      */

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -85,7 +85,7 @@ abstract class Routable
     /**
      * Prepend middleware to the middleware collection
      *
-     * @param mixed $callable The callback routine
+     * @param callable|string $callable The callback routine
      *
      * @return static
      */


### PR DESCRIPTION
I replaced the mixed typehints for callables with callable|string like suggested in  https://github.com/slimphp/Slim/issues/1656
