### PR TITLE
Added dynamic exception handling functionality

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -590,8 +590,15 @@ class App
             // This is a Stop exception and contains the response
             return $e->getResponse();
         } else {
-            // Other exception, use $request and $response params
-            $handler = 'errorHandler';
+            // Determine if a handler is defined for the exception
+            $handlers = $this->container->get('settings')['handlers'];
+            if (in_array(get_class($e, $handlers))
+            {
+              $handler = $settings['handlers'][get_class($e)];
+            } else {
+              // Other exception, use $request and $response params
+              $handler = 'errorHandler';
+            }
             $params = [$request, $response, $e];
         }
 

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -592,7 +592,7 @@ class App
         } else {
             // Determine if a handler is defined for the exception
             $handlers = $this->container->get('settings')['handlers'];
-            if (in_array(get_class($e, $handlers))
+            if (in_array(get_class($e), $handlers)
             {
               $handler = $settings['handlers'][get_class($e)];
             } else {


### PR DESCRIPTION
This change enables developers to develop error handlers for every time of exception they want.
In the settings they add handlers in the form "ExceptionType" => "handler".
Example, I use Eloquent ORM and i want to handle the ModelNotFoundException: 

```
<?php
return [
    'settings' => [
        'displayErrorDetails' => true,

        // Renderer settings
        'renderer' => [
            'template_path' => __DIR__ . '/../templates/',
        ],

        // Monolog settings
        'logger' => [
            'name' => 'slim-app',
            'path' => __DIR__ . '/../logs/app.log',
        ],
        // Custom Error Handlers
        'handlers' => [
            'ModelNotFoundException' => 'modelNotFoundHandler',
         ],
```

Then the developer injects the custom errorhandler like describer in the Slim Docs: http://www.slimframework.com/docs/handlers/error.html
