### PR TITLE
Move valid protocol versions to a class static var

### DIFF
--- a/Slim/Http/Message.php
+++ b/Slim/Http/Message.php
@@ -32,6 +32,17 @@ abstract class Message implements MessageInterface
     protected $protocolVersion = '1.1';
 
     /**
+     * A map of valid protocol versions
+     *
+     * @var array
+     */
+    protected static $validProtocolVersions = [
+        '1.0' => true,
+        '1.1' => true,
+        '2.0' => true,
+    ];
+
+    /**
      * Headers
      *
      * @var \Slim\Interfaces\Http\HeadersInterface
@@ -86,13 +97,11 @@ abstract class Message implements MessageInterface
      */
     public function withProtocolVersion($version)
     {
-        static $valid = [
-            '1.0' => true,
-            '1.1' => true,
-            '2.0' => true,
-        ];
-        if (!isset($valid[$version])) {
-            throw new InvalidArgumentException('Invalid HTTP version. Must be one of: 1.0, 1.1, 2.0');
+        if (!isset(self::$validProtocolVersions[$version])) {
+            throw new InvalidArgumentException(
+                'Invalid HTTP version. Must be one of: '
+                . implode(', ', array_keys(self::$validProtocolVersions))
+            );
         }
         $clone = clone $this;
         $clone->protocolVersion = $version;


### PR DESCRIPTION
Just a matter of taste: i think it looks uglier as a function static var. 
Also, in this way it's also available to all Message(s)
