### PR TITLE
(Thoughts?) Feature - Allow users to Specify their own Http Classes Easily

### DIFF
--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -58,7 +58,7 @@ class DefaultServicesProvider
              * @return ServerRequestInterface
              */
             $container['request'] = function ($container) {
-                return Request::createFromEnvironment($container->get('environment'));
+                return Request::createFromEnvironment($container->get('environment'), $container->get('settings'));
             };
         }
 

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -130,10 +130,11 @@ class Request extends Message implements ServerRequestInterface
      * Environment object
      *
      * @param  Environment $environment The Slim application Environment
+     * @param  Collection $settings The Slim application Settings
      *
      * @return self
      */
-    public static function createFromEnvironment(Environment $environment)
+    public static function createFromEnvironment(Environment $environment, Collection $settings)
     {
         $method = $environment['REQUEST_METHOD'];
         $uri = Uri::createFromEnvironment($environment);

--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -13,6 +13,7 @@ use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Slim\Collection;
+use Slim\Interfaces\Http\RequestBuilderInterface;
 
 /**
  * Represents Uploaded Files.
@@ -22,7 +23,7 @@ use Slim\Collection;
  * @link https://github.com/php-fig/http-message/blob/master/src/UploadedFileInterface.php
  * @link https://github.com/php-fig/http-message/blob/master/src/StreamInterface.php
  */
-class UploadedFile implements UploadedFileInterface
+class UploadedFile implements UploadedFileInterface, RequestBuilderInterface
 {
     /**
      * The client-provided full path to the file
@@ -115,7 +116,8 @@ class UploadedFile implements UploadedFileInterface
 
             $parsed[$field] = [];
             if (!is_array($uploadedFile['error'])) {
-                $parsed[$field] = new static(
+                $class = static::build($settings);
+                $parsed[$field] = new $class(
                     $uploadedFile['tmp_name'],
                     isset($uploadedFile['name']) ? $uploadedFile['name'] : null,
                     isset($uploadedFile['type']) ? $uploadedFile['type'] : null,
@@ -139,6 +141,17 @@ class UploadedFile implements UploadedFileInterface
         }
 
         return $parsed;
+    }
+
+    /**
+     * Check to see if user specified their own uploaded file class.
+     *
+     * @param Collection $settings
+     * @return mixed
+     */
+    public static function build(Collection $settings)
+    {
+        return $settings->get('uploadedFileClass', __CLASS__);
     }
 
     /**

--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -12,6 +12,7 @@ use RuntimeException;
 use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
+use Slim\Collection;
 
 /**
  * Represents Uploaded Files.
@@ -78,10 +79,11 @@ class UploadedFile implements UploadedFileInterface
      * Create a normalized tree of UploadedFile instances from the Environment.
      *
      * @param Environment $env The environment
+     * @param Collection $settings The settings
      *
      * @return array|null A normalized tree of UploadedFile instances or null if none are provided.
      */
-    public static function createFromEnvironment(Environment $env)
+    public static function createFromEnvironment(Environment $env, Collection $settings)
     {
         if (is_array($env['slim.files']) && $env->has('slim.files')) {
             return $env['slim.files'];
@@ -96,10 +98,11 @@ class UploadedFile implements UploadedFileInterface
      * Parse a non-normalized, i.e. $_FILES superglobal, tree of uploaded file data.
      *
      * @param array $uploadedFiles The non-normalized tree of uploaded file data.
+     * @param Collection $settings The $settings
      *
      * @return array A normalized tree of UploadedFile instances.
      */
-    private static function parseUploadedFiles(array $uploadedFiles)
+    private static function parseUploadedFiles(array $uploadedFiles, Collection $settings)
     {
         $parsed = [];
         foreach ($uploadedFiles as $field => $uploadedFile) {

--- a/Slim/Interfaces/Http/RequestBuilderInterface.php
+++ b/Slim/Interfaces/Http/RequestBuilderInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Slim Framework (http://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2016 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+namespace Slim\Interfaces\Http;
+use Slim\Collection;
+
+/**
+ * Request Builder Interface
+ *
+ * @package Slim
+ * @since   3.0.0
+ */
+interface RequestBuilderInterface
+{
+    public static function build(Collection $settings);
+}


### PR DESCRIPTION
The problem - Currently, you are limited to using Slims classes to parse requests for the Uri, Headers, Cookies, and UploadedFiles. https://github.com/slimphp/Slim/blob/3.x/Slim/Http/Request.php#L139

Solution - Allow the user to specify the class they want to use in order to handle the request type in the settings file. For example, a user declares the setting => `'uploadedFileClass' => '<Their new UploadedFileClass>'`, then the users class will be used instead of the default. 

Now users can go about extending the UploadedFile class and adding methods that they want. 

**I did break all tests, just curious if anyone else wanted the same functionality**
