### PR TITLE
Added support for http.cats

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -91,8 +91,10 @@ class Error
     {
         $title = 'Slim Application Error';
 
+        $html = '<p><img src="https://http.cat/500" alt="500 Internal Server Error" /></p>';
+
         if ($this->displayErrorDetails) {
-            $html = '<p>The application could not run because of the following error:</p>';
+            $html .= '<p>The application could not run because of the following error:</p>';
             $html .= '<h2>Details</h2>';
             $html .= $this->renderHtmlException($exception);
 
@@ -101,7 +103,7 @@ class Error
                 $html .= $this->renderHtmlException($exception);
             }
         } else {
-            $html = '<p>A website error has occurred. Sorry for the temporary inconvenience.</p>';
+            $html .= '<p>A website error has occurred. Sorry for the temporary inconvenience.</p>';
         }
 
         $output = sprintf(

--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -163,6 +163,7 @@ class NotAllowed
     </head>
     <body>
         <h1>Method not allowed</h1>
+        <p><img src="https://http.cat/405" alt="405 Method Not Allowed" /></p>
         <p>Method not allowed. Must be one of: <strong>$allow</strong></p>
     </body>
 </html>

--- a/Slim/Handlers/NotFound.php
+++ b/Slim/Handlers/NotFound.php
@@ -144,6 +144,7 @@ class NotFound
     </head>
     <body>
         <h1>Page Not Found</h1>
+        <p><img src="https://http.cat/404" alt="404 Not Found" /></p>
         <p>
             The page you are looking for could not be found. Check the address bar
             to ensure your URL is spelled correctly. If all else fails, you can


### PR DESCRIPTION
HTTP error messages and codes can be very confusing. Thankfully an [awesome service](https://http.cat/) is available to help make these codes clearer and more understandable.

I've modified the error handlers to integrate this service into the error pages. Screen captures included below.

![404](https://res.cloudinary.com/radiophp/image/upload/v1454083519/Slim404_yr9sze.png)
![500](https://res.cloudinary.com/radiophp/image/upload/v1454083518/Slim500_yyd4s2.png)
![405](https://res.cloudinary.com/radiophp/image/upload/v1454083516/Slim405_u7jjjl.png)
