### PR TITLE
Create Request::reparseBody

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1025,6 +1025,20 @@ class Request extends Message implements ServerRequestInterface
     }
 
     /**
+     * Force Body to be parsed again.
+     *
+     * Note: This method is not part of the PSR-7 standard.
+     *
+     * @return self
+     */
+    public function reparseBody()
+    {
+        $this->bodyParsed = false;
+
+        return $this;
+    }
+
+    /**
      * Register media type parser.
      *
      * Note: This method is not part of the PSR-7 standard.

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -772,6 +772,30 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($request->getParsedBody());
     }
 
+    public function testGetParsedBodyAfterCallReparseBody()
+    {
+        $uri = Uri::createFromString('https://example.com:443/?one=1');
+        $headers = new Headers([
+            'Content-Type' => 'application/x-www-form-urlencoded;charset=utf8',
+        ]);
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('foo=bar');
+        $body->rewind();
+        $request = new Request('POST', $uri, $headers, $cookies, $serverParams, $body);
+
+        $this->assertEquals(['foo' => 'bar'], $request->getParsedBody());
+
+        $newBody = new RequestBody();
+        $newBody->write('abc=123');
+        $newBody->rewind();
+        $request = $request->withBody($newBody);
+        $request->reparseBody();
+
+        $this->assertEquals(['abc' => '123'], $request->getParsedBody());
+    }
+
     /**
      * @expectedException \RuntimeException
      */


### PR DESCRIPTION
Create `Request::reparseBody` as a fix for #1803 
