### PR TITLE
Make $file public in UploadedFile

### DIFF
--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -26,9 +26,11 @@ class UploadedFile implements UploadedFileInterface
     /**
      * The client-provided full path to the file
      *
+     * @note this is public to maintain BC with 3.1.0 and earlier.
+     *
      * @var string
      */
-    protected $file;
+    public $file;
     /**
      * The client-provided file name.
      *


### PR DESCRIPTION
This property was public prior to 3.1.0, so needs to remain public.

Fixes #1798 
