### PR TITLE
Add leading slash if missing in route patterns

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -143,6 +143,9 @@ class Router implements RouterInterface
             throw new InvalidArgumentException('Route pattern must be a string');
         }
 
+        // Ensure pattern has a leading slash
+        $pattern = '/' . ltrim($pattern, '/');
+
         // Prepend parent group pattern(s)
         if ($this->routeGroups) {
             $pattern = $this->processGroups() . $pattern;
@@ -297,6 +300,9 @@ class Router implements RouterInterface
      */
     public function pushGroup($pattern, $callable)
     {
+        // Ensure pattern has a leading slash
+        $pattern = '/' . ltrim($pattern, '/');
+
         $group = new RouteGroup($pattern, $callable);
         array_push($this->routeGroups, $group);
         return $group;


### PR DESCRIPTION
This PR allows to omit the leading slash when defining routes.

For the record, I have a lot of routes like so:

``` php
$app->get('/about', function () {
    return view('about');
});
```
