### PR TITLE
Handle nested uploaded files correctly

### DIFF
--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -109,6 +109,7 @@ class UploadedFile implements UploadedFileInterface
                 }
                 continue;
             }
+
             $parsed[$field] = [];
             if (!is_array($uploadedFile['error'])) {
                 $parsed[$field] = new static(
@@ -120,15 +121,16 @@ class UploadedFile implements UploadedFileInterface
                     true
                 );
             } else {
+                $subArray = [];
                 foreach ($uploadedFile['error'] as $fileIdx => $error) {
-                    $parsed[$field][] = new static(
-                        $uploadedFile['tmp_name'][$fileIdx],
-                        isset($uploadedFile['name']) ? $uploadedFile['name'][$fileIdx] : null,
-                        isset($uploadedFile['type']) ? $uploadedFile['type'][$fileIdx] : null,
-                        isset($uploadedFile['size']) ? $uploadedFile['size'][$fileIdx] : null,
-                        $uploadedFile['error'][$fileIdx],
-                        true
-                    );
+                    // normalise subarray and re-parse to move the input's keyname up a level
+                    $subArray[$fileIdx]['name'] = $uploadedFile['name'][$fileIdx];
+                    $subArray[$fileIdx]['type'] = $uploadedFile['type'][$fileIdx];
+                    $subArray[$fileIdx]['tmp_name'] = $uploadedFile['tmp_name'][$fileIdx];
+                    $subArray[$fileIdx]['error'] = $uploadedFile['error'][$fileIdx];
+                    $subArray[$fileIdx]['size'] = $uploadedFile['size'][$fileIdx];
+
+                    $parsed[$field] = static::parseUploadedFiles($subArray);
                 }
             }
         }

