### PR TITLE
fix typo in error handler.

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -103,7 +103,7 @@ class Error
             $message .= $this->renderTextException($exception);
         }
 
-        $message .= 'View in rendered output by enabling the "displayErrrorDetails" setting.' . PHP_EOL;
+        $message .= 'View in rendered output by enabling the "displayErrorDetails" setting.' . PHP_EOL;
 
         error_log($message);
     }


### PR DESCRIPTION
s/Errror/Error - there was a typo in "Errror" word in method **writeToErrorLog**
