### PR TITLE
Do not check streams with is_writable in UploadedFile::moveTo()

### DIFF
--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -226,11 +226,11 @@ class UploadedFile implements UploadedFileInterface
             throw new RuntimeException('Uploaded file already moved');
         }
 
-        if (!is_writable(dirname($targetPath))) {
+        $targetIsStream = strpos($targetPath, '://') > 0;
+        if (!$targetIsStream && !is_writable(dirname($targetPath))) {
             throw new InvalidArgumentException('Upload target path is not writable');
         }
 
-        $targetIsStream = strpos($targetPath, '://') > 0;
         if ($targetIsStream) {
             if (!copy($this->file, $targetPath)) {
                 throw new RuntimeException(sprintf('Error moving uploaded file %1s to %2s', $this->name, $targetPath));

--- a/tests/Http/UploadedFilesTest.php
+++ b/tests/Http/UploadedFilesTest.php
@@ -198,9 +198,6 @@ class UploadedFilesTest extends \PHPUnit_Framework_TestCase
         $uploadedFile->getStream();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testMoveToStream()
     {
         $uploadedFile = $this->generateNewTmpFile();


### PR DESCRIPTION
This is a bug reported by @dopesong while adding tests for the UploadedFile implementation in #1920 
