### PR TITLE
Ensure that responses with an indeterminate-length body have their content sent

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -385,16 +385,25 @@ class App
             if (!$contentLength) {
                 $contentLength = $body->getSize();
             }
-            $totalChunks    = ceil($contentLength / $chunkSize);
-            $lastChunkSize  = $contentLength % $chunkSize;
-            $currentChunk   = 0;
-            while (!$body->eof() && $currentChunk < $totalChunks) {
-                if (++$currentChunk == $totalChunks && $lastChunkSize > 0) {
-                    $chunkSize = $lastChunkSize;
+            if (isset($contentLength)) {
+                $totalChunks    = ceil($contentLength / $chunkSize);
+                $lastChunkSize  = $contentLength % $chunkSize;
+                $currentChunk   = 0;
+                while (!$body->eof() && $currentChunk < $totalChunks) {
+                    if (++$currentChunk == $totalChunks && $lastChunkSize > 0) {
+                        $chunkSize = $lastChunkSize;
+                    }
+                    echo $body->read($chunkSize);
+                    if (connection_status() != CONNECTION_NORMAL) {
+                        break;
+                    }
                 }
-                echo $body->read($chunkSize);
-                if (connection_status() != CONNECTION_NORMAL) {
-                    break;
+            } else {
+                while (!$body->eof()) {
+                    echo $body->read($chunkSize);
+                    if (connection_status() != CONNECTION_NORMAL) {
+                        break;
+                    }
                 }
             }
         }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1562,6 +1562,23 @@ class AppTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testRespondIndeterminateLength()
+    {
+        $app = new App();
+        $body_stream = fopen('php://temp', 'r+');
+        $response = new Response();
+        $body = $this->getMockBuilder("\Slim\Http\Body")
+            ->setMethods(["getSize"])
+            ->setConstructorArgs([$body_stream])
+            ->getMock();
+        fwrite($body_stream, "Hello");
+        rewind($body_stream);
+        $body->method("getSize")->willReturn(null);
+        $response = $response->withBody($body);
+        $app->respond($response);
+        $this->expectOutputString("Hello");
+    }
+
     public function testExceptionErrorHandlerDoesNotDisplayErrorDetails()
     {
         $app = new App();


### PR DESCRIPTION
In cases where the body getSize() returns null and no length has been provided via header, no content will be sent due to ceil(null / $chunkSize) == 0. This affects custom body objects as would be used to stream data in cases where waiting for the body to be complete would be prohibitively expensive and no size can be determined in advance, for example the results of "tail -0f /var/log/messages | head" or "du -sk /home/*".

This fixes the issue by doing the loop without chunk counting if the size is not known.
