### PR TITLE
Added failing unit test for bad HTTP requests.

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1981,6 +1981,30 @@ class AppTest extends \PHPUnit_Framework_TestCase
     }
 
 
+    /**
+     * If the client provides an unsupported HTTP method (outside the HTTP spec scope), the server should by default respond with 400.
+     * ... and not 405 since that implies the server knows the request method but that it is not allowed on the resource.
+     */
+    public function testUnsupportedMethodUsedByClient() {
+
+        // Prepare request and response objects
+        $env = Environment::mock([
+            'REQUEST_URI' => '/',
+            'REQUEST_METHOD' => 'BADMTHD',
+        ]);
+
+        $req = Request::createFromEnvironment($env);
+        $res = new Response();
+        $app = new App();
+
+        // Invoke app
+        $resOut = $app($req, $res);
+
+        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
+        $this->assertEquals(400, $resOut->getStatusCode());
+
+    }
+
     public function testContainerSetToRoute()
     {
         // Prepare request and response objects

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1982,6 +1982,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testUnsupportedMethodUsedByClient()
     {
+        $this->markTestSkipped('Handling of bad methods needs to be fixed first.');
         // Prepare request and response objects
         $env = Environment::mock([
             'REQUEST_URI' => '/',

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1980,13 +1980,8 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $response = $method->invoke($app, $response);
     }
 
-
-    /**
-     * If the client provides an unsupported HTTP method (outside the HTTP spec scope), the server should by default respond with 400.
-     * ... and not 405 since that implies the server knows the request method but that it is not allowed on the resource.
-     */
-    public function testUnsupportedMethodUsedByClient() {
-
+    public function testUnsupportedMethodUsedByClient()
+    {
         // Prepare request and response objects
         $env = Environment::mock([
             'REQUEST_URI' => '/',
@@ -2002,7 +1997,6 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
         $this->assertEquals(400, $resOut->getStatusCode());
-
     }
 
     public function testContainerSetToRoute()


### PR DESCRIPTION
Hello

As requested I have written a failing unit test to illustrate the issue with an unsupported method used by clients.

Currently this results in a code 500 error on an "out-of-the-box" Slim deployment, which is not ideal.

Issue: https://github.com/slimphp/Slim/issues/2005