### PR TITLE
Fix $request->withBody

### DIFF
--- a/Slim/Http/Message.php
+++ b/Slim/Http/Message.php
@@ -290,6 +290,10 @@ abstract class Message implements MessageInterface
         $clone = clone $this;
         $clone->body = $body;
 
+        if (property_exists($clone, 'bodyParsed')) {
+            $clone->bodyParsed = false;
+        }
+
         return $clone;
     }
 }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -772,6 +772,29 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($request->getParsedBody());
     }
 
+    public function testGetParsedBodyAfterWithBody()
+    {
+        $uri = Uri::createFromString('https://example.com:443/?one=1');
+        $headers = new Headers([
+            'Content-Type' => 'application/x-www-form-urlencoded;charset=utf8',
+        ]);
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('foo=bar');
+        $body->rewind();
+        $request = new Request('POST', $uri, $headers, $cookies, $serverParams, $body);
+
+        $this->assertEquals(['foo' => 'bar'], $request->getParsedBody());
+
+        $newBody = new RequestBody();
+        $newBody->write('abc=123');
+        $newBody->rewind();
+        $request = $request->withBody($newBody);
+
+        $this->assertEquals(['abc' => '123'], $request->getParsedBody());
+    }
+
     /**
      * @expectedException \RuntimeException
      */


### PR DESCRIPTION
`$request->withBody` must set `bodyParsed = false` 'cause body will have to be parsed again on `$request->getParsedBody()`

Fix https://github.com/slimphp/Slim/issues/1803
