### PR TITLE
Compound services before Pimple container creation

### DIFF
--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -8,9 +8,9 @@
  */
 namespace Slim;
 
+use Interop\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Slim\Exception\ContainerValueNotFoundException;
 use Slim\Handlers\Error;
 use Slim\Handlers\NotFound;
 use Slim\Handlers\NotAllowed;
@@ -30,146 +30,72 @@ use Slim\Interfaces\RouterInterface;
 class DefaultServicesProvider
 {
     /**
-     * Register Slim's default services.
+     * Default settings
      *
-     * @param Container $container A DI container implementing ArrayAccess and container-interop.
+     * @var array
      */
-    public function register($container)
+    protected static $defaultSettings = [
+        'httpVersion' => '1.1',
+        'responseChunkSize' => 4096,
+        'outputBuffering' => 'append',
+        'determineRouteBeforeAppMiddleware' => false,
+        'displayErrorDetails' => false,
+    ];
+
+    /**
+     * Get Slim's default services.
+     *
+     * @param array $userSettings Associative array of application settings
+     *
+     * @return Callable[]
+     */
+    public static function getDefaultServices(array $userSettings = [])
     {
-        if (!isset($container['environment'])) {
-            /**
-             * This service MUST return a shared instance
-             * of \Slim\Interfaces\Http\EnvironmentInterface.
-             *
-             * @return EnvironmentInterface
-             */
-            $container['environment'] = function () {
+        $defaultSettings = self::$defaultSettings;
+
+        return [
+            'settings' => function () use ($defaultSettings, $userSettings) {
+                return new Collection(array_merge($defaultSettings, $userSettings));
+            },
+
+            'environment' => function () {
                 return new Environment($_SERVER);
-            };
-        }
+            },
 
-        if (!isset($container['request'])) {
-            /**
-             * PSR-7 Request object
-             *
-             * @param Container $container
-             *
-             * @return ServerRequestInterface
-             */
-            $container['request'] = function ($container) {
+            'request' => function (ContainerInterface $container) {
                 return Request::createFromEnvironment($container->get('environment'));
-            };
-        }
+            },
 
-        if (!isset($container['response'])) {
-            /**
-             * PSR-7 Response object
-             *
-             * @param Container $container
-             *
-             * @return ResponseInterface
-             */
-            $container['response'] = function ($container) {
-                $headers = new Headers(['Content-Type' => 'text/html; charset=UTF-8']);
+            'response' => function (ContainerInterface $container) {
+                $headers = new Headers(['Content-Type' => 'text/html; charset=utf-8']);
                 $response = new Response(200, $headers);
 
                 return $response->withProtocolVersion($container->get('settings')['httpVersion']);
-            };
-        }
+            },
 
-        if (!isset($container['router'])) {
-            /**
-             * This service MUST return a SHARED instance
-             * of \Slim\Interfaces\RouterInterface.
-             *
-             * @return RouterInterface
-             */
-            $container['router'] = function () {
+            'router' => function () {
                 return new Router;
-            };
-        }
+            },
 
-        if (!isset($container['foundHandler'])) {
-            /**
-             * This service MUST return a SHARED instance
-             * of \Slim\Interfaces\InvocationStrategyInterface.
-             *
-             * @return InvocationStrategyInterface
-             */
-            $container['foundHandler'] = function () {
+            'foundHandler' => function () {
                 return new RequestResponse;
-            };
-        }
+            },
 
-        if (!isset($container['errorHandler'])) {
-            /**
-             * This service MUST return a callable
-             * that accepts three arguments:
-             *
-             * 1. Instance of \Psr\Http\Message\ServerRequestInterface
-             * 2. Instance of \Psr\Http\Message\ResponseInterface
-             * 3. Instance of \Exception
-             *
-             * The callable MUST return an instance of
-             * \Psr\Http\Message\ResponseInterface.
-             *
-             * @param Container $container
-             *
-             * @return callable
-             */
-            $container['errorHandler'] = function ($container) {
+            'errorHandler' => function (ContainerInterface $container) {
                 return new Error($container->get('settings')['displayErrorDetails']);
-            };
-        }
+            },
 
-        if (!isset($container['notFoundHandler'])) {
-            /**
-             * This service MUST return a callable
-             * that accepts two arguments:
-             *
-             * 1. Instance of \Psr\Http\Message\ServerRequestInterface
-             * 2. Instance of \Psr\Http\Message\ResponseInterface
-             *
-             * The callable MUST return an instance of
-             * \Psr\Http\Message\ResponseInterface.
-             *
-             * @return callable
-             */
-            $container['notFoundHandler'] = function () {
+            'notFoundHandler' => function () {
                 return new NotFound;
-            };
-        }
+            },
 
-        if (!isset($container['notAllowedHandler'])) {
-            /**
-             * This service MUST return a callable
-             * that accepts three arguments:
-             *
-             * 1. Instance of \Psr\Http\Message\ServerRequestInterface
-             * 2. Instance of \Psr\Http\Message\ResponseInterface
-             * 3. Array of allowed HTTP methods
-             *
-             * The callable MUST return an instance of
-             * \Psr\Http\Message\ResponseInterface.
-             *
-             * @return callable
-             */
-            $container['notAllowedHandler'] = function () {
+            'notAllowedHandler' => function () {
                 return new NotAllowed;
-            };
-        }
+            },
 
-        if (!isset($container['callableResolver'])) {
-            /**
-             * Instance of \Slim\Interfaces\CallableResolverInterface
-             *
-             * @param Container $container
-             *
-             * @return CallableResolverInterface
-             */
-            $container['callableResolver'] = function ($container) {
+            'callableResolver' => function (ContainerInterface $container) {
                 return new CallableResolver($container);
-            };
-        }
+            },
+        ];
     }
 }

--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -9,8 +9,6 @@
 namespace Slim;
 
 use Interop\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Slim\Handlers\Error;
 use Slim\Handlers\NotFound;
 use Slim\Handlers\NotAllowed;
@@ -19,10 +17,6 @@ use Slim\Http\Environment;
 use Slim\Http\Headers;
 use Slim\Http\Request;
 use Slim\Http\Response;
-use Slim\Interfaces\CallableResolverInterface;
-use Slim\Interfaces\Http\EnvironmentInterface;
-use Slim\Interfaces\InvocationStrategyInterface;
-use Slim\Interfaces\RouterInterface;
 
 /**
  * Slim's default Service Provider.


### PR DESCRIPTION
Compound default services and those provided to container creation before adding them to Pimple container __construct

Avoids the need to continuously verify for service existence by defining them in advance
