### PR TITLE
Improve Router.php namedRoutes caching

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -58,13 +58,6 @@ class Router implements RouterInterface
     protected $routeCounter = 0;
 
     /**
-     * Named routes
-     *
-     * @var null|Route[]
-     */
-    protected $namedRoutes;
-
-    /**
      * Route groups
      *
      * @var RouteGroup[]
@@ -199,13 +192,12 @@ class Router implements RouterInterface
      */
     public function getNamedRoute($name)
     {
-        if (count($this->namedRoutes) != count($this->routes)) {
-            $this->buildNameIndex();
+        foreach ($this->routes as $route) {
+            if ($name == $route->getName()) {
+                return $route;
+            }
         }
-        if (!isset($this->namedRoutes[$name])) {
-            throw new RuntimeException('Named route does not exist for name: ' . $name);
-        }
-        return $this->namedRoutes[$name];
+        throw new RuntimeException('Named route does not exist for name: ' . $name);
     }
 
     /**
@@ -365,19 +357,5 @@ class Router implements RouterInterface
     {
         trigger_error('urlFor() is deprecated. Use pathFor() instead.', E_USER_DEPRECATED);
         return $this->pathFor($name, $data, $queryParams);
-    }
-
-    /**
-     * Build index of named routes
-     */
-    protected function buildNameIndex()
-    {
-        $this->namedRoutes = [];
-        foreach ($this->routes as $route) {
-            $name = $route->getName();
-            if ($name) {
-                $this->namedRoutes[$name] = $route;
-            }
-        }
     }
 }

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -199,7 +199,7 @@ class Router implements RouterInterface
      */
     public function getNamedRoute($name)
     {
-        if (is_null($this->namedRoutes)) {
+        if (count($this->namedRoutes) != count($this->routes)) {
             $this->buildNameIndex();
         }
         if (!isset($this->namedRoutes[$name])) {


### PR DESCRIPTION
pathFor() should function properly ( and not throw an exception) during the following sequence.

1) call pathFor()
2) map() a new named route
3) call pathFor() for the route added in step 2.

Therefore, getNamedRoute() should be more precise than is_null($this->namedRoutes).  Comparing the size of namedRoutes to routes, while not perfect, is better.
