### PR TITLE
Support structured suffix body parsers (+json/+xml)

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -967,9 +967,15 @@ class Request extends Message implements ServerRequestInterface
         }
 
         $mediaType = $this->getMediaType();
-        $body = (string)$this->getBody();
+
+        // look for a media type with a structured syntax suffix (RFC 6839)
+        $parts = explode('+', $mediaType);
+        if (count($parts) >= 2) {
+            $mediaType = 'application/' . $parts[count($parts)-1];
+        }
 
         if (isset($this->bodyParsers[$mediaType]) === true) {
+            $body = (string)$this->getBody();
             $parsed = $this->bodyParsers[$mediaType]($body);
 
             if (!is_null($parsed) && !is_object($parsed) && !is_array($parsed)) {

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -722,12 +722,42 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'bar'], $request->getParsedBody());
     }
 
+    public function testGetParsedBodyWithJsonStructuredSuffix()
+    {
+        $method = 'GET';
+        $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
+        $headers = new Headers();
+        $headers->set('Content-Type', 'application/vnd.api+json;charset=utf8');
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('{"foo":"bar"}');
+        $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
+
+        $this->assertEquals(['foo' => 'bar'], $request->getParsedBody());
+    }
+
     public function testGetParsedBodyXml()
     {
         $method = 'GET';
         $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
         $headers = new Headers();
         $headers->set('Content-Type', 'application/xml;charset=utf8');
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('<person><name>Josh</name></person>');
+        $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
+
+        $this->assertEquals('Josh', $request->getParsedBody()->name);
+    }
+
+    public function testGetParsedBodyWithXmlStructuredSuffix()
+    {
+        $method = 'GET';
+        $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
+        $headers = new Headers();
+        $headers->set('Content-Type', 'application/hal+xml;charset=utf8');
         $cookies = [];
         $serverParams = [];
         $body = new RequestBody();


### PR DESCRIPTION
Add body parsers for structured syntax suffixes (RFC 6839) - that is, media types with the format {anything}+json and {anything}+xml

This is a more generic solution to that addressed in https://github.com/slimphp/Slim/pull/1779. 

We'll have to sort out the error handlers in a separate PR.
