### PR TITLE
Add appendFormDataMediaType for custom Content-type control with parsing form data

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -77,6 +77,22 @@ class Request
     public $cookies;
 
     /**
+     * Add custom form data media type
+     * @param string $formDataMediaType
+     */
+    public static function appendFormDataMediaType($formDataMediaType)
+    {
+        $result = false;
+        
+        if (($formDataMediaType != '') && !in_array($formDataMediaType, self::$formDataMediaTypes)) {
+            self::$formDataMediaTypes[] = $formDataMediaType;
+            $result = true;
+        }
+        
+        return $result;
+    }
+    
+    /**
      * Constructor
      * @param \Slim\Environment $env
      */


### PR DESCRIPTION
Example.

Somewhere after app initialisation, but before any declaration of hooks and routing:

```
\Slim\Http\Request::appendFormDataMediaType('application/json');
```

And right after you can use content-type matching in the "slim.before" hook:

```
$app->hook('slim.before', function () use ($app)
{
  ...
    // Check content type
  $contentType = $app->request()->getMediaType();
  if ($contentType != 'application/json')
  {
    $app->response()->headers->set('X-Reason', 'Unsupported content type, only "application/json"  allowed');
    $app->halt(415);
  }
});
```

Consider your webapp uses logic like this one:

```
$ curl -XPOST http://someapi/ --header "X-API-Version: 1.234" --header "X-API-key: someapikey" --header "Content-type: application/json" --data "a=b&c=d"
```

If you don't append your custom content type string to static array  \Slim\Http\Request::$formDataMediaTypes, then no form data will be parsed if you used a code like this one (somewhere in route functions):

```
...
$paramA = $app->request()->params('a');
$paramC = $app->request()->params('c');
...
```

I hope this piece of code will be useful in case of custom content type handling and saving form data parsing behaviour.

Thanks.
