### PR TITLE
Fix url mismatch when the base path contains a space

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -197,7 +197,8 @@ class Uri implements UriInterface
         }
 
         // Path
-        $requestScriptName = parse_url($env->get('SCRIPT_NAME'), PHP_URL_PATH);
+        $envScriptName = str_replace(' ', '%20', $env->get('SCRIPT_NAME'));
+        $requestScriptName = parse_url($envScriptName, PHP_URL_PATH);
         $requestScriptDir = dirname($requestScriptName);
 
         // parse_url() requires a full URL. As we don't extract the domain name or scheme,

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -197,13 +197,13 @@ class Uri implements UriInterface
         }
 
         // Path
-        $envScriptName = str_replace(' ', '%20', $env->get('SCRIPT_NAME'));
-        $requestScriptName = parse_url($envScriptName, PHP_URL_PATH);
+        $requestScriptName = parse_url($env->get('SCRIPT_NAME'), PHP_URL_PATH);
         $requestScriptDir = dirname($requestScriptName);
 
         // parse_url() requires a full URL. As we don't extract the domain name or scheme,
         // we use a stand-in.
         $requestUri = parse_url('http://example.com' . $env->get('REQUEST_URI'), PHP_URL_PATH);
+        $requestUri = rawurldecode($requestUri);
 
         $basePath = '';
         $virtualPath = $requestUri;

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -558,15 +558,15 @@ class UriTest extends \PHPUnit_Framework_TestCase
     public function testCreateEnvironmentWithBasePathContainingSpace()
     {
         $environment = Environment::mock([
-            'SCRIPT_NAME' => '/foo bar/index.php',
-            'REQUEST_URI' => '/foo%20bar/baz',
+            'SCRIPT_NAME' => "/f'oo bar/index.php",
+            'REQUEST_URI' => "/f'oo%20bar/baz",
         ]);
         $uri = Uri::createFromEnvironment($environment);
 
-        $this->assertEquals('/foo%20bar', $uri->getBasePath());
+        $this->assertEquals("/f%27oo%20bar", $uri->getBasePath());
         $this->assertEquals('baz', $uri->getPath());
 
-        $this->assertEquals('http://localhost/foo%20bar/baz', (string) $uri);
+        $this->assertEquals('http://localhost/f%27oo%20bar/baz', (string) $uri);
     }
 
     public function testGetBaseUrl()

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -555,6 +555,20 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://localhost/foo/bar', (string) $uri);
     }
 
+    public function testCreateEnvironmentWithBasePathContainingSpace()
+    {
+        $environment = Environment::mock([
+            'SCRIPT_NAME' => '/foo bar/index.php',
+            'REQUEST_URI' => '/foo%20bar/baz',
+        ]);
+        $uri = Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('/foo%20bar', $uri->getBasePath());
+        $this->assertEquals('baz', $uri->getPath());
+
+        $this->assertEquals('http://localhost/foo%20bar/baz', (string) $uri);
+    }
+
     public function testGetBaseUrl()
     {
         $environment = Environment::mock([


### PR DESCRIPTION
Related to this issue:
http://discourse.slimframework.com/t/how-to-use-routes-well/573

When the application has a base path that contains a space the base path will not be set correctly. This is because in the `REQUEST_URI` the space is rawurlencoded and in the `SCRIPT_NAME` it is not.

This behavour can be seen in his example, and I also tested this om my pc.

``` php
array(
 'REQUEST_URI' => "/PHP/Lumy%203/tests/",
 'SCRIPT_NAME' => "/PHP/Lumy 3/tests/index.php",
);
```

I could not simply `rawurlencode` the entire `SCRIPT_NAME` as slashes must remain untouched.

To fix this particular issue I just replaced the space, but there may be other characters that should be encoded.
