### PR TITLE
Fixing Infinite Loop in Error, Unit Test

### DIFF
--- a/Slim/Handlers/AbstractError.php
+++ b/Slim/Handlers/AbstractError.php
@@ -43,14 +43,14 @@ abstract class AbstractError extends AbstractHandler
 
         $message = 'Slim Application Error:' . PHP_EOL;
         $message .= $this->renderThrowableAsText($throwable);
-        while ($error = $throwable->getPrevious()) {
+        while ($throwable = $throwable->getPrevious()) {
             $message .= PHP_EOL . 'Previous error:' . PHP_EOL;
             $message .= $this->renderThrowableAsText($throwable);
         }
 
         $message .= PHP_EOL . 'View in rendered output by enabling the "displayErrorDetails" setting.' . PHP_EOL;
 
-        error_log($message);
+        $this->logError($message);
     }
 
     /**
@@ -85,5 +85,15 @@ abstract class AbstractError extends AbstractHandler
         }
 
         return $text;
+    }
+
+    /**
+     * Wraps the error_log function so that this can be easily tested
+     *
+     * @param $message
+     */
+    protected function logError($message)
+    {
+        error_log($message);
     }
 }

--- a/tests/Handlers/ErrorTest.php
+++ b/tests/Handlers/ErrorTest.php
@@ -44,6 +44,26 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that an exception with a previous exception provides correct output
+     * to the error log
+     */
+    public function testPreviousException()
+    {
+        $error = $this->getMock('\Slim\Handlers\Error', ['logError']);
+        $error->expects($this->once())->method('logError')->with(
+            $this->logicalAnd(
+                $this->stringContains("Type: Exception\nMessage: Second Oops"),
+                $this->stringContains("Previous Error:\nType: Exception\nMessage: First Oops")
+            )
+        );
+
+        $first = new \Exception("First Oops");
+        $second = new \Exception("Second Oops", 0, $first);
+
+        $error->__invoke($this->getRequest('GET', 'application/json'), new Response(), $second);
+    }
+
+    /**
      * @param string $method
      * @return \PHPUnit_Framework_MockObject_MockObject|\Slim\Http\Request
      */


### PR DESCRIPTION
I found an infinite loop while trying to get the throwable's previous error. In order to test this, I had to wrap the global error_log function within a method in the class. 
