### PR TITLE
Write to the error log if displayErrorDetails is false

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -117,30 +117,29 @@ class Error
      */
     protected function renderTextException(Exception $exception)
     {
-        $html = sprintf('Type: %s' . PHP_EOL, get_class($exception));
+        $text = sprintf('Type: %s' . PHP_EOL, get_class($exception));
 
         if (($code = $exception->getCode())) {
-            $html .= sprintf('Code: %s' . PHP_EOL, $code);
+            $text .= sprintf('Code: %s' . PHP_EOL, $code);
         }
 
         if (($message = $exception->getMessage())) {
-            $html .= sprintf('Message: %s' . PHP_EOL, htmlentities($message));
+            $text .= sprintf('Message: %s' . PHP_EOL, htmlentities($message));
         }
 
         if (($file = $exception->getFile())) {
-            $html .= sprintf('File: %s' . PHP_EOL, $file);
+            $text .= sprintf('File: %s' . PHP_EOL, $file);
         }
 
         if (($line = $exception->getLine())) {
-            $html .= sprintf('Line: %s' . PHP_EOL, $line);
+            $text .= sprintf('Line: %s' . PHP_EOL, $line);
         }
 
         if (($trace = $exception->getTraceAsString())) {
-            $html .= 'Trace: ';
-            $html .= sprintf('%s', $trace);
+            $text .= sprintf('Trace: %s', $trace);
         }
 
-        return $html;
+        return $text;
     }
 
     /**

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -26,6 +26,17 @@ use Slim\Tests\Mocks\MockAction;
 
 class AppTest extends \PHPUnit_Framework_TestCase
 {
+    public static function setupBeforeClass()
+    {
+        // ini_set('log_errors', 0);
+        ini_set('error_log', tempnam(sys_get_temp_dir(), 'slim'));
+    }
+
+    public static function tearDownAfterClass()
+    {
+        // ini_set('log_errors', 1);
+    }
+
     public function testContainerInterfaceException()
     {
         $this->setExpectedException('InvalidArgumentException', 'Expected a ContainerInterface');


### PR DESCRIPTION
When displayErrorDetails is false, then the developer doesn't get any information on the exception. Add this information to the error log so that they can find it.

Closes #1761 
