### PR TITLE
replaced deprecated getMock calls with getMockBuilder equivalents.

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1220,7 +1220,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
-        $mock = $this->getMock('StdClass', ['bar']);
+        $mock = $this->getMockBuilder('StdClass')->setMethods(['bar'])->getMock();
 
         $app = new App();
         $container = $app->getContainer();
@@ -1257,7 +1257,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
-        $mock = $this->getMock('StdClass');
+        $mock = $this->getMockBuilder('StdClass')->getMock();
 
         $app = new App();
         $container = $app->getContainer();
@@ -1589,7 +1589,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $app->respond($response);
         $this->expectOutputString("Hello");
     }
-    
+
     public function testResponseWithStreamReadYieldingLessBytesThanAsked()
     {
         $app = new App([
@@ -1597,7 +1597,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
         ]);
         $app->get('/foo', function ($req, $res) {
             $res->write('Hello');
-            
+
             return $res;
         });
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -84,7 +84,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetWithErrorThrownByFactoryClosure()
     {
-        $invokable = $this->getMockBuilder('TestClass')->setMethods(['__invoke'])->getMock();
+        $invokable = $this->getMockBuilder('StdClass')->setMethods(['__invoke'])->getMock();
         /** @var \Callable $invokable */
         $invokable->expects($this->any())
             ->method('__invoke')

--- a/tests/DeferredCallableTest.php
+++ b/tests/DeferredCallableTest.php
@@ -22,7 +22,7 @@ class DeferredCallableTest extends \PHPUnit_Framework_TestCase
 
     public function testItBindsClosuresToContainer()
     {
-        $assertCalled = $this->getMock('fooClass', ['foo']);
+        $assertCalled = $this->getMockBuilder('StdClass')->setMethods(['foo'])->getMock();
         $assertCalled
             ->expects($this->once())
             ->method('foo');

--- a/tests/Handlers/ErrorTest.php
+++ b/tests/Handlers/ErrorTest.php
@@ -64,7 +64,7 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
 
     public function testNotFoundContentType()
     {
-        $errorMock = $this->getMock(Error::class, ['determineContentType']);
+        $errorMock = $this->getMockBuilder(Error::class)->setMethods(['determineContentType'])->getMock();
         $errorMock->method('determineContentType')
             ->will($this->returnValue('unknown/type'));
 
@@ -82,7 +82,7 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
      */
     public function testPreviousException()
     {
-        $error = $this->getMock('\Slim\Handlers\Error', ['logError']);
+        $error = $this->getMockBuilder('\Slim\Handlers\Error')->setMethods(['logError'])->getMock();
         $error->expects($this->once())->method('logError')->with(
             $this->logicalAnd(
                 $this->stringContains("Type: Exception\nMessage: Second Oops"),

--- a/tests/Handlers/NotAllowedTest.php
+++ b/tests/Handlers/NotAllowedTest.php
@@ -55,10 +55,10 @@ class NotAllowedTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($res->hasHeader('Allow'));
         $this->assertEquals('POST, PUT', $res->getHeaderLine('Allow'));
     }
-    
+
     public function testNotFoundContentType()
     {
-        $errorMock = $this->getMock(NotAllowed::class, ['determineContentType']);
+        $errorMock = $this->getMockBuilder(NotAllowed::class)->setMethods(['determineContentType'])->getMock();
         $errorMock->method('determineContentType')
             ->will($this->returnValue('unknown/type'));
 

--- a/tests/Handlers/NotFoundTest.php
+++ b/tests/Handlers/NotFoundTest.php
@@ -45,7 +45,7 @@ class NotFoundTest extends \PHPUnit_Framework_TestCase
 
     public function testNotFoundContentType()
     {
-        $errorMock = $this->getMock(NotFound::class, ['determineContentType']);
+        $errorMock = $this->getMockBuilder(NotFound::class)->setMethods(['determineContentType'])->getMock();
         $errorMock->method('determineContentType')
             ->will($this->returnValue('unknown/type'));
 

--- a/tests/Handlers/PhpErrorTest.php
+++ b/tests/Handlers/PhpErrorTest.php
@@ -69,7 +69,7 @@ class PhpErrorTest extends \PHPUnit_Framework_TestCase
      */
     public function testNotFoundContentType()
     {
-        $errorMock = $this->getMock(PhpError::class, ['determineContentType']);
+        $errorMock = $this->getMockBuilder(PhpError::class)->setMethods(['determineContentType'])->getMock();
         $errorMock->method('determineContentType')
             ->will($this->returnValue('unknown/type'));
 

--- a/tests/MiddlewareAwareTest.php
+++ b/tests/MiddlewareAwareTest.php
@@ -147,8 +147,8 @@ class MiddlewareAwareTest extends \PHPUnit_Framework_TestCase
         });
         $this->setExpectedException('RuntimeException');
         $stack->callMiddlewareStack(
-            $this->getMock('Psr\Http\Message\ServerRequestInterface'),
-            $this->getMock('Psr\Http\Message\ResponseInterface')
+            $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->disableOriginalConstructor()->getMock()
         );
     }
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -418,7 +418,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $queryParams = ['a' => 'b', 'c' => 'd'];
 
         //create a router that mocks the pathFor with expected args
-        $router = $this->getMock('\Slim\Router', ['pathFor']);
+        $router = $this->getMockBuilder('\Slim\Router')->setMethods(['pathFor'])->getMock();
         $router->expects($this->once())->method('pathFor')->with($name, $data, $queryParams);
         $router->urlFor($name, $data, $queryParams);
 


### PR DESCRIPTION
This replaces deprecated shortcut getMock methods in the tests and replaces them with long form getMockBuilder based equivalents.
