### PR TITLE
Deprecate Request and Response in Container

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -659,16 +659,14 @@ class App
 
             // register our new environment with the container for BC
             if ($this->container instanceof \ArrayAccess) {
-                if (!$this->container->has('environment')) {
-                    $container['environment'] = function () use ($environment) {
-                        trigger_error(
-                            'Retrieving the environment from the container is deprecated; '
-                            . 'update your code to use the one within the Request object.',
-                            E_USER_DEPRECATED
-                        );
-                        return $environment;
-                    };
-                }
+                $container['environment'] = function () use ($environment) {
+                    trigger_error(
+                        'Retrieving the environment from the container is deprecated; '
+                        . 'update your code to use the one within the Request object.',
+                        E_USER_DEPRECATED
+                    );
+                    return $environment;
+                };
             }
         }
 

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -498,9 +498,7 @@ class App
         $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
 
         if (!$response) {
-            $headers = new Headers(['Content-Type' => 'text/html; charset=UTF-8']);
-            $response = new Response(200, $headers);
-            $response = $response->withProtocolVersion($this->container->get('settings')['httpVersion']);
+            $response = $this->createResponse();
         }
 
         return $this($request, $response);

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -721,5 +721,7 @@ class App
                 return $response;
             };
         }
+
+        return $response;
     }
 }

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -658,23 +658,26 @@ class App
             $environment = $this->container->get('environment');
         } else {
             $environment = new Environment($_SERVER);
-            // register our new environment with the Container for BC
-            if (!$this->container->has('environment')) {
-                $container['environment'] = function () {
-                    trigger_error(
-                        'Retrieving the environment from the container is deprecated; '
-                        . 'update your code to use the one within the Request object.',
-                        E_USER_DEPRECATED
-                    );
-                    return new Environment($_SERVER);
-                };
+
+            // register our new environment with the container for BC
+            if ($this->container instanceof \ArrayAccess) {
+                if (!$this->container->has('environment')) {
+                    $container['environment'] = function () {
+                        trigger_error(
+                            'Retrieving the environment from the container is deprecated; '
+                            . 'update your code to use the one within the Request object.',
+                            E_USER_DEPRECATED
+                        );
+                        return new Environment($_SERVER);
+                    };
+                }
             }
         }
 
         $request = Request::createFromEnvironment($environment);
 
+        // register our new request with the container for BC
         if ($this->container instanceof \ArrayAccess) {
-
             $container['request'] = function ($container) {
                 trigger_error(
                     'Retrieving the request from the container is deprecated; '
@@ -707,8 +710,8 @@ class App
         $response = new Response(200, $headers);
         $response = $response->withProtocolVersion($this->container->get('settings')['httpVersion']);
 
+        // register our new response with the container for BC
         if ($this->container instanceof \ArrayAccess) {
-            // register our new response with the Container for BC
             $container['response'] = function ($container) {
                 trigger_error(
                     'Retrieving the response from the container is deprecated; '

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -662,13 +662,13 @@ class App
             // register our new environment with the container for BC
             if ($this->container instanceof \ArrayAccess) {
                 if (!$this->container->has('environment')) {
-                    $container['environment'] = function () {
+                    $container['environment'] = function () use ($environment) {
                         trigger_error(
                             'Retrieving the environment from the container is deprecated; '
                             . 'update your code to use the one within the Request object.',
                             E_USER_DEPRECATED
                         );
-                        return new Environment($_SERVER);
+                        return $environment;
                     };
                 }
             }
@@ -678,14 +678,14 @@ class App
 
         // register our new request with the container for BC
         if ($this->container instanceof \ArrayAccess) {
-            $container['request'] = function ($container) {
+            $container['request'] = function ($container) use ($request) {
                 trigger_error(
                     'Retrieving the request from the container is deprecated; '
                     . 'update your code to use the Request object that is passed through the middleware. '
                     . 'To use your own Request object, pass it in as the second parameter to run().',
                     E_USER_DEPRECATED
                 );
-                return Request::createFromEnvironment($container->get('environment'));
+                return $request;
             };
         }
 
@@ -712,7 +712,7 @@ class App
 
         // register our new response with the container for BC
         if ($this->container instanceof \ArrayAccess) {
-            $container['response'] = function ($container) {
+            $container['response'] = function ($container) use ($response) {
                 trigger_error(
                     'Retrieving the response from the container is deprecated; '
                     . 'update your code to use the Response object that is passed through the middleware. '
@@ -720,10 +720,7 @@ class App
                     E_USER_DEPRECATED
                 );
 
-                $headers = new Headers(['Content-Type' => 'text/html; charset=UTF-8']);
-                $response = new Response(200, $headers);
-
-                return $response->withProtocolVersion($container->get('settings')['httpVersion']);
+                return $response;
             };
         }
     }

--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -45,6 +45,11 @@ class DefaultServicesProvider
              * @return EnvironmentInterface
              */
             $container['environment'] = function () {
+                trigger_error(
+                    'Retrieving the environment from the container is deprecated; '
+                    . 'update your code to use the one within the Request object.',
+                    E_USER_DEPRECATED
+                );
                 return new Environment($_SERVER);
             };
         }
@@ -58,6 +63,12 @@ class DefaultServicesProvider
              * @return ServerRequestInterface
              */
             $container['request'] = function ($container) {
+                trigger_error(
+                    'Retrieving the request from the container is deprecated; '
+                    . 'update your code to use the Request object that is passed through the middleware. '
+                    . 'To use your own Request object, pass it in as the second parameter to run().',
+                    E_USER_DEPRECATED
+                );
                 return Request::createFromEnvironment($container->get('environment'));
             };
         }
@@ -71,6 +82,13 @@ class DefaultServicesProvider
              * @return ResponseInterface
              */
             $container['response'] = function ($container) {
+                trigger_error(
+                    'Retrieving the response from the container is deprecated; '
+                    . 'update your code to use the Response object that is passed through the middleware. '
+                    . 'To use your own Response object, pass it in as the third parameter to run().',
+                    E_USER_DEPRECATED
+                );
+
                 $headers = new Headers(['Content-Type' => 'text/html; charset=UTF-8']);
                 $response = new Response(200, $headers);
 

--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -37,65 +37,6 @@ class DefaultServicesProvider
      */
     public function register($container)
     {
-        if (!isset($container['environment'])) {
-            /**
-             * This service MUST return a shared instance
-             * of \Slim\Interfaces\Http\EnvironmentInterface.
-             *
-             * @return EnvironmentInterface
-             */
-            $container['environment'] = function () {
-                trigger_error(
-                    'Retrieving the environment from the container is deprecated; '
-                    . 'update your code to use the one within the Request object.',
-                    E_USER_DEPRECATED
-                );
-                return new Environment($_SERVER);
-            };
-        }
-
-        if (!isset($container['request'])) {
-            /**
-             * PSR-7 Request object
-             *
-             * @param Container $container
-             *
-             * @return ServerRequestInterface
-             */
-            $container['request'] = function ($container) {
-                trigger_error(
-                    'Retrieving the request from the container is deprecated; '
-                    . 'update your code to use the Request object that is passed through the middleware. '
-                    . 'To use your own Request object, pass it in as the second parameter to run().',
-                    E_USER_DEPRECATED
-                );
-                return Request::createFromEnvironment($container->get('environment'));
-            };
-        }
-
-        if (!isset($container['response'])) {
-            /**
-             * PSR-7 Response object
-             *
-             * @param Container $container
-             *
-             * @return ResponseInterface
-             */
-            $container['response'] = function ($container) {
-                trigger_error(
-                    'Retrieving the response from the container is deprecated; '
-                    . 'update your code to use the Response object that is passed through the middleware. '
-                    . 'To use your own Response object, pass it in as the third parameter to run().',
-                    E_USER_DEPRECATED
-                );
-
-                $headers = new Headers(['Content-Type' => 'text/html; charset=UTF-8']);
-                $response = new Response(200, $headers);
-
-                return $response->withProtocolVersion($container->get('settings')['httpVersion']);
-            };
-        }
-
         if (!isset($container['router'])) {
             /**
              * This service MUST return a SHARED instance

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -27,7 +27,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGet()
     {
-        $this->assertInstanceOf('\Slim\Http\Environment', $this->container->get('environment'));
+        $this->assertInstanceOf('\Slim\Router', $this->container->get('router'));
     }
 
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -43,22 +43,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test container has request
-     */
-    public function testGetRequest()
-    {
-        @$this->assertInstanceOf('\Psr\Http\Message\RequestInterface', $this->container['request']);
-    }
-
-    /**
-     * Test container has response
-     */
-    public function testGetResponse()
-    {
-        @$this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $this->container['response']);
-    }
-
-    /**
      * Test container has router
      */
     public function testGetRouter()

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -47,7 +47,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetRequest()
     {
-        $this->assertInstanceOf('\Psr\Http\Message\RequestInterface', $this->container['request']);
+        @$this->assertInstanceOf('\Psr\Http\Message\RequestInterface', $this->container['request']);
     }
 
     /**
@@ -55,7 +55,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetResponse()
     {
-        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $this->container['response']);
+        @$this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $this->container['response']);
     }
 
     /**


### PR DESCRIPTION
This PR adds deprecation notices when you retrieve the Request, Response or Environment from the Container. It's very confusing to have these in the Container as they are "stale" and should never be used.

It updates `App::run()` so that it no longer uses the container for these objects, but instead creates them itself. I've also updated `run()`'s signature so that you can now pass in a request and a response object if you want to use your own.

Similarly, I've updated `App::subRequest` to create it's own Environment and Response objects.

Would appreciate people's thoughts on this.
