### PR TITLE
use stdClass as a dummy during testing for non-existent classes.

### DIFF
--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -84,7 +84,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetWithErrorThrownByFactoryClosure()
     {
-        $invokable = $this->getMockBuilder('TestClass')->setMethods(['__invoke'])->getMock();
+        $invokable = $this->getMockBuilder('stdClass')->setMethods(['__invoke'])->getMock();
         /** @var \Callable $invokable */
         $invokable->expects($this->any())
             ->method('__invoke')

--- a/tests/DeferredCallableTest.php
+++ b/tests/DeferredCallableTest.php
@@ -22,7 +22,7 @@ class DeferredCallableTest extends \PHPUnit_Framework_TestCase
 
     public function testItBindsClosuresToContainer()
     {
-        $assertCalled = $this->getMock('fooClass', ['foo']);
+        $assertCalled = $this->getMock('stdClass', ['foo']);
         $assertCalled
             ->expects($this->once())
             ->method('foo');


### PR DESCRIPTION
phpunit 5.5.2 on PHP7 complains if non-existent classes are mocked, giving an undefined index error. I have replaced two mock classes that don't exist with stdClass to mitigate this.
