### PR TITLE
Add getServerParam method

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -849,6 +849,22 @@ class Request extends Message implements ServerRequestInterface
         return $this->serverParams;
     }
 
+    /**
+     * Retrieve a server parameter.
+     *
+     * Note: This method is not part of the PSR-7 standard.
+     *
+     * @param  string $key
+     * @param  mixed  $default
+     * @return mixed
+     */
+    public function getServerParam($key, $default = null)
+    {
+        $serverParams = $this->getServerParams();
+
+        return isset($serverParams[$key]) ? $serverParams[$key] : $default;
+    }
+
     /*******************************************************************************
      * Attributes
      ******************************************************************************/

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -639,6 +639,21 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testGetServerParam()
+    {
+        $shouldBe = 'HTTP/1.1';
+        $request = $this->requestFactory(['SERVER_PROTOCOL' => 'HTTP/1.1']);
+
+        $this->assertEquals($shouldBe, $this->requestFactory()->getServerParam('SERVER_PROTOCOL'));
+    }
+
+    public function testGetServerParamWithDefault()
+    {
+        $shouldBe = 'bar';
+
+        $this->assertEquals($shouldBe, $this->requestFactory()->getServerParam('HTTP_NOT_EXIST', 'bar'));
+    }
+
     /*******************************************************************************
      * File Params
      ******************************************************************************/


### PR DESCRIPTION
Add getServerParam method to `Slim\Http\Request`.

It's inconvenient to use server params without a method to get single parameter from $_SERVER.
Just like getCookieParam() to getCookieParams() , getParsedBodyParam() to getParsedBodyParams().
