### PR TITLE
Add parameter to Container::get() to allow it to return false if a re…

### DIFF
--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -110,15 +110,19 @@ class Container extends PimpleContainer implements ContainerInterface
      * Finds an entry of the container by its identifier and returns it.
      *
      * @param string $id Identifier of the entry to look for.
+     * @param bool $throwExceptionIfNotFound Whether or not to throw an exception if the requested entry is not found (default=true)
      *
      * @throws ContainerValueNotFoundException  No entry was found for this identifier.
      * @throws ContainerException               Error while retrieving the entry.
      *
      * @return mixed Entry.
      */
-    public function get($id)
+    public function get($id, $throwExceptionIfNotFound=true)
     {
         if (!$this->offsetExists($id)) {
+            if (!$throwExceptionIfNotFound) {
+                return false;
+            }
             throw new ContainerValueNotFoundException(sprintf('Identifier "%s" is not defined.', $id));
         }
         try {


### PR DESCRIPTION
…quested entry is not found

There may be instances where you wish to check if a requested container entry already exists. While this is currently possible with a try/catch block, this patch makes this easier by allowing the function to return false instead of throwing an exception. This change is backwards compatible and should not introduce any issues.
