### PR TITLE
define precise interface for the di container

### DIFF
--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -8,13 +8,13 @@
  */
 namespace Slim;
 
-use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
 use Pimple\Container as PimpleContainer;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Exception\ContainerValueNotFoundException;
 use Slim\Exception\ContainerException as SlimContainerException;
+use Slim\Interfaces\ArrayContainerInterface;
 
 /**
  * Slim's default DI container is Pimple.
@@ -44,7 +44,7 @@ use Slim\Exception\ContainerException as SlimContainerException;
  * @property-read callable notAllowedHandler
  * @property-read \Slim\Interfaces\CallableResolverInterface callableResolver
  */
-class Container extends PimpleContainer implements ContainerInterface
+class Container extends PimpleContainer implements ArrayContainerInterface
 {
     /**
      * Default settings

--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -24,6 +24,7 @@ use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\Http\EnvironmentInterface;
 use Slim\Interfaces\InvocationStrategyInterface;
 use Slim\Interfaces\RouterInterface;
+use Slim\Interfaces\ArrayContainerInterface;
 
 /**
  * Slim's default Service Provider.
@@ -33,9 +34,9 @@ class DefaultServicesProvider
     /**
      * Register Slim's default services.
      *
-     * @param Container $container A DI container implementing ArrayAccess and container-interop.
+     * @param ArrayContainerInterface $container A DI container
      */
-    public function register($container)
+    public function register(ArrayContainerInterface $container)
     {
         if (!isset($container['environment'])) {
             /**

--- a/Slim/Interfaces/ArrayContainerInterface.php
+++ b/Slim/Interfaces/ArrayContainerInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2016 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+namespace Slim\Interfaces;
+
+use Interop\Container\ContainerInterface;
+
+interface ArrayContainerInterface extends \ArrayAccess, ContainerInterface
+{
+}


### PR DESCRIPTION
In the docblock of `Slim\DefaultServicesProvider::register`, there's a line saying: `@param Container $container A DI container implementing ArrayAccess and container-interop`. The `Container`s FQCN is `Slim\Container` which extends the PimpleContainer. So, it _does_ implement `ArrayAccess` and the interop `ContainerInterface`, but _not only_ this, is also adds a (IMHO) unneccessary constraint to the Slim Container. This makes it very hard to use a different container. (It's possible because the constraint is only a comment, but it's not "clean" style).

I declared a dedicated interface which actually does exactly what the comment "A DI container implementing ArrayAccess and conatiner-interop" says. And added it also as a type hint to the method declaration.
