### PR TITLE
Support +json & +xml accept headers when creating error responses

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -295,6 +295,14 @@ class Error
             return $selectedContentTypes[0];
         }
 
+        // handle +json and +xml specially
+        if (preg_match('/\+(json|xml)/', $acceptHeader, $matches)) {
+            $mediaType = 'application/' . $matches[1];
+            if (in_array($mediaType, $this->knownContentTypes)) {
+                return $mediaType;
+            }
+        }
+
         return 'text/html';
     }
 }

--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -92,6 +92,14 @@ class NotAllowed
             return $selectedContentTypes[0];
         }
 
+        // handle +json and +xml specially
+        if (preg_match('/\+(json|xml)/', $acceptHeader, $matches)) {
+            $mediaType = 'application/' . $matches[1];
+            if (in_array($mediaType, $this->knownContentTypes)) {
+                return $mediaType;
+            }
+        }
+
         return 'text/html';
     }
 

--- a/Slim/Handlers/NotFound.php
+++ b/Slim/Handlers/NotFound.php
@@ -80,6 +80,14 @@ class NotFound
             return $selectedContentTypes[0];
         }
 
+        // handle +json and +xml specially
+        if (preg_match('/\+(json|xml)/', $acceptHeader, $matches)) {
+            $mediaType = 'application/' . $matches[1];
+            if (in_array($mediaType, $this->knownContentTypes)) {
+                return $mediaType;
+            }
+        }
+
         return 'text/html';
     }
 

--- a/tests/Handlers/ErrorTest.php
+++ b/tests/Handlers/ErrorTest.php
@@ -16,10 +16,12 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
     public function errorProvider()
     {
         return [
-            ['application/json', '{'],
-            ['application/xml', '<error>'],
-            ['text/xml', '<error>'],
-            ['text/html', '<html>'],
+            ['application/json', 'application/json', '{'],
+            ['application/vnd.api+json', 'application/json', '{'],
+            ['application/xml', 'application/xml', '<error>'],
+            ['application/hal+xml', 'application/xml', '<error>'],
+            ['text/xml', 'text/xml', '<error>'],
+            ['text/html', 'text/html', '<html>'],
         ];
     }
 
@@ -28,13 +30,13 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider errorProvider
      */
-    public function testError($contentType, $startOfBody)
+    public function testError($acceptHeader, $contentType, $startOfBody)
     {
-        $notAllowed = new Error();
-        $e  = new \Exception("Oops");
+        $error = new Error();
+        $e = new \Exception("Oops");
 
         /** @var Response $res */
-        $res = $notAllowed->__invoke($this->getRequest('GET', $contentType), new Response(), $e);
+        $res = $error->__invoke($this->getRequest('GET', $acceptHeader), new Response(), $e);
 
         $this->assertSame(500, $res->getStatusCode());
         $this->assertSame($contentType, $res->getHeaderLine('Content-Type'));
@@ -45,10 +47,10 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
      * @param string $method
      * @return \PHPUnit_Framework_MockObject_MockObject|\Slim\Http\Request
      */
-    protected function getRequest($method, $contentType = 'text/html')
+    protected function getRequest($method, $acceptHeader)
     {
         $req = $this->getMockBuilder('Slim\Http\Request')->disableOriginalConstructor()->getMock();
-        $req->expects($this->once())->method('getHeaderLine')->will($this->returnValue($contentType));
+        $req->expects($this->once())->method('getHeaderLine')->will($this->returnValue($acceptHeader));
 
         return $req;
     }

--- a/tests/Handlers/NotAllowedTest.php
+++ b/tests/Handlers/NotAllowedTest.php
@@ -16,10 +16,12 @@ class NotAllowedTest extends \PHPUnit_Framework_TestCase
     public function invalidMethodProvider()
     {
         return [
-            ['application/json', '{'],
-            ['application/xml', '<root>'],
-            ['text/xml', '<root>'],
-            ['text/html', '<html>'],
+            ['application/json', 'application/json', '{'],
+            ['application/vnd.api+json', 'application/json', '{'],
+            ['application/xml', 'application/xml', '<root>'],
+            ['application/hal+xml', 'application/xml', '<root>'],
+            ['text/xml', 'text/xml', '<root>'],
+            ['text/html', 'text/html', '<html>'],
         ];
     }
 
@@ -28,12 +30,12 @@ class NotAllowedTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider invalidMethodProvider
      */
-    public function testInvalidMethod($contentType, $startOfBody)
+    public function testInvalidMethod($acceptHeader, $contentType, $startOfBody)
     {
         $notAllowed = new NotAllowed();
 
         /** @var Response $res */
-        $res = $notAllowed->__invoke($this->getRequest('GET', $contentType), new Response(), ['POST', 'PUT']);
+        $res = $notAllowed->__invoke($this->getRequest('GET', $acceptHeader), new Response(), ['POST', 'PUT']);
 
         $this->assertSame(405, $res->getStatusCode());
         $this->assertTrue($res->hasHeader('Allow'));

--- a/tests/Handlers/NotFoundTest.php
+++ b/tests/Handlers/NotFoundTest.php
@@ -17,10 +17,12 @@ class NotFoundTest extends \PHPUnit_Framework_TestCase
     public function notFoundProvider()
     {
         return [
-            ['application/json', '{'],
-            ['application/xml', '<root>'],
-            ['text/xml', '<root>'],
-            ['text/html', '<html>'],
+            ['application/json', 'application/json', '{'],
+            ['application/vnd.api+json', 'application/json', '{'],
+            ['application/xml', 'application/xml', '<root>'],
+            ['application/hal+xml', 'application/xml', '<root>'],
+            ['text/xml', 'text/xml', '<root>'],
+            ['text/html', 'text/html', '<html>'],
         ];
     }
 
@@ -29,12 +31,12 @@ class NotFoundTest extends \PHPUnit_Framework_TestCase
      *
      * @dataProvider notFoundProvider
      */
-    public function testNotFound($contentType, $startOfBody)
+    public function testNotFound($acceptHeader, $contentType, $startOfBody)
     {
         $notAllowed = new NotFound();
 
         /** @var Response $res */
-        $res = $notAllowed->__invoke($this->getRequest('GET', $contentType), new Response(), ['POST', 'PUT']);
+        $res = $notAllowed->__invoke($this->getRequest('GET', $acceptHeader), new Response(), ['POST', 'PUT']);
 
         $this->assertSame(404, $res->getStatusCode());
         $this->assertSame($contentType, $res->getHeaderLine('Content-Type'));


### PR DESCRIPTION
Support structured suffix body parsers (+json/+xml) for error handling.

This means that if the request has an Accept header of "application/hal+xml" and an error condition occurs, then the response will have an content type of "application/xml" rather than "text/html" as it is today.

This is the flip side to #1781 
