### PR TITLE
Use class name constant instead of magic string.

### DIFF
--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -148,7 +148,7 @@ class Container extends PimpleContainer implements ContainerInterface
     {
         $trace = $exception->getTrace()[0];
 
-        return $trace['class'] === 'Pimple\Container' && $trace['function'] === 'offsetGet';
+        return $trace['class'] === PimpleContainer::class && $trace['function'] === 'offsetGet';
     }
 
     /**


### PR DESCRIPTION
The MyClass::class constant has fully qualified class name. Available
since PHP 5.5 release for all classes.