--- a/tests/Http/UploadedFilesTest.php
+++ b/tests/Http/UploadedFilesTest.php
@@ -223,7 +223,6 @@ class UploadedFilesTest extends \PHPUnit_Framework_TestCase
             ],
             // nested array of files: <input name="files[details][avatar][]" type="file">
             [
-                // $_FILES array
                 [
                     'files' => [
                         'tmp_name' => [

--- a/tests/Http/UploadedFilesTest.php
+++ b/tests/Http/UploadedFilesTest.php
@@ -119,29 +119,53 @@ class UploadedFilesTest extends \PHPUnit_Framework_TestCase
     public function providerCreateFromEnvironment()
     {
         return [
+            // no nest: <input name="avatar" type="file">
             [
+                // $_FILES array
                 [
-                    'files' => [
+                    'avatar' => [
+                        'tmp_name' => 'phpUxcOty',
+                        'name'     => 'my-avatar.png',
+                        'size'     => 90996,
+                        'type'     => 'image/png',
+                        'error'    => 0,
+                    ],
+                ],
+                // expected format of array
+                [
+                    'avatar' => new UploadedFile('phpUxcOty', 'my-avatar.png', 'image/png', 90996, UPLOAD_ERR_OK, true)
+                ]
+            ],
+            // array of files: <input name="avatars[]" type="file">
+            [
+                // $_FILES array
+                [
+                    'avatars' => [
                         'tmp_name' => [
                             0 => __DIR__ . DIRECTORY_SEPARATOR . 'file0.txt',
                             1 => __DIR__ . DIRECTORY_SEPARATOR . 'file1.html',
                         ],
-                        'name'     => [
+                        'name' => [
                             0 => 'file0.txt',
                             1 => 'file1.html',
                         ],
-                        'type'     => [
+                        'type' => [
                             0 => 'text/plain',
                             1 => 'text/html',
                         ],
-                        'error'    => [
+                        'error' => [
+                            0 => 0,
+                            1 => 0
+                        ],
+                        'size' => [
                             0 => 0,
                             1 => 0
                         ]
                     ],
                 ],
+                // expected format of array
                 [
-                    'files' => [
+                    'avatars' => [
                         0 => new UploadedFile(
                             __DIR__ . DIRECTORY_SEPARATOR . 'file0.txt',
                             'file0.txt',
@@ -161,20 +185,115 @@ class UploadedFilesTest extends \PHPUnit_Framework_TestCase
                     ],
                 ]
             ],
+            // single nested file: <input name="details[avatar]" type="file">
             [
+                // $_FILES array
                 [
-                    'avatar' => [
-                        'tmp_name' => 'phpUxcOty',
-                        'name'     => 'my-avatar.png',
-                        'size'     => 90996,
-                        'type'     => 'image/png',
-                        'error'    => 0,
+                    'details' => [
+                        'tmp_name' => [
+                            'avatar' => __DIR__ . DIRECTORY_SEPARATOR . 'file0.txt',
+                        ],
+                        'name' => [
+                            'avatar' => 'file0.txt',
+                        ],
+                        'type' => [
+                            'avatar' => 'text/plain',
+                        ],
+                        'error' => [
+                            'avatar' => 0,
+                        ],
+                        'size' => [
+                            'avatar' => 0,
+                        ],
                     ],
                 ],
+                // expected format of array
                 [
-                    'avatar' => new UploadedFile('phpUxcOty', 'my-avatar.png', 'image/png', 90996, UPLOAD_ERR_OK, true)
+                    'details' => [
+                        'avatar' => new UploadedFile(
+                            __DIR__ . DIRECTORY_SEPARATOR . 'file0.txt',
+                            'file0.txt',
+                            'text/plain',
+                            null,
+                            UPLOAD_ERR_OK,
+                            true
+                        ),
+                    ],
                 ]
-            ]
+            ],
+            // nested array of files: <input name="files[details][avatar][]" type="file">
+            [
+                // $_FILES array
+                [
+                    'files' => [
+                        'tmp_name' => [
+                            'details' => [
+                                'avatar' => [
+                                    0 => __DIR__ . DIRECTORY_SEPARATOR . 'file0.txt',
+                                    1 => __DIR__ . DIRECTORY_SEPARATOR . 'file1.html',
+                                ],
+                            ],
+                        ],
+                        'name' => [
+                            'details' => [
+                                'avatar' => [
+                                    0 => 'file0.txt',
+                                    1 => 'file1.html',
+                                ],
+                            ],
+                        ],
+                        'type' => [
+                            'details' => [
+                                'avatar' => [
+                                    0 => 'text/plain',
+                                    1 => 'text/html',
+                                ],
+                            ],
+                        ],
+                        'error' => [
+                            'details' => [
+                                'avatar' => [
+                                    0 => 0,
+                                    1 => 0
+                                ],
+                            ],
+                        ],
+                        'size' => [
+                            'details' => [
+                                'avatar' => [
+                                    0 => 0,
+                                    1 => 0
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                // expected format of array
+                [
+                    'files' => [
+                        'details' => [
+                            'avatar' => [
+                                0 => new UploadedFile(
+                                    __DIR__ . DIRECTORY_SEPARATOR . 'file0.txt',
+                                    'file0.txt',
+                                    'text/plain',
+                                    null,
+                                    UPLOAD_ERR_OK,
+                                    true
+                                ),
+                                1 => new UploadedFile(
+                                    __DIR__ . DIRECTORY_SEPARATOR . 'file1.html',
+                                    'file1.html',
+                                    'text/html',
+                                    null,
+                                    UPLOAD_ERR_OK,
+                                    true
+                                ),
+                            ],
+                        ],
+                    ],
+                ]
+            ],
         ];
     }
 


### PR DESCRIPTION
The $_FILES array is very weird when you have a nested name of the type:
`<input name="files[details][avatar][]" type="file">` has the structure
is:

```
    [
        'files' => [
            'tmp_name' => [
                'details' => [
                    'avatar' => [
                        0 => __DIR__ . DIRECTORY_SEPARATOR . 'file0.txt',
                        1 => __DIR__ . DIRECTORY_SEPARATOR . 'file1.html',
                    ],
                ],
            ],
            'name' => [
                'details' => [
                    'avatar' => [
                        0 => 'file0.txt',
                        1 => 'file1.html',
                    ],
                ],
            ],
            'type' => [
                'details' => [
                    'avatar' => [
                        0 => 'text/plain',
                        1 => 'text/html',
                    ],
                ],
            ],
            'error' => [
                'details' => [
                    'avatar' => [
                        0 => 0,
                        1 => 0
                    ],
                ],
            ],
            'size' => [
                'details' => [
                    'avatar' => [
                        0 => 0,
                        1 => 0
                    ],
                ],
            ],
        ],
    ],
```

As such, when we iterate over the array, we have to normalise each time to ensure that keep the actual $_FILES array key names known all the way down to the actual data.

Fixes #1806 
