### PR TITLE
Configurable FastRoute Caching

### DIFF
--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -56,6 +56,8 @@ class Container extends PimpleContainer implements ContainerInterface
         'outputBuffering' => 'append',
         'determineRouteBeforeAppMiddleware' => false,
         'displayErrorDetails' => false,
+        'routerCacheDisabled' => true,
+        'routerCacheFile' => '',
     ];
 
     /**
@@ -94,7 +96,7 @@ class Container extends PimpleContainer implements ContainerInterface
         $this['settings'] = function () use ($userSettings, $defaultSettings) {
             return new Collection(array_merge($defaultSettings, $userSettings));
         };
-        
+
         $defaultProvider = new DefaultServicesProvider();
         $defaultProvider->register($this);
     }

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -161,7 +161,9 @@ class Container extends PimpleContainer implements ContainerInterface
                 if ($this['settings']['routerCacheDisabled']) {
                     return new Router;
                 } else {
-                    return (new Router)->setCacheFilePath($this['settings']['routerCacheFile']);
+                    return (new Router)
+                        ->setCacheDisabled(false)
+                        ->setCacheFile($this['settings']['routerCacheFile']);
                 }
             };
         }

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -68,6 +68,8 @@ class Container extends PimpleContainer implements ContainerInterface
         'outputBuffering' => 'append',
         'determineRouteBeforeAppMiddleware' => false,
         'displayErrorDetails' => false,
+        'routerCacheDisabled' => true,
+        'routerCacheFile' => '',
     ];
 
     /**
@@ -156,7 +158,11 @@ class Container extends PimpleContainer implements ContainerInterface
              * @return RouterInterface
              */
             $this['router'] = function () {
-                return new Router;
+                if ($this['settings']['routerCacheDisabled']) {
+                    return new Router;
+                } else {
+                    return (new Router)->setCacheFilePath($this['settings']['routerCacheFile']);
+                }
             };
         }
 

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -155,15 +155,19 @@ class Container extends PimpleContainer implements ContainerInterface
              * This service MUST return a SHARED instance
              * of \Slim\Interfaces\RouterInterface.
              *
+             * @param Container $c
+             *
              * @return RouterInterface
              */
