### PR TITLE
Allow dispatching of the router in middleware

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -48,6 +48,7 @@ use Slim\Interfaces\RouterInterface;
  */
 class App
 {
+    use DispatchRouterTrait;
     use MiddlewareAwareTrait;
 
     /**
@@ -497,35 +498,6 @@ class App
         }
 
         return $this($request, $response);
-    }
-
-    /**
-     * Dispatch the router to find the route. Prepare the route for use.
-     *
-     * @param ServerRequestInterface $request
-     * @param RouterInterface        $router
-     * @return ServerRequestInterface
-     */
-    protected function dispatchRouterAndPrepareRoute(ServerRequestInterface $request, RouterInterface $router)
-    {
-        $routeInfo = $router->dispatch($request);
-
-        if ($routeInfo[0] === Dispatcher::FOUND) {
-            $routeArguments = [];
-            foreach ($routeInfo[2] as $k => $v) {
-                $routeArguments[$k] = urldecode($v);
-            }
-
-            $route = $router->lookupRoute($routeInfo[1]);
-            $route->prepare($request, $routeArguments);
-
-            // add route to the request's attributes in case a middleware or handler needs access to the route
-            $request = $request->withAttribute('route', $route);
-        }
-
-        $routeInfo['request'] = [$request->getMethod(), (string) $request->getUri()];
-
-        return $request->withAttribute('routeInfo', $routeInfo);
     }
 
     /**

--- a/Slim/DispatchRouterTrait.php
+++ b/Slim/DispatchRouterTrait.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2016 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+namespace Slim;
+
+use FastRoute\Dispatcher;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Interfaces\RouterInterface;
+
+/**
+ * This trait allows us to dispatch the router to find the route.
+ *
+ * This exists as a trait so that end users can reuse this in middleware
+ * to dispatch the route. Once the method is called, the route will be
+ * available from the request object.
+ */
+trait DispatchRouterTrait
+{
+    /**
+     * Dispatch the router to find the route. Prepare the route for use.
+     *
+     * @param ServerRequestInterface $request
+     * @param RouterInterface        $router
+     * @return ServerRequestInterface
+     */
+    protected function dispatchRouterAndPrepareRoute(ServerRequestInterface $request, RouterInterface $router)
+    {
+        $routeInfo = $router->dispatch($request);
+
+        if ($routeInfo[0] === Dispatcher::FOUND) {
+            $routeArguments = [];
+            foreach ($routeInfo[2] as $k => $v) {
+                $routeArguments[$k] = urldecode($v);
+            }
+
+            $route = $router->lookupRoute($routeInfo[1]);
+            $route->prepare($request, $routeArguments);
+
+            // add route to the request's attributes in case a middleware or handler needs access to the route
+            $request = $request->withAttribute('route', $route);
+        }
+
+        $routeInfo['request'] = [$request->getMethod(), (string) $request->getUri()];
+
+        return $request->withAttribute('routeInfo', $routeInfo);
+    }
+}


### PR DESCRIPTION
Currently, the router is not dispatched until after the app middleware.
If we set `determineRouteBeforeAppMiddleware` in the settings, the router is dispatched straight away.
There seems to be no middle ground.

If we move App::dispatchRouterAndPrepareRoute into a trait, this allows us to dispatch the route in middleware without duplicating the contents of that method.

``` php
<?php
class RouteDispatcherMiddleware
{
    use Slim\DispatchRouterTrait;

    protected $router;

    public function __construct($router)
    {
        $this->router = $router;
    }

    public function __invoke($request, $response, $next)
    {
        if (! $request->getAttribute('route')) {
            $this->dispatchRouterAndPrepareRoute($request, $this->router);
        }
        return $next($request, $response);
    }
}
```

This means users can get the best of both.

``` php
$app->add(new MiddlewareThatRequiresAccessToTheRoute());
$app->add(new RouteDispatcherMiddleware($app->getContainer()->get('router');
$app->add(new MiddlewareThatManipulatesTheRequest());
```
