### PR TITLE
withJson should not set http status code implicitly

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -290,11 +290,12 @@ class Response extends Message implements ResponseInterface
      * response to the client.
      *
      * @param  mixed  $data   The data
+     * @param  int    $status The HTTP status code.
      * @param  int    $encodingOptions Json encoding options
      * @throws \RuntimeException
      * @return self
      */
-    public function withJson($data, $encodingOptions = 0)
+    public function withJson($data, $status = null, $encodingOptions = 0)
     {
         $body = $this->getBody();
         $body->rewind();
@@ -305,7 +306,11 @@ class Response extends Message implements ResponseInterface
             throw new \RuntimeException(json_last_error_msg(), json_last_error());
         }
 
-        return $this->withHeader('Content-Type', 'application/json;charset=utf-8');
+        $response_with_json = $this->withHeader('Content-Type', 'application/json;charset=utf-8');
+        if (isset($status)) {
+            return $response_with_json->withStatus($status);
+        }
+        return $response_with_json;
     }
 
     /**

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -306,11 +306,11 @@ class Response extends Message implements ResponseInterface
             throw new \RuntimeException(json_last_error_msg(), json_last_error());
         }
 
-        $response_with_json = $this->withHeader('Content-Type', 'application/json;charset=utf-8');
+        $responseWithJson = $this->withHeader('Content-Type', 'application/json;charset=utf-8');
         if (isset($status)) {
-            return $response_with_json->withStatus($status);
+            return $responseWithJson->withStatus($status);
         }
-        return $response_with_json;
+        return $responseWithJson;
     }
 
     /**

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -290,12 +290,11 @@ class Response extends Message implements ResponseInterface
      * response to the client.
      *
      * @param  mixed  $data   The data
-     * @param  int    $status The HTTP status code.
      * @param  int    $encodingOptions Json encoding options
      * @throws \RuntimeException
      * @return self
      */
-    public function withJson($data, $status = 200, $encodingOptions = 0)
+    public function withJson($data, $encodingOptions = 0)
     {
         $body = $this->getBody();
         $body->rewind();
@@ -306,7 +305,7 @@ class Response extends Message implements ResponseInterface
             throw new \RuntimeException(json_last_error_msg(), json_last_error());
         }
 
-        return $this->withStatus($status)->withHeader('Content-Type', 'application/json;charset=utf-8');
+        return $this->withHeader('Content-Type', 'application/json;charset=utf-8');
     }
 
     /**

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -305,6 +305,9 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('{"foo":"bar1\u0026bar2"}', $dataJson);
         $this->assertEquals($data['foo'], json_decode($dataJson, true)['foo']);
+
+        $response = $response->withStatus(201)->withJson([]);
+        $this->assertEquals($response->getStatusCode(), 201);
     }
 
     /**

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -284,8 +284,9 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $data = ['foo' => 'bar1&bar2'];
 
         $response = new Response();
-        $response = $response->withJson($data);
+        $response = $response->withJson($data, 201);
 
+        $this->assertEquals(201, $response->getStatusCode());
         $this->assertEquals('application/json;charset=utf-8', $response->getHeaderLine('Content-Type'));
 
         $body = $response->getBody();
@@ -296,7 +297,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data['foo'], json_decode($dataJson, true)['foo']);
 
         // Test encoding option
-        $response = $response->withJson($data, JSON_HEX_AMP);
+        $response = $response->withJson($data, 200, JSON_HEX_AMP);
 
         $body = $response->getBody();
         $body->rewind();
@@ -315,7 +316,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar'.chr(233), $data['foo']);
         
         $response = new Response();
-        $response->withJson($data);
+        $response->withJson($data, 200);
 
         // Safety net: this assertion should not occur, since the RuntimeException
         // must have been caught earlier by the test framework

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -284,9 +284,8 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $data = ['foo' => 'bar1&bar2'];
 
         $response = new Response();
-        $response = $response->withJson($data, 201);
+        $response = $response->withJson($data);
 
-        $this->assertEquals(201, $response->getStatusCode());
         $this->assertEquals('application/json;charset=utf-8', $response->getHeaderLine('Content-Type'));
 
         $body = $response->getBody();
@@ -297,7 +296,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data['foo'], json_decode($dataJson, true)['foo']);
 
         // Test encoding option
-        $response = $response->withJson($data, 200, JSON_HEX_AMP);
+        $response = $response->withJson($data, JSON_HEX_AMP);
 
         $body = $response->getBody();
         $body->rewind();
@@ -316,7 +315,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar'.chr(233), $data['foo']);
         
         $response = new Response();
-        $response->withJson($data, 200);
+        $response->withJson($data);
 
         // Safety net: this assertion should not occur, since the RuntimeException
         // must have been caught earlier by the test framework


### PR DESCRIPTION
I thought that `withJson` set http status code confusing user.
e.g.
`$response->withStatus(500)->withJson([])`
and
`$response->withJson([])->withStatus(500)`
are not equally.:cry:
We should fix `withJson` to intuitive.
Thank you for your consideration.
