### PR TITLE
Env REQUEST_URI can contain query params.

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -218,6 +218,9 @@ class Uri implements UriInterface
 
         // Query string
         $queryString = $env->get('QUERY_STRING', '');
+        if ($queryString === '') {
+            $queryString = parse_url('http://example.com' . $env->get('REQUEST_URI'), PHP_URL_QUERY);
+        }
 
         // Fragment
         $fragment = '';

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -633,4 +633,16 @@ class UriTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertSame('/foo/index.php', $uri->getBasePath());
     }
+
+    public function testRequestURICanContainParams()
+    {
+        $uri = Uri::createFromEnvironment(
+            Environment::mock(
+                [
+                    'REQUEST_URI' => '/foo?abc=123',
+                ]
+            )
+        );
+        $this->assertEquals('abc=123', $uri->getQuery());
+    }
 }


### PR DESCRIPTION
This is a typical scenario on tests, where REQUEST_URI contains path and
all params to perform a request. No need to set QUERY_STRING in
environment separately.