-            $this['router'] = function () {
-                if ($this['settings']['routerCacheDisabled']) {
+            $this['router'] = function ($c) {
+                if (is_null($c->get('settings')['routerCacheDisabled'])
+                    || $c->get('settings')['routerCacheDisabled']
+                ) {
                     return new Router;
                 } else {
                     return (new Router)
                         ->setCacheDisabled(false)
-                        ->setCacheFile($this['settings']['routerCacheFile']);
+                        ->setCacheFile($c->get('settings')['routerCacheFile']);
                 }
             };
         }

--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -83,10 +83,20 @@ class DefaultServicesProvider
              * This service MUST return a SHARED instance
              * of \Slim\Interfaces\RouterInterface.
              *
+             * @param Container $container
+             *
              * @return RouterInterface
              */
-            $container['router'] = function () {
-                return new Router;
+            $container['router'] = function ($container) {
+                if (is_null($container->get('settings')['routerCacheDisabled'])
+                    || $container->get('settings')['routerCacheDisabled']
+                ) {
+                    return new Router;
+                } else {
+                    return (new Router)
+                        ->setCacheDisabled(false)
+                        ->setCacheFile($container->get('settings')['routerCacheFile']);
+                }
             };
         }
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -45,11 +45,18 @@ class Router implements RouterInterface
     protected $basePath = '';
 
     /**
+     * Fast route cache is disabled
+     *
+     * @var bool
+     */
+    protected $cacheDisabled = true;
+
+    /**
      * Path to fast route cache file
      *
      * @var string
      */
-    protected $cacheFilePath;
+    protected $cacheFile;
 
     /**
      * Routes
@@ -112,23 +119,37 @@ class Router implements RouterInterface
     }
 
     /**
-     * Set path to fast route cache file
+     * Enable/disable route cache
      *
-     * @param string $cacheFilePath
+     * @param bool $cacheDisabled
      *
      * @return self
      */
-    public function setCacheFilePath($cacheFilePath)
+    public function setCacheDisabled($cacheDisabled)
     {
-        if (!is_string($cacheFilePath)) {
-            throw new InvalidArgumentException('Router cacheFilePath must be a string');
+        $this->cacheDisabled = $cacheDisabled;
+
+        return $this;
+    }
+
+    /**
+     * Set path to fast route cache file
+     *
+     * @param string $cacheFile
+     *
+     * @return self
+     */
+    public function setCacheFile($cacheFile)
+    {
+        if (!is_string($cacheFile)) {
+            throw new InvalidArgumentException('Router cacheFile must be a string');
         }
 
-        if (!is_writable(dirname($cacheFilePath))) {
-            throw new RuntimeException('Router cacheFilePath directory must be writable');
+        if (!is_writable(dirname($cacheFile))) {
+            throw new RuntimeException('Router cacheFile directory must be writable');
         }
 
-        $this->cacheFilePath = $cacheFilePath;
+        $this->cacheFile = $cacheFile;
 
         return $this;
     }
@@ -190,8 +211,12 @@ class Router implements RouterInterface
      */
     protected function createDispatcher()
     {
+        if (!$this->cacheDisabled && is_null($this->cacheFile)) {
+            throw new RuntimeException('Router cache enabled but cacheFile not set');
+        }
+
         return $this->dispatcher ?: call_user_func_array(
-            '\FastRoute\\' . (isset($this->cacheFilePath) ? 'cachedDispatcher' : 'simpleDispatcher'),
+            '\FastRoute\\' . (!$this->cacheDisabled ? 'cachedDispatcher' : 'simpleDispatcher'),
             [
                 function (RouteCollector $routeCollector) {
                     foreach ($this->getRoutes() as $route) {
@@ -204,8 +229,8 @@ class Router implements RouterInterface
                 },
                 [
                     'routeParser' => $this->routeParser,
-                    'cacheFile' => $this->cacheFilePath,
-                    'cacheDisabled' => !isset($this->cacheFilePath),
+                    'cacheFile' => $this->cacheFile,
+                    'cacheDisabled' => $this->cacheDisabled,
                 ],
             ]
         );

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -112,41 +112,55 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Get cacheFilePath protected property from Route instance
+     * Get cacheDisabled protected property from Route instance
      *
      * @return string
      */
-    protected function getRouteCacheFilePath()
+    protected function getRouteCacheDisabled()
     {
         $router = $this->container['router'];
-        $getCacheFilePath = function ($router) {
-            return $router->cacheFilePath;
+        $getCacheDisabled = function ($router) {
+            return $router->cacheDisabled;
         };
-        $getCacheFilePath = \Closure::bind(
-            $getCacheFilePath,
-            null,
-            $this->container['router']
-        );
-
-        return $getCacheFilePath($router);
+        $getCacheDisabled = \Closure::bind($getCacheDisabled, null, $this->container['router']);
+        return $getCacheDisabled($router);
     }
 
     /**
-     * Test no cache path is set to Route when option is disabled from config
+     * Get cacheFile protected property from Route instance
+     *
+     * @return string
      */
-    public function testRouteCachePathNotSetWhenCacheDisabled()
+    protected function getRouteCacheFile()
+    {
+        $router = $this->container['router'];
+        $getCacheFile = function ($router) {
+            return $router->cacheFile;
+        };
+        $getCacheFile = \Closure::bind($getCacheFile, null, $this->container['router']);
+        return $getCacheFile($router);
+    }
+
+    /**
+     * Test that cache is not enabled and no cache file is set to Router
+     * when option is disabled from config
+     */
+    public function testRouteCacheFileNotSetWhenCacheDisabled()
     {
         $this->container->get('settings')['routerCacheDisabled'] = true;
-        $this->assertNull($this->getRouteCacheFilePath());
+        $this->assertTrue($this->getRouteCacheDisabled());
+        $this->assertNull($this->getRouteCacheFile());
     }
 
     /**
-     * Test cache path is set to Route when cache is enabled in config
+     * Test that cache is enabled and cache file is set to Router
+     * when option is enabled from config
      */
-    public function testRouteCachePathSetWhenCacheEnabled()
+    public function testRouteCacheSetWhenCacheEnabled()
     {
         $this->container->get('settings')['routerCacheDisabled'] = false;
         $this->container->get('settings')['routerCacheFile'] = 'slim';
-        $this->assertEquals('slim', $this->getRouteCacheFilePath());
+        $this->assertFalse($this->getRouteCacheDisabled());
+        $this->assertEquals('slim', $this->getRouteCacheFile());
     }
 }

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -105,4 +105,48 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->container->get('settings')['httpVersion'] = '1.2';
         $this->assertSame('1.2', $this->container->__get('settings')['httpVersion']);
     }
+
+    public function testRouteCacheDisabledByDefault()
+    {
+        $this->assertTrue($this->container->get('settings')['routerCacheDisabled']);
+    }
+
+    /**
+     * Get cacheFilePath protected property from Route instance
+     *
+     * @return string
+     */
+    protected function getRouteCacheFilePath()
+    {
+        $router = $this->container['router'];
+        $getCacheFilePath = function ($router) {
+            return $router->cacheFilePath;
+        };
+        $getCacheFilePath = \Closure::bind(
+            $getCacheFilePath,
+            null,
+            $this->container['router']
+        );
+
+        return $getCacheFilePath($router);
+    }
+
+    /**
+     * Test no cache path is set to Route when option is disabled from config
+     */
+    public function testRouteCachePathNotSetWhenCacheDisabled()
+    {
+        $this->container->get('settings')['routerCacheDisabled'] = true;
+        $this->assertNull($this->getRouteCacheFilePath());
+    }
+
+    /**
+     * Test cache path is set to Route when cache is enabled in config
+     */
+    public function testRouteCachePathSetWhenCacheEnabled()
+    {
+        $this->container->get('settings')['routerCacheDisabled'] = false;
+        $this->container->get('settings')['routerCacheFile'] = 'slim';
+        $this->assertEquals('slim', $this->getRouteCacheFilePath());
+    }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -223,30 +223,48 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test cacheFilePath should be a string
+     * Test cacheFile should be a string
      */
-    public function testSettingInvalidCacheFilePathNotString()
+    public function testSettingInvalidCacheFileNotString()
     {
         $this->setExpectedException(
             '\InvalidArgumentException',
-            'Router cacheFilePath must be a string'
+            'Router cacheFile must be a string'
         );
-        $this->router->setCacheFilePath(['invalid']);
+        $this->router->setCacheFile(['invalid']);
     }
 
     /**
-     * Test if cacheFilePath is not a writable directory
+     * Test if cacheFile is not a writable directory
      */
-    public function testSettingInvalidCacheFilePathNotExisting()
+    public function testSettingInvalidCacheFileNotExisting()
     {
         $this->setExpectedException(
             '\RuntimeException',
-            'Router cacheFilePath directory must be writable'
+            'Router cacheFile directory must be writable'
         );
 
-        $this->router->setCacheFilePath(
+        $this->router->setCacheFile(
             dirname(__FILE__) . uniqid(microtime(true)) . '/' . uniqid(microtime(true))
         );
+    }
+
+    /**
+     * Test if cache is enabled but cache file is not set
+     */
+    public function testCacheFileNotSetButCacheEnabled()
+    {
+        $this->setExpectedException(
+            '\RuntimeException',
+            'Router cache enabled but cacheFile not set'
+        );
+
+        $this->router->setCacheDisabled(false);
+
+        $class = new \ReflectionClass($this->router);
+        $method = $class->getMethod('createDispatcher');
+        $method->setAccessible(true);
+        $method->invoke($this->router);
     }
 
     /**
@@ -255,7 +273,8 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     public function testCreateDispatcherWithRouteCache()
     {
         $cacheFile = dirname(__FILE__) . '/' . uniqid(microtime(true));
-        $this->router->setCacheFilePath($cacheFile);
+        $this->router->setCacheDisabled(false);
+        $this->router->setCacheFile($cacheFile);
         $class = new \ReflectionClass($this->router);
         $method = $class->getMethod('createDispatcher');
         $method->setAccessible(true);

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -86,7 +86,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             $this->router->relativePathFor('foo', ['first' => 'josh', 'last' => 'lockhart'])
         );
     }
-    
+
     public function testPathForWithNoBasePath()
     {
         $this->router->setBasePath('');
@@ -104,7 +104,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             $this->router->pathFor('foo', ['first' => 'josh', 'last' => 'lockhart'])
         );
     }
-    
+
     public function testPathForWithBasePath()
     {
         $methods = ['GET'];
@@ -220,5 +220,46 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $prop = $class->getProperty('dispatcher');
         $prop->setAccessible(true);
         $this->assertInstanceOf('\FastRoute\Dispatcher', $prop->getValue($this->router));
+    }
+
+    /**
+     * Test cacheFilePath should be a string
+     */
+    public function testSettingInvalidCacheFilePathNotString()
+    {
+        $this->setExpectedException(
+            '\InvalidArgumentException',
+            'Router cacheFilePath must be a string'
+        );
+        $this->router->setCacheFilePath(['invalid']);
+    }
+
+    /**
+     * Test if cacheFilePath is not a writable directory
+     */
+    public function testSettingInvalidCacheFilePathNotExisting()
+    {
+        $this->setExpectedException(
+            '\RuntimeException',
+            'Router cacheFilePath directory must be writable'
+        );
+
+        $this->router->setCacheFilePath(
+            dirname(__FILE__) . uniqid(microtime(true)) . '/' . uniqid(microtime(true))
+        );
+    }
+
+    /**
+     * Test route dispatcher is created in case of route cache
+     */
+    public function testCreateDispatcherWithRouteCache()
+    {
+        $cacheFile = dirname(__FILE__) . '/' . uniqid(microtime(true));
+        $this->router->setCacheFilePath($cacheFile);
+        $class = new \ReflectionClass($this->router);
+        $method = $class->getMethod('createDispatcher');
+        $method->setAccessible(true);
+        $this->assertInstanceOf('\FastRoute\Dispatcher', $method->invoke($this->router));
+        unlink($cacheFile);
     }
 }


### PR DESCRIPTION
Enabling FastRoute cache can be made.

There are 2 new parameters in main settings that are with same meaning like FastRoute cache aprameters, but prefixed with 'router':
- routerCacheDisabled - turn on/off route cache (true|false)
- routerCacheFile - file path to be cached (string - file path with writeable directory)

Cache is disabled by default
