### PR TITLE
argument should be rawurldecode, not urldecode. 

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -515,7 +515,7 @@ class App
         if ($routeInfo[0] === Dispatcher::FOUND) {
             $routeArguments = [];
             foreach ($routeInfo[2] as $k => $v) {
-                $routeArguments[$k] = urldecode($v);
+                $routeArguments[$k] = rawurldecode($v);
             }
 
             $route = $router->lookupRoute($routeInfo[1]);


### PR DESCRIPTION
in rfc2396.

>    The plus "+", dollar "$", and comma "," characters have been added to
>   those in the "reserved" set, since they are treated as reserved
>   within the query component.
> So reserved chars should be bypassed to users, if in argument field.
