### PR TITLE
Improve performance

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -46,35 +46,36 @@ final class CallableResolver implements CallableResolverInterface
      */
     public function resolve($toResolve)
     {
+        if (is_callable($toResolve)) {
+            return $toResolve;
+        }
+        
         $resolved = $toResolve;
+        // check for slim callable as "class:method"
+        $callablePattern = '!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!';
+        if (preg_match($callablePattern, $toResolve, $matches)) {
+            $class = $matches[1];
+            $method = $matches[2];
 
-        if (!is_callable($toResolve) && is_string($toResolve)) {
-            // check for slim callable as "class:method"
-            $callablePattern = '!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!';
-            if (preg_match($callablePattern, $toResolve, $matches)) {
-                $class = $matches[1];
-                $method = $matches[2];
-
-                if ($this->container->has($class)) {
-                    $resolved = [$this->container->get($class), $method];
-                } else {
-                    if (!class_exists($class)) {
-                        throw new RuntimeException(sprintf('Callable %s does not exist', $class));
-                    }
-                    $resolved = [new $class($this->container), $method];
-                }
+            if ($this->container->has($class)) {
+                $resolved = [$this->container->get($class), $method];
             } else {
-                // check if string is something in the DIC that's callable or is a class name which
-                // has an __invoke() method
-                $class = $toResolve;
-                if ($this->container->has($class)) {
-                    $resolved = $this->container->get($class);
-                } else {
-                    if (!class_exists($class)) {
-                        throw new RuntimeException(sprintf('Callable %s does not exist', $class));
-                    }
-                    $resolved = new $class($this->container);
+                if (!class_exists($class)) {
+                    throw new RuntimeException(sprintf('Callable %s does not exist', $class));
                 }
+                $resolved = [new $class($this->container), $method];
+            }
+        } else {
+            // check if string is something in the DIC that's callable or is a class name which
+            // has an __invoke() method
+            $class = $toResolve;
+            if ($this->container->has($class)) {
+                $resolved = $this->container->get($class);
+            } else {
+                if (!class_exists($class)) {
+                    throw new RuntimeException(sprintf('Callable %s does not exist', $class));
+                }
+                $resolved = new $class($this->container);
             }
         }
 


### PR DESCRIPTION
Return early if $toResove is already a callable and remove string checking.
This reduces 2 function calls. (is_callable(), is_string())
