### PR TITLE
Ensure withJson returns a new Response

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -306,16 +306,16 @@ class Response extends Message implements ResponseInterface
      */
     public function withJson($data, $status = null, $encodingOptions = 0)
     {
-        $body = $this->getBody();
-        $body->rewind();
-        $body->write($json = json_encode($data, $encodingOptions));
+        $clone = clone $this;
+        $clone->body = new Body(fopen('php://temp', 'w+'));
+        $clone->body->write($json = json_encode($data, $encodingOptions));
 
         // Ensure that the json encoding passed successfully
         if ($json === false) {
             throw new \RuntimeException(json_last_error_msg(), json_last_error());
         }
 
-        $responseWithJson = $this->withHeader('Content-Type', 'application/json;charset=utf-8');
+        $responseWithJson = $clone->withHeader('Content-Type', 'application/json;charset=utf-8');
         if (isset($status)) {
             return $responseWithJson->withStatus($status);
         }

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -306,16 +306,15 @@ class Response extends Message implements ResponseInterface
      */
     public function withJson($data, $status = null, $encodingOptions = 0)
     {
-        $clone = clone $this;
-        $clone->body = new Body(fopen('php://temp', 'w+'));
-        $clone->body->write($json = json_encode($data, $encodingOptions));
+        $response = $this->withBody(new Body(fopen('php://temp', 'r+')));
+        $response->body->write($json = json_encode($data, $encodingOptions));
 
         // Ensure that the json encoding passed successfully
         if ($json === false) {
             throw new \RuntimeException(json_last_error_msg(), json_last_error());
         }
 
-        $responseWithJson = $clone->withHeader('Content-Type', 'application/json;charset=utf-8');
+        $responseWithJson = $response->withHeader('Content-Type', 'application/json;charset=utf-8');
         if (isset($status)) {
             return $responseWithJson->withStatus($status);
         }

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -287,15 +287,23 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         $data = ['foo' => 'bar1&bar2'];
 
-        $response = new Response();
-        $response = $response->withJson($data, 201);
+        $originalResponse = new Response();
+        $response = $originalResponse->withJson($data, 201);
 
+        $this->assertNotEquals($response->getStatusCode(), $originalResponse->getStatusCode());
         $this->assertEquals(201, $response->getStatusCode());
         $this->assertEquals('application/json;charset=utf-8', $response->getHeaderLine('Content-Type'));
 
         $body = $response->getBody();
         $body->rewind();
         $dataJson = $body->getContents(); //json_decode($body->getContents(), true);
+
+        $originalBody = $originalResponse->getBody();
+        $originalBody->rewind();
+        $originalContents = $originalBody->getContents();
+
+        // test the original body hasn't be replaced
+        $this->assertNotEquals($dataJson, $originalContents);
 
         $this->assertEquals('{"foo":"bar1&bar2"}', $dataJson);
         $this->assertEquals($data['foo'], json_decode($dataJson, true)['foo']);
@@ -321,7 +329,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     {
         $data = ['foo' => 'bar'.chr(233)];
         $this->assertEquals('bar'.chr(233), $data['foo']);
-        
+
         $response = new Response();
         $response->withJson($data, 200);
 


### PR DESCRIPTION
Fixes issue #1818. The withJson method now clones the Response, and
updates this with a new header, and a new Body.
