### PR TITLE
add missed class property (issue #1758)

### DIFF
--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -29,7 +29,6 @@ class UploadedFile implements UploadedFileInterface
      * @var string
      */
     protected $file;
-
     /**
      * The client-provided file name.
      *

--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -24,6 +24,13 @@ use Psr\Http\Message\UploadedFileInterface;
 class UploadedFile implements UploadedFileInterface
 {
     /**
+     * The client-provided full path to the file
+     *
+     * @var string
+     */
+    protected $file;
+
+    /**
      * The client-provided file name.
      *
      * @var string


### PR DESCRIPTION
as @geggleto noticed, the UploadedFile class doesn't have **$file** property defined. This property dynamically defined in constructor which is fine but doesn't look clear. 
