### PR TITLE
Ensure getParsedBody() return null if body is not parsed

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -978,9 +978,10 @@ class Request extends Message implements ServerRequestInterface
                 );
             }
             $this->bodyParsed = $parsed;
+            return $this->bodyParsed;
         }
 
-        return $this->bodyParsed;
+        return null;
     }
 
     /**

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -20,9 +20,9 @@ use Slim\Http\Uri;
 
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
-    public function requestFactory()
+    public function requestFactory($envData = [])
     {
-        $env = Environment::mock();
+        $env = Environment::mock($envData);
 
         $uri = Uri::createFromString('https://example.com:443/foo/bar?abc=123');
         $headers = Headers::createFromEnvironment($env);
@@ -834,6 +834,24 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $clone = $request->withParsedBody(null);
 
         $this->assertNull($clone->getParsedBody());
+    }
+
+    public function testGetParsedBodyReturnsNullWhenThereIsNoBodyData()
+    {
+        $request = $this->requestFactory(['REQUEST_METHOD' => 'POST']);
+
+        $this->assertNull($request->getParsedBody());
+    }
+
+    public function testGetParsedBodyReturnsNullWhenThereIsNoMediaTypeParserRegistered()
+    {
+        $request = $this->requestFactory([
+            'REQUEST_METHOD' => 'POST',
+            'CONTENT_TYPE' => 'text/csv',
+        ]);
+        $request->getBody()->write('foo,bar,baz');
+
+        $this->assertNull($request->getParsedBody());
     }
 
     /**


### PR DESCRIPTION
PSR-7 states that getParsedBody() must return null, an array or an object. If we can't parse the body as there's no media type parser available, then return null.

Fixes #1807
