### PR TITLE
Removed DeferredCallable from route callable

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -235,7 +235,9 @@ class App
      */
     public function map(array $methods, $pattern, $callable)
     {
-        $callable = new DeferredCallable($callable, $this->container);
+        if ($callable instanceof Closure) {
+            $callable = $callable->bindTo($this->container);
+        }
 
         $route = $this->container->get('router')->map($methods, $pattern, $callable);
         if (is_callable([$route, 'setContainer'])) {

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -18,6 +18,8 @@ use Interop\Container\ContainerInterface;
  */
 abstract class Routable
 {
+    use CallableResolverAwareTrait;
+    
     /**
      * Route callable
      *

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -311,6 +311,8 @@ class Route extends Routable implements RouteInterface
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
+        $this->callable = $this->resolveCallable($this->callable);
+
         /** @var InvocationStrategyInterface $handler */
         $handler = isset($this->container) ? $this->container->get('foundHandler') : new RequestResponse();
 

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -18,7 +18,6 @@ use Slim\Interfaces\RouteGroupInterface;
  */
 class RouteGroup extends Routable implements RouteGroupInterface
 {
-    use CallableResolverAwareTrait;
     /**
      * Create a new RouteGroup
      *

--- a/tests/Mocks/InvocationStrategyTest.php
+++ b/tests/Mocks/InvocationStrategyTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2016 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/master/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Mocks;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Interfaces\InvocationStrategyInterface;
+
+class InvocationStrategyTest implements InvocationStrategyInterface
+{
+    public static $LastCalledFor = null;
+
+    /**
+     * Invoke a route callable.
+     *
+     * @param callable $callable The callable to invoke using the strategy.
+     * @param ServerRequestInterface $request The request object.
+     * @param ResponseInterface $response The response object.
+     * @param array $routeArguments The route's placholder arguments
+     *
+     * @return ResponseInterface|string The response from the callable.
+     */
+    public function __invoke(
+        callable $callable,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        array $routeArguments
+    ) {
+        static::$LastCalledFor = $callable;
+
+        return $response;
+    }
+}

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -18,6 +18,7 @@ use Slim\Http\Response;
 use Slim\Http\Uri;
 use Slim\Route;
 use Slim\Tests\Mocks\CallableTest;
+use Slim\Tests\Mocks\InvocationStrategyTest;
 use Slim\Tests\Mocks\MiddlewareStub;
 
 class RouteTest extends \PHPUnit_Framework_TestCase
@@ -128,7 +129,6 @@ class RouteTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(2, $prop->getValue($route));
     }
-
 
 
     public function testIdentifier()
@@ -383,5 +383,29 @@ class RouteTest extends \PHPUnit_Framework_TestCase
 
         $output = ob_get_clean();
         $this->assertEquals('foo', $output);
+    }
+
+    /**
+     * Ensure that `foundHandler` is called on actual callable
+     */
+    public function testInvokeDeferredCallable()
+    {
+        $container = new Container();
+        $container['CallableTest'] = new CallableTest;
+        $container['foundHandler'] = function () {
+            return new InvocationStrategyTest();
+        };
+
+        $route = new Route(['GET'], '/', 'CallableTest:toCall');
+        $route->setContainer($container);
+
+        $uri = Uri::createFromString('https://example.com:80');
+        $body = new Body(fopen('php://temp', 'r+'));
+        $request = new Request('GET', $uri, new Headers(), [], Environment::mock()->all(), $body);
+
+        $result = $route->callMiddlewareStack($request, new Response);
+
+        $this->assertInstanceOf('Slim\Http\Response', $result);
+        $this->assertEquals([$container['CallableTest'], 'toCall'], InvocationStrategyTest::$LastCalledFor);
     }
 }


### PR DESCRIPTION
Fix for https://github.com/slimphp/Slim/issues/1785

Route callable was already lazy resolved before the introduction of DeferredCallable
