### PR TITLE
Add HTTP 111: Connection Refused

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -50,6 +50,7 @@ class Response extends Message implements ResponseInterface
         100 => 'Continue',
         101 => 'Switching Protocols',
         102 => 'Processing',
+        111 => 'Connection Refused',
         //Successful 2xx
         200 => 'OK',
         201 => 'Created',


### PR DESCRIPTION
Ran into this when attempting to connect to a turned-off Redis server using the Predis library through Slim. This was the HTTP error code that was returned, and Slim triggered the `phpErrorHandler` against its own code because this was missing from the list.

I had never heard of this error code before, and I could not find it in [RFC 2616](https://tools.ietf.org/html/rfc2616) or [RFC 6585](https://tools.ietf.org/html/rfc6585). But apparently it's quite common. [Google: http error 111](https://www.google.com/search?q=http+error+111).

---

Here is the Exception that was logged. Cleaned-up for readability.

``` plain
[06-Aug-2016 05:04:22 UTC] PHP Fatal error:  Uncaught InvalidArgumentException: ReasonPhrase must be supplied for this code in /vagrant/vendor/slim/slim/Slim/Http/Response.php:194

Stack trace:
#0 /vagrant/vendor/slim/slim/Slim/Http/Response.php(321): Slim\Http\Response->withStatus(111)
#1 /vagrant/src/Application/EventHandler/Error/ErrorHandler.php(49): Slim\Http\Response->withJson(Array, 111, 450)
#2 [internal function]: Application\EventHandler\Error\ErrorHandler->Application\EventHandler\Error\{closure}(Object(Slim\Http\Request), Object(Slim\Http\Response), Object(Predis\Connection\ConnectionException))
#3 /vagrant/vendor/slim/slim/Slim/App.php(613): call_user_func_array(Object(Closure), Array)
#4 /vagrant/vendor/slim/slim/Slim/App.php(339): Slim\App->handleException(Object(Predis\Connection\ConnectionException), Object(Slim\Http\Request), Object(Slim\Http\Response))
#5 /vagrant/vendor/slim/slim/Slim/App.php(298): Slim\App->process(Object(Slim\Http\Request), Object(Slim\Http\Response))
#6 /vagrant/bootstrap.php(127): Slim\App->run()
#7 /vagrant/publi in /vagrant/vendor/slim/slim/Slim/Http/Response.php on line 194
```

---

Running on PHP 7.0.9. Slim Framework 3.5.0. Here is a snippet from `composer.lock`:

``` plain
"name": "slim/slim",
"version": "3.5.0",
"source": {
    "type": "git",
    "url": "https://github.com/slimphp/Slim.git",
    "reference": "184352bc1913d7ba552ab4131d62f4730ddb0893"
},
```
