### PR TITLE
Ensure determineContentType() returns a valid result

### DIFF
--- a/Slim/Handlers/AbstractHandler.php
+++ b/Slim/Handlers/AbstractHandler.php
@@ -43,7 +43,7 @@ abstract class AbstractHandler
         $selectedContentTypes = array_intersect(explode(',', $acceptHeader), $this->knownContentTypes);
 
         if (count($selectedContentTypes)) {
-            return $selectedContentTypes[0];
+            return current($selectedContentTypes);
         }
 
         // handle +json and +xml specially

--- a/tests/Handlers/AbstractHandlerTest.php
+++ b/tests/Handlers/AbstractHandlerTest.php
@@ -39,4 +39,32 @@ class AbstractHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('text/html', $return);
     }
+
+    /**
+     * Ensure that an acceptable media-type is found in the Accept header even
+     * if it's not the first in the list.
+     */
+    public function testAcceptableMediaTypeIsNotFirstInList()
+    {
+        $request = $this->getMockBuilder('Slim\Http\Request')
+            ->disableOriginalConstructor()
+            ->getMock();
+        
+        $request->expects($this->any())
+            ->method('getHeaderLine')
+            ->willReturn('text/plain,text/html');
+
+        // provide access to the determineContentType() as it's a protected method
+        $class = new \ReflectionClass(AbstractHandler::class);
+        $method = $class->getMethod('determineContentType');
+        $method->setAccessible(true);
+
+        // use a mock object here as AbstractHandler cannot be directly instantiated
+        $abstractHandler = $this->getMockForAbstractClass(AbstractHandler::class);
+        
+        // call determineContentType()
+        $return = $method->invoke($abstractHandler, $request);
+
+        $this->assertEquals('text/html', $return);
+    }
 }


### PR DESCRIPTION
If the acceptable media type in the Accept header is not first in the list, we need to ensure that we return it correctly.

Fixes #1892
