### PR TITLE
Fix namespaces usage. Correct phpdocs

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -8,22 +8,19 @@
  */
 namespace Slim;
 
-use Exception;
-use Throwable;
-use Closure;
+use FastRoute\Dispatcher;
+use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Interop\Container\ContainerInterface;
-use FastRoute\Dispatcher;
-use Slim\Exception\SlimException;
+use Psr\Http\Message\ServerRequestInterface;
 use Slim\Exception\MethodNotAllowedException;
 use Slim\Exception\NotFoundException;
-use Slim\Http\Uri;
-use Slim\Http\Headers;
+use Slim\Exception\SlimException;
 use Slim\Http\Body;
+use Slim\Http\Headers;
 use Slim\Http\Request;
+use Slim\Http\Uri;
 use Slim\Interfaces\Http\EnvironmentInterface;
 use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;
@@ -110,7 +107,7 @@ class App
     }
 
     /**
-     * Calling a non-existant method on App checks to see if there's an item
+     * Calling a non-existent method on App checks to see if there's an item
      * in the container that is callable and if so, calls it.
      *
      * @param  string $method
@@ -235,7 +232,7 @@ class App
      */
     public function map(array $methods, $pattern, $callable)
     {
-        if ($callable instanceof Closure) {
+        if ($callable instanceof \Closure) {
             $callable = $callable->bindTo($this->container);
         }
 
@@ -286,7 +283,7 @@ class App
      * @param bool|false $silent
      * @return ResponseInterface
      *
-     * @throws Exception
+     * @throws \Exception
      * @throws MethodNotAllowedException
      * @throws NotFoundException
      */
@@ -314,7 +311,7 @@ class App
      * @param ResponseInterface $response
      * @return ResponseInterface
      *
-     * @throws Exception
+     * @throws \Exception
      * @throws MethodNotAllowedException
      * @throws NotFoundException
      */
@@ -335,9 +332,9 @@ class App
         // Traverse middleware stack
         try {
             $response = $this->callMiddlewareStack($request, $response);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $response = $this->handleException($e, $request, $response);
-        } catch (Throwable $e) {
+        } catch (\Throwable $e) {
             $response = $this->handlePhpError($e, $request, $response);
         }
 
@@ -583,14 +580,14 @@ class App
      * Call relevant handler from the Container if needed. If it doesn't exist,
      * then just re-throw.
      *
-     * @param  Exception $e
+     * @param  \Exception $e
      * @param  ServerRequestInterface $request
      * @param  ResponseInterface $response
      *
      * @return ResponseInterface
-     * @throws Exception if a handler is needed and not found
+     * @throws \Exception if a handler is needed and not found
      */
-    protected function handleException(Exception $e, ServerRequestInterface $request, ResponseInterface $response)
+    protected function handleException(\Exception $e, ServerRequestInterface $request, ResponseInterface $response)
     {
         if ($e instanceof MethodNotAllowedException) {
             $handler = 'notAllowedHandler';
@@ -621,13 +618,13 @@ class App
      * Call relevant handler from the Container if needed. If it doesn't exist,
      * then just re-throw.
      *
-     * @param  Throwable $e
+     * @param  \Throwable $e
      * @param  ServerRequestInterface $request
      * @param  ResponseInterface $response
      * @return ResponseInterface
-     * @throws Throwable
+     * @throws \Throwable
      */
-    protected function handlePhpError(Throwable $e, ServerRequestInterface $request, ResponseInterface $response)
+    protected function handlePhpError(\Throwable $e, ServerRequestInterface $request, ResponseInterface $response)
     {
         $handler = 'phpErrorHandler';
         $params = [$request, $response, $e];

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -8,7 +8,6 @@
  */
 namespace Slim;
 
-use RuntimeException;
 use Interop\Container\ContainerInterface;
 use Slim\Interfaces\CallableResolverInterface;
 
@@ -41,8 +40,8 @@ final class CallableResolver implements CallableResolverInterface
      *
      * @return callable
      *
-     * @throws RuntimeException if the callable does not exist
-     * @throws RuntimeException if the callable is not resolvable
+     * @throws \RuntimeException if the callable does not exist
+     * @throws \RuntimeException if the callable is not resolvable
      */
     public function resolve($toResolve)
     {
@@ -59,7 +58,7 @@ final class CallableResolver implements CallableResolverInterface
                     $resolved = [$this->container->get($class), $method];
                 } else {
                     if (!class_exists($class)) {
-                        throw new RuntimeException(sprintf('Callable %s does not exist', $class));
+                        throw new \RuntimeException(sprintf('Callable %s does not exist', $class));
                     }
                     $resolved = [new $class($this->container), $method];
                 }
@@ -71,7 +70,7 @@ final class CallableResolver implements CallableResolverInterface
                     $resolved = $this->container->get($class);
                 } else {
                     if (!class_exists($class)) {
-                        throw new RuntimeException(sprintf('Callable %s does not exist', $class));
+                        throw new \RuntimeException(sprintf('Callable %s does not exist', $class));
                     }
                     $resolved = new $class($this->container);
                 }
@@ -79,7 +78,7 @@ final class CallableResolver implements CallableResolverInterface
         }
 
         if (!is_callable($resolved)) {
-            throw new RuntimeException(sprintf('%s is not resolvable', $toResolve));
+            throw new \RuntimeException(sprintf('%s is not resolvable', $toResolve));
         }
 
         return $resolved;

--- a/Slim/CallableResolverAwareTrait.php
+++ b/Slim/CallableResolverAwareTrait.php
@@ -8,7 +8,6 @@
  */
 namespace Slim;
 
-use RuntimeException;
 use Interop\Container\ContainerInterface;
 use Slim\Interfaces\CallableResolverInterface;
 
@@ -31,7 +30,7 @@ trait CallableResolverAwareTrait
      *
      * @return \Closure
      *
-     * @throws RuntimeException If the string cannot be resolved as a callable
+     * @throws \RuntimeException If the string cannot be resolved as a callable
      */
     protected function resolveCallable($callable)
     {

--- a/Slim/Collection.php
+++ b/Slim/Collection.php
@@ -8,7 +8,6 @@
  */
 namespace Slim;
 
-use ArrayIterator;
 use Slim\Interfaces\CollectionInterface;
 
 /**
@@ -199,6 +198,6 @@ class Collection implements CollectionInterface
      */
     public function getIterator()
     {
-        return new ArrayIterator($this->data);
+        return new \ArrayIterator($this->data);
     }
 }

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -11,10 +11,8 @@ namespace Slim;
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
 use Pimple\Container as PimpleContainer;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Slim\Exception\ContainerValueNotFoundException;
 use Slim\Exception\ContainerException as SlimContainerException;
+use Slim\Exception\ContainerValueNotFoundException;
 
 /**
  * Slim's default DI container is Pimple.

--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -10,11 +10,10 @@ namespace Slim;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Slim\Exception\ContainerValueNotFoundException;
-use Slim\Handlers\PhpError;
 use Slim\Handlers\Error;
-use Slim\Handlers\NotFound;
 use Slim\Handlers\NotAllowed;
+use Slim\Handlers\NotFound;
+use Slim\Handlers\PhpError;
 use Slim\Handlers\Strategies\RequestResponse;
 use Slim\Http\Environment;
 use Slim\Http\Headers;

--- a/Slim/DeferredCallable.php
+++ b/Slim/DeferredCallable.php
@@ -9,7 +9,6 @@
 
 namespace Slim;
 
-use Closure;
 use Interop\Container\ContainerInterface;
 
 class DeferredCallable
@@ -34,7 +33,7 @@ class DeferredCallable
     public function __invoke()
     {
         $callable = $this->resolveCallable($this->callable);
-        if ($callable instanceof Closure) {
+        if ($callable instanceof \Closure) {
             $callable = $callable->bindTo($this->container);
         }
 

--- a/Slim/Exception/ContainerException.php
+++ b/Slim/Exception/ContainerException.php
@@ -8,13 +8,12 @@
  */
 namespace Slim\Exception;
 
-use InvalidArgumentException;
 use Interop\Container\Exception\ContainerException as InteropContainerException;
 
 /**
  * Container Exception
  */
-class ContainerException extends InvalidArgumentException implements InteropContainerException
+class ContainerException extends \InvalidArgumentException implements InteropContainerException
 {
 
 }

--- a/Slim/Exception/ContainerValueNotFoundException.php
+++ b/Slim/Exception/ContainerValueNotFoundException.php
@@ -8,13 +8,12 @@
  */
 namespace Slim\Exception;
 
-use RuntimeException;
 use Interop\Container\Exception\NotFoundException as InteropNotFoundException;
 
 /**
  * Not Found Exception
  */
-class ContainerValueNotFoundException extends RuntimeException implements InteropNotFoundException
+class ContainerValueNotFoundException extends \RuntimeException implements InteropNotFoundException
 {
 
 }

--- a/Slim/Exception/MethodNotAllowedException.php
+++ b/Slim/Exception/MethodNotAllowedException.php
@@ -8,8 +8,8 @@
  */
 namespace Slim\Exception;
 
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 class MethodNotAllowedException extends SlimException
 {

--- a/Slim/Exception/SlimException.php
+++ b/Slim/Exception/SlimException.php
@@ -8,9 +8,8 @@
  */
 namespace Slim\Exception;
 
-use Exception;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Stop Exception
@@ -18,7 +17,7 @@ use Psr\Http\Message\ResponseInterface;
  * This Exception is thrown when the Slim application needs to abort
  * processing and return control flow to the outer PHP script.
  */
-class SlimException extends Exception
+class SlimException extends \Exception
 {
     /**
      * A request object

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -11,7 +11,6 @@ namespace Slim\Handlers;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Http\Body;
-use UnexpectedValueException;
 
 /**
  * Default Slim application error handler
@@ -29,7 +28,7 @@ class Error extends AbstractError
      * @param \Exception             $exception The caught Exception object
      *
      * @return ResponseInterface
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, \Exception $exception)
     {
@@ -49,7 +48,7 @@ class Error extends AbstractError
                 break;
             
             default:
-                throw new UnexpectedValueException('Cannot render unknown content type ' . $contentType);
+                throw new \UnexpectedValueException('Cannot render unknown content type ' . $contentType);
         }
 
         $this->writeToErrorLog($exception);

--- a/Slim/Handlers/NotAllowed.php
+++ b/Slim/Handlers/NotAllowed.php
@@ -8,10 +8,9 @@
  */
 namespace Slim\Handlers;
 
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Slim\Http\Body;
-use UnexpectedValueException;
 
 /**
  * Default Slim application not allowed handler
@@ -29,7 +28,7 @@ class NotAllowed extends AbstractHandler
      * @param  string[]               $methods  Allowed HTTP methods
      *
      * @return ResponseInterface
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, array $methods)
     {
@@ -54,7 +53,7 @@ class NotAllowed extends AbstractHandler
                     $output = $this->renderHtmlNotAllowedMessage($methods);
                     break;
                 default:
-                    throw new UnexpectedValueException('Cannot render unknown content type ' . $contentType);
+                    throw new \UnexpectedValueException('Cannot render unknown content type ' . $contentType);
             }
         }
 

--- a/Slim/Handlers/NotFound.php
+++ b/Slim/Handlers/NotFound.php
@@ -11,7 +11,6 @@ namespace Slim\Handlers;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Slim\Http\Body;
-use UnexpectedValueException;
 
 /**
  * Default Slim application not found handler.
@@ -28,7 +27,7 @@ class NotFound extends AbstractHandler
      * @param  ResponseInterface      $response The most recent Response object
      *
      * @return ResponseInterface
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
@@ -48,7 +47,7 @@ class NotFound extends AbstractHandler
                 break;
             
             default:
-                throw new UnexpectedValueException('Cannot render unknown content type ' . $contentType);
+                throw new \UnexpectedValueException('Cannot render unknown content type ' . $contentType);
         }
 
         $body = new Body(fopen('php://temp', 'r+'));

--- a/Slim/Handlers/PhpError.php
+++ b/Slim/Handlers/PhpError.php
@@ -11,7 +11,6 @@ namespace Slim\Handlers;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Http\Body;
-use UnexpectedValueException;
 
 /**
  * Default Slim application error handler for PHP 7+ Throwables
@@ -29,7 +28,7 @@ class PhpError extends AbstractError
      * @param \Throwable             $error     The caught Throwable object
      *
      * @return ResponseInterface
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, \Throwable $error)
     {
@@ -48,7 +47,7 @@ class PhpError extends AbstractError
                 $output = $this->renderHtmlErrorMessage($error);
                 break;
             default:
-                throw new UnexpectedValueException('Cannot render unknown content type ' . $contentType);
+                throw new \UnexpectedValueException('Cannot render unknown content type ' . $contentType);
         }
 
         $this->writeToErrorLog($error);

--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -8,7 +8,6 @@
  */
 namespace Slim\Http;
 
-use InvalidArgumentException;
 use Slim\Interfaces\Http\CookiesInterface;
 
 /**
@@ -161,7 +160,7 @@ class Cookies implements CookiesInterface
      *
      * @return array Associative array of cookie names and values
      *
-     * @throws InvalidArgumentException if the cookie data cannot be parsed
+     * @throws \InvalidArgumentException if the cookie data cannot be parsed
      */
     public static function parseHeader($header)
     {
@@ -170,7 +169,7 @@ class Cookies implements CookiesInterface
         }
 
         if (is_string($header) === false) {
-            throw new InvalidArgumentException('Cannot parse Cookie data. Header value must be a string.');
+            throw new \InvalidArgumentException('Cannot parse Cookie data. Header value must be a string.');
         }
 
         $header = rtrim($header, "\r\n");

--- a/Slim/Http/Message.php
+++ b/Slim/Http/Message.php
@@ -8,7 +8,6 @@
  */
 namespace Slim\Http;
 
-use InvalidArgumentException;
 use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\StreamInterface;
 
@@ -82,7 +81,7 @@ abstract class Message implements MessageInterface
      *
      * @param string $version HTTP protocol version
      * @return static
-     * @throws InvalidArgumentException if the http version is an invalid number
+     * @throws \InvalidArgumentException if the http version is an invalid number
      */
     public function withProtocolVersion($version)
     {
@@ -92,7 +91,7 @@ abstract class Message implements MessageInterface
             '2.0' => true,
         ];
         if (!isset($valid[$version])) {
-            throw new InvalidArgumentException('Invalid HTTP version. Must be one of: 1.0, 1.1, 2.0');
+            throw new \InvalidArgumentException('Invalid HTTP version. Must be one of: 1.0, 1.1, 2.0');
         }
         $clone = clone $this;
         $clone->protocolVersion = $version;

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -8,13 +8,11 @@
  */
 namespace Slim\Http;
 
-use Closure;
 use InvalidArgumentException;
-use Psr\Http\Message\UploadedFileInterface;
-use RuntimeException;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\UriInterface;
 use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UploadedFileInterface;
+use Psr\Http\Message\UriInterface;
 use Slim\Collection;
 use Slim\Interfaces\Http\HeadersInterface;
 
@@ -954,7 +952,7 @@ class Request extends Message implements ServerRequestInterface
      *
      * @return null|array|object The deserialized body parameters, if any.
      *     These will typically be an array or object.
-     * @throws RuntimeException if the request body media type parser returns an invalid value
+     * @throws \RuntimeException if the request body media type parser returns an invalid value
      */
     public function getParsedBody()
     {
@@ -979,7 +977,7 @@ class Request extends Message implements ServerRequestInterface
             $parsed = $this->bodyParsers[$mediaType]($body);
 
             if (!is_null($parsed) && !is_object($parsed) && !is_array($parsed)) {
-                throw new RuntimeException(
+                throw new \RuntimeException(
                     'Request body media type parser return value must be an array, an object, or null'
                 );
             }
@@ -1056,7 +1054,7 @@ class Request extends Message implements ServerRequestInterface
      */
     public function registerMediaTypeParser($mediaType, callable $callable)
     {
-        if ($callable instanceof Closure) {
+        if ($callable instanceof \Closure) {
             $callable = $callable->bindTo($this);
         }
         $this->bodyParsers[(string)$mediaType] = $callable;

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -8,7 +8,6 @@
  */
 namespace Slim\Http;
 
-use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
@@ -180,7 +179,7 @@ class Response extends Message implements ResponseInterface
         $code = $this->filterStatus($code);
 
         if (!is_string($reasonPhrase) && !method_exists($reasonPhrase, '__toString')) {
-            throw new InvalidArgumentException('ReasonPhrase must be a string');
+            throw new \InvalidArgumentException('ReasonPhrase must be a string');
         }
 
         $clone = clone $this;
@@ -190,7 +189,7 @@ class Response extends Message implements ResponseInterface
         }
 
         if ($reasonPhrase === '') {
-            throw new InvalidArgumentException('ReasonPhrase must be supplied for this code');
+            throw new \InvalidArgumentException('ReasonPhrase must be supplied for this code');
         }
 
         $clone->reasonPhrase = $reasonPhrase;
@@ -208,7 +207,7 @@ class Response extends Message implements ResponseInterface
     protected function filterStatus($status)
     {
         if (!is_integer($status) || $status<100 || $status>599) {
-            throw new InvalidArgumentException('Invalid HTTP status code');
+            throw new \InvalidArgumentException('Invalid HTTP status code');
         }
 
         return $status;

--- a/Slim/Http/Stream.php
+++ b/Slim/Http/Stream.php
@@ -8,9 +8,7 @@
  */
 namespace Slim\Http;
 
-use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;
-use RuntimeException;
 
 /**
  * Represents a data stream as defined in PSR-7.
@@ -91,7 +89,7 @@ class Stream implements StreamInterface
      *
      * @param  resource $stream A PHP resource handle.
      *
-     * @throws InvalidArgumentException If argument is not a resource.
+     * @throws \InvalidArgumentException If argument is not a resource.
      */
     public function __construct($stream)
     {
@@ -141,12 +139,12 @@ class Stream implements StreamInterface
      *
      * @param resource $newStream A PHP resource handle.
      *
-     * @throws InvalidArgumentException If argument is not a valid PHP resource.
+     * @throws \InvalidArgumentException If argument is not a valid PHP resource.
      */
     protected function attach($newStream)
     {
         if (is_resource($newStream) === false) {
-            throw new InvalidArgumentException(__METHOD__ . ' argument must be a valid PHP resource');
+            throw new \InvalidArgumentException(__METHOD__ . ' argument must be a valid PHP resource');
         }
 
         if ($this->isAttached() === true) {
@@ -200,7 +198,7 @@ class Stream implements StreamInterface
         try {
             $this->rewind();
             return $this->getContents();
-        } catch (RuntimeException $e) {
+        } catch (\RuntimeException $e) {
             return '';
         }
     }
@@ -241,12 +239,12 @@ class Stream implements StreamInterface
      *
      * @return int Position of the file pointer
      *
-     * @throws RuntimeException on error.
+     * @throws \RuntimeException on error.
      */
     public function tell()
     {
         if (!$this->isAttached() || ($position = ftell($this->stream)) === false || $this->isPipe()) {
-            throw new RuntimeException('Could not get the position of the pointer in stream');
+            throw new \RuntimeException('Could not get the position of the pointer in stream');
         }
 
         return $position;
@@ -342,13 +340,13 @@ class Stream implements StreamInterface
      *     offset bytes SEEK_CUR: Set position to current location plus offset
      *     SEEK_END: Set position to end-of-stream plus offset.
      *
-     * @throws RuntimeException on failure.
+     * @throws \RuntimeException on failure.
      */
     public function seek($offset, $whence = SEEK_SET)
     {
         // Note that fseek returns 0 on success!
         if (!$this->isSeekable() || fseek($this->stream, $offset, $whence) === -1) {
-            throw new RuntimeException('Could not seek in stream');
+            throw new \RuntimeException('Could not seek in stream');
         }
     }
 
@@ -362,12 +360,12 @@ class Stream implements StreamInterface
      *
      * @link http://www.php.net/manual/en/function.fseek.php
      *
-     * @throws RuntimeException on failure.
+     * @throws \RuntimeException on failure.
      */
     public function rewind()
     {
         if (!$this->isSeekable() || rewind($this->stream) === false) {
-            throw new RuntimeException('Could not rewind stream');
+            throw new \RuntimeException('Could not rewind stream');
         }
     }
 
@@ -381,12 +379,12 @@ class Stream implements StreamInterface
      * @return string Returns the data read from the stream, or an empty string
      *     if no bytes are available.
      *
-     * @throws RuntimeException if an error occurs.
+     * @throws \RuntimeException if an error occurs.
      */
     public function read($length)
     {
         if (!$this->isReadable() || ($data = fread($this->stream, $length)) === false) {
-            throw new RuntimeException('Could not read from stream');
+            throw new \RuntimeException('Could not read from stream');
         }
 
         return $data;
@@ -399,12 +397,12 @@ class Stream implements StreamInterface
      *
      * @return int Returns the number of bytes written to the stream.
      *
-     * @throws RuntimeException on failure.
+     * @throws \RuntimeException on failure.
      */
     public function write($string)
     {
         if (!$this->isWritable() || ($written = fwrite($this->stream, $string)) === false) {
-            throw new RuntimeException('Could not write to stream');
+            throw new \RuntimeException('Could not write to stream');
         }
 
         // reset size so that it will be recalculated on next call to getSize()
@@ -418,13 +416,13 @@ class Stream implements StreamInterface
      *
      * @return string
      *
-     * @throws RuntimeException if unable to read or an error occurs while
+     * @throws \RuntimeException if unable to read or an error occurs while
      *     reading.
      */
     public function getContents()
     {
         if (!$this->isReadable() || ($contents = stream_get_contents($this->stream)) === false) {
-            throw new RuntimeException('Could not get contents of stream');
+            throw new \RuntimeException('Could not get contents of stream');
         }
 
         return $contents;

--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -8,8 +8,6 @@
  */
 namespace Slim\Http;
 
-use RuntimeException;
-use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
@@ -216,39 +214,39 @@ class UploadedFile implements UploadedFileInterface
      *
      * @param string $targetPath Path to which to move the uploaded file.
      *
-     * @throws InvalidArgumentException if the $path specified is invalid.
-     * @throws RuntimeException on any error during the move operation, or on
+     * @throws \InvalidArgumentException if the $path specified is invalid.
+     * @throws \RuntimeException on any error during the move operation, or on
      *     the second or subsequent call to the method.
      */
     public function moveTo($targetPath)
     {
         if ($this->moved) {
-            throw new RuntimeException('Uploaded file already moved');
+            throw new \RuntimeException('Uploaded file already moved');
         }
 
         if (!is_writable(dirname($targetPath))) {
-            throw new InvalidArgumentException('Upload target path is not writable');
+            throw new \InvalidArgumentException('Upload target path is not writable');
         }
 
         $targetIsStream = strpos($targetPath, '://') > 0;
         if ($targetIsStream) {
             if (!copy($this->file, $targetPath)) {
-                throw new RuntimeException(sprintf('Error moving uploaded file %1s to %2s', $this->name, $targetPath));
+                throw new \RuntimeException(sprintf('Error moving uploaded file %1s to %2s', $this->name, $targetPath));
             }
             if (!unlink($this->file)) {
-                throw new RuntimeException(sprintf('Error removing uploaded file %1s', $this->name));
+                throw new \RuntimeException(sprintf('Error removing uploaded file %1s', $this->name));
             }
         } elseif ($this->sapi) {
             if (!is_uploaded_file($this->file)) {
-                throw new RuntimeException(sprintf('%1s is not a valid uploaded file', $this->file));
+                throw new \RuntimeException(sprintf('%1s is not a valid uploaded file', $this->file));
             }
 
             if (!move_uploaded_file($this->file, $targetPath)) {
-                throw new RuntimeException(sprintf('Error moving uploaded file %1s to %2s', $this->name, $targetPath));
+                throw new \RuntimeException(sprintf('Error moving uploaded file %1s to %2s', $this->name, $targetPath));
             }
         } else {
             if (!rename($this->file, $targetPath)) {
-                throw new RuntimeException(sprintf('Error moving uploaded file %1s to %2s', $this->name, $targetPath));
+                throw new \RuntimeException(sprintf('Error moving uploaded file %1s to %2s', $this->name, $targetPath));
             }
         }
 

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -8,9 +8,7 @@
  */
 namespace Slim\Http;
 
-use InvalidArgumentException;
-use \Psr\Http\Message\UriInterface;
-use Slim\Http\Environment;
+use Psr\Http\Message\UriInterface;
 
 /**
  * Value object representing a URI.
@@ -140,7 +138,7 @@ class Uri implements UriInterface
     public static function createFromString($uri)
     {
         if (!is_string($uri) && !method_exists($uri, '__toString')) {
-            throw new InvalidArgumentException('Uri must be a string');
+            throw new \InvalidArgumentException('Uri must be a string');
         }
 
         $parts = parse_url($uri);
@@ -284,8 +282,8 @@ class Uri implements UriInterface
      * @param  string $scheme Raw Uri scheme.
      * @return string
      *
-     * @throws InvalidArgumentException If the Uri scheme is not a string.
-     * @throws InvalidArgumentException If Uri scheme is not "", "https", or "http".
+     * @throws \InvalidArgumentException If the Uri scheme is not a string.
+     * @throws \InvalidArgumentException If Uri scheme is not "", "https", or "http".
      */
     protected function filterScheme($scheme)
     {
@@ -296,12 +294,12 @@ class Uri implements UriInterface
         ];
 
         if (!is_string($scheme) && !method_exists($scheme, '__toString')) {
-            throw new InvalidArgumentException('Uri scheme must be a string');
+            throw new \InvalidArgumentException('Uri scheme must be a string');
         }
 
         $scheme = str_replace('://', '', strtolower((string)$scheme));
         if (!isset($valid[$scheme])) {
-            throw new InvalidArgumentException('Uri scheme must be one of: "", "https", "http"');
+            throw new \InvalidArgumentException('Uri scheme must be one of: "", "https", "http"');
         }
 
         return $scheme;
@@ -479,7 +477,7 @@ class Uri implements UriInterface
      * @param  null|int $port The Uri port number.
      * @return null|int
      *
-     * @throws InvalidArgumentException If the port is invalid.
+     * @throws \InvalidArgumentException If the port is invalid.
      */
     protected function filterPort($port)
     {
@@ -487,7 +485,7 @@ class Uri implements UriInterface
             return $port;
         }
 
-        throw new InvalidArgumentException('Uri port must be null or an integer between 1 and 65535 (inclusive)');
+        throw new \InvalidArgumentException('Uri port must be null or an integer between 1 and 65535 (inclusive)');
     }
 
     /********************************************************************************
@@ -549,7 +547,7 @@ class Uri implements UriInterface
     public function withPath($path)
     {
         if (!is_string($path)) {
-            throw new InvalidArgumentException('Uri path must be a string');
+            throw new \InvalidArgumentException('Uri path must be a string');
         }
 
         $clone = clone $this;
@@ -589,7 +587,7 @@ class Uri implements UriInterface
     public function withBasePath($basePath)
     {
         if (!is_string($basePath)) {
-            throw new InvalidArgumentException('Uri path must be a string');
+            throw new \InvalidArgumentException('Uri path must be a string');
         }
         if (!empty($basePath)) {
             $basePath = '/' . trim($basePath, '/'); // <-- Trim on both sides
@@ -673,7 +671,7 @@ class Uri implements UriInterface
     public function withQuery($query)
     {
         if (!is_string($query) && !method_exists($query, '__toString')) {
-            throw new InvalidArgumentException('Uri query must be a string');
+            throw new \InvalidArgumentException('Uri query must be a string');
         }
         $query = ltrim((string)$query, '?');
         $clone = clone $this;
@@ -741,7 +739,7 @@ class Uri implements UriInterface
     public function withFragment($fragment)
     {
         if (!is_string($fragment) && !method_exists($fragment, '__toString')) {
-            throw new InvalidArgumentException('Uri fragment must be a string');
+            throw new \InvalidArgumentException('Uri fragment must be a string');
         }
         $fragment = ltrim((string)$fragment, '#');
         $clone = clone $this;

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -8,9 +8,8 @@
  */
 namespace Slim\Interfaces;
 
-use InvalidArgumentException;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Route Interface
@@ -77,7 +76,7 @@ interface RouteInterface
      * @param string $name
      *
      * @return static
-     * @throws InvalidArgumentException if the route name is not a string
+     * @throws \InvalidArgumentException if the route name is not a string
      */
     public function setName($name);
 

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -8,8 +8,6 @@
  */
 namespace Slim\Interfaces;
 
-use RuntimeException;
-use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -66,7 +64,7 @@ interface RouterInterface
      *
      * @return \Slim\Interfaces\RouteInterface
      *
-     * @throws RuntimeException   If named route does not exist
+     * @throws \RuntimeException   If named route does not exist
      */
     public function getNamedRoute($name);
 
@@ -86,8 +84,8 @@ interface RouterInterface
      *
      * @return string
      *
-     * @throws RuntimeException         If named route does not exist
-     * @throws InvalidArgumentException If required data not provided
+     * @throws \RuntimeException         If named route does not exist
+     * @throws \InvalidArgumentException If required data not provided
      */
     public function relativePathFor($name, array $data = [], array $queryParams = []);
 
@@ -100,8 +98,8 @@ interface RouterInterface
      *
      * @return string
      *
-     * @throws RuntimeException         If named route does not exist
-     * @throws InvalidArgumentException If required data not provided
+     * @throws \RuntimeException         If named route does not exist
+     * @throws \InvalidArgumentException If required data not provided
      */
     public function pathFor($name, array $data = [], array $queryParams = []);
 }

--- a/Slim/MiddlewareAwareTrait.php
+++ b/Slim/MiddlewareAwareTrait.php
@@ -8,12 +8,8 @@
  */
 namespace Slim;
 
-use RuntimeException;
-use SplStack;
-use SplDoublyLinkedList;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use UnexpectedValueException;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Middleware
@@ -50,13 +46,13 @@ trait MiddlewareAwareTrait
      *                           3. A "next" middleware callable
      * @return static
      *
-     * @throws RuntimeException         If middleware is added while the stack is dequeuing
-     * @throws UnexpectedValueException If the middleware doesn't return a Psr\Http\Message\ResponseInterface
+     * @throws \RuntimeException         If middleware is added while the stack is dequeuing
+     * @throws \UnexpectedValueException If the middleware doesn't return a Psr\Http\Message\ResponseInterface
      */
     protected function addMiddleware(callable $callable)
     {
         if ($this->middlewareLock) {
-            throw new RuntimeException('Middleware can’t be added once the stack is dequeuing');
+            throw new \RuntimeException('Middleware can’t be added once the stack is dequeuing');
         }
 
         if (is_null($this->stack)) {
@@ -66,7 +62,7 @@ trait MiddlewareAwareTrait
         $this->stack[] = function (ServerRequestInterface $req, ResponseInterface $res) use ($callable, $next) {
             $result = call_user_func($callable, $req, $res, $next);
             if ($result instanceof ResponseInterface === false) {
-                throw new UnexpectedValueException(
+                throw new \UnexpectedValueException(
                     'Middleware must return instance of \Psr\Http\Message\ResponseInterface'
                 );
             }
@@ -82,18 +78,18 @@ trait MiddlewareAwareTrait
      *
      * @param callable $kernel The last item to run as middleware
      *
-     * @throws RuntimeException if the stack is seeded more than once
+     * @throws \RuntimeException if the stack is seeded more than once
      */
     protected function seedMiddlewareStack(callable $kernel = null)
     {
         if (!is_null($this->stack)) {
-            throw new RuntimeException('MiddlewareStack can only be seeded once.');
+            throw new \RuntimeException('MiddlewareStack can only be seeded once.');
         }
         if ($kernel === null) {
             $kernel = $this;
         }
-        $this->stack = new SplStack;
-        $this->stack->setIteratorMode(SplDoublyLinkedList::IT_MODE_LIFO | SplDoublyLinkedList::IT_MODE_KEEP);
+        $this->stack = new \SplStack;
+        $this->stack->setIteratorMode(\SplDoublyLinkedList::IT_MODE_LIFO | \SplDoublyLinkedList::IT_MODE_KEEP);
         $this->stack[] = $kernel;
     }
 

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -97,6 +97,7 @@ abstract class Routable
     /**
      * Set the route pattern
      *
+     * @param $newPattern string
      * @set string
      */
     public function setPattern($newPattern)

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -8,10 +8,8 @@
  */
 namespace Slim;
 
-use Exception;
-use InvalidArgumentException;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Slim\Handlers\Strategies\RequestResponse;
 use Slim\Interfaces\InvocationStrategyInterface;
 use Slim\Interfaces\RouteInterface;
@@ -177,12 +175,12 @@ class Route extends Routable implements RouteInterface
      *
      * @param boolean|string $mode
      *
-     * @throws InvalidArgumentException If an unknown buffering mode is specified
+     * @throws \InvalidArgumentException If an unknown buffering mode is specified
      */
     public function setOutputBuffering($mode)
     {
         if (!in_array($mode, [false, 'prepend', 'append'], true)) {
-            throw new InvalidArgumentException('Unknown output buffering mode');
+            throw new \InvalidArgumentException('Unknown output buffering mode');
         }
         $this->outputBuffering = $mode;
     }
@@ -194,12 +192,12 @@ class Route extends Routable implements RouteInterface
      *
      * @return self
      *
-     * @throws InvalidArgumentException if the route name is not a string
+     * @throws \InvalidArgumentException if the route name is not a string
      */
     public function setName($name)
     {
         if (!is_string($name)) {
-            throw new InvalidArgumentException('Route name must be a string');
+            throw new \InvalidArgumentException('Route name must be a string');
         }
         $this->name = $name;
         return $this;
@@ -324,7 +322,7 @@ class Route extends Routable implements RouteInterface
                 ob_start();
                 $newResponse = $handler($this->callable, $request, $response, $this->arguments);
                 $output = ob_get_clean();
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
                 ob_end_clean();
                 throw $e;
             }

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -8,7 +8,6 @@
  */
 namespace Slim;
 
-use Closure;
 use Slim\Interfaces\RouteGroupInterface;
 
 /**
@@ -38,7 +37,7 @@ class RouteGroup extends Routable implements RouteGroupInterface
     public function __invoke(App $app = null)
     {
         $callable = $this->resolveCallable($this->callable);
-        if ($callable instanceof Closure && $app !== null) {
+        if ($callable instanceof \Closure && $app !== null) {
             $callable = $callable->bindTo($app);
         }
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -8,17 +8,15 @@
  */
 namespace Slim;
 
+use FastRoute\DataGenerator;
 use FastRoute\Dispatcher;
-use InvalidArgumentException;
-use RuntimeException;
-use Psr\Http\Message\ServerRequestInterface;
 use FastRoute\RouteCollector;
 use FastRoute\RouteParser;
 use FastRoute\RouteParser\Std as StdParser;
-use FastRoute\DataGenerator;
+use Psr\Http\Message\ServerRequestInterface;
 use Slim\Interfaces\RouteGroupInterface;
-use Slim\Interfaces\RouterInterface;
 use Slim\Interfaces\RouteInterface;
+use Slim\Interfaces\RouterInterface;
 
 /**
  * Router
@@ -96,7 +94,7 @@ class Router implements RouterInterface
     public function setBasePath($basePath)
     {
         if (!is_string($basePath)) {
-            throw new InvalidArgumentException('Router basePath must be a string');
+            throw new \InvalidArgumentException('Router basePath must be a string');
         }
 
         $this->basePath = $basePath;
@@ -114,13 +112,13 @@ class Router implements RouterInterface
     public function setCacheFile($cacheFile)
     {
         if (!is_string($cacheFile) && $cacheFile !== false) {
-            throw new InvalidArgumentException('Router cacheFile must be a string or false');
+            throw new \InvalidArgumentException('Router cacheFile must be a string or false');
         }
 
         $this->cacheFile = $cacheFile;
 
         if ($cacheFile !== false && !is_writable(dirname($cacheFile))) {
-            throw new RuntimeException('Router cacheFile directory must be writable');
+            throw new \RuntimeException('Router cacheFile directory must be writable');
         }
 
 
@@ -136,12 +134,12 @@ class Router implements RouterInterface
      *
      * @return RouteInterface
      *
-     * @throws InvalidArgumentException if the route pattern isn't a string
+     * @throws \InvalidArgumentException if the route pattern isn't a string
      */
     public function map($methods, $pattern, $handler)
     {
         if (!is_string($pattern)) {
-            throw new InvalidArgumentException('Route pattern must be a string');
+            throw new \InvalidArgumentException('Route pattern must be a string');
         }
 
         // Prepend parent group pattern(s)
@@ -233,7 +231,7 @@ class Router implements RouterInterface
      *
      * @return Route
      *
-     * @throws RuntimeException   If named route does not exist
+     * @throws \RuntimeException   If named route does not exist
      */
     public function getNamedRoute($name)
     {
@@ -242,7 +240,7 @@ class Router implements RouterInterface
                 return $route;
             }
         }
-        throw new RuntimeException('Named route does not exist for name: ' . $name);
+        throw new \RuntimeException('Named route does not exist for name: ' . $name);
     }
     
     /**
@@ -250,7 +248,7 @@ class Router implements RouterInterface
      *
      * @param string $name        Route name
      *
-     * @throws RuntimeException   If named route does not exist
+     * @throws \RuntimeException   If named route does not exist
      */
     public function removeNamedRoute($name)
     {
@@ -307,7 +305,7 @@ class Router implements RouterInterface
     public function lookupRoute($identifier)
     {
         if (!isset($this->routes[$identifier])) {
-            throw new RuntimeException('Route not found, looks like your route cache is stale.');
+            throw new \RuntimeException('Route not found, looks like your route cache is stale.');
         }
         return $this->routes[$identifier];
     }
@@ -321,8 +319,8 @@ class Router implements RouterInterface
      *
      * @return string
      *
-     * @throws RuntimeException         If named route does not exist
-     * @throws InvalidArgumentException If required data not provided
+     * @throws \RuntimeException         If named route does not exist
+     * @throws \InvalidArgumentException If required data not provided
      */
     public function relativePathFor($name, array $data = [], array $queryParams = [])
     {
@@ -364,7 +362,7 @@ class Router implements RouterInterface
         }
 
         if (empty($segments)) {
-            throw new InvalidArgumentException('Missing data for URL segment: ' . $segmentName);
+            throw new \InvalidArgumentException('Missing data for URL segment: ' . $segmentName);
         }
         $url = implode('', $segments);
 
@@ -385,8 +383,8 @@ class Router implements RouterInterface
      *
      * @return string
      *
-     * @throws RuntimeException         If named route does not exist
-     * @throws InvalidArgumentException If required data not provided
+     * @throws \RuntimeException         If named route does not exist
+     * @throws \InvalidArgumentException If required data not provided
      */
     public function pathFor($name, array $data = [], array $queryParams = [])
     {
@@ -410,8 +408,8 @@ class Router implements RouterInterface
      *
      * @return string
      *
-     * @throws RuntimeException         If named route does not exist
-     * @throws InvalidArgumentException If required data not provided
+     * @throws \RuntimeException         If named route does not exist
+     * @throws \InvalidArgumentException If required data not provided
      */
     public function urlFor($name, array $data = [], array $queryParams = [])
     {


### PR DESCRIPTION
Fixes:
- Remove import for classes from global namespace
- Remove imports for classes which actually in the same namespace
- Correct code due to previous point
- Remove obsolete `use`s
- Order uses alphabetically
