### PR TITLE
Reuse getParsedBodyParam for determining method override in POST body.

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -248,12 +248,9 @@ class Request extends Message implements ServerRequestInterface
             if ($customMethod) {
                 $this->method = $this->filterMethod($customMethod);
             } elseif ($this->originalMethod === 'POST') {
-                $body = $this->getParsedBody();
-
-                if (is_object($body) && property_exists($body, '_METHOD')) {
-                    $this->method = $this->filterMethod((string)$body->_METHOD);
-                } elseif (is_array($body) && isset($body['_METHOD'])) {
-                    $this->method = $this->filterMethod((string)$body['_METHOD']);
+                $overrideMethod = $this->getParsedBodyParam('_METHOD');
+                if ($overrideMethod !== null) {
+                    $this->method = $overrideMethod;
                 }
 
                 if ($this->getBody()->eof()) {


### PR DESCRIPTION
Makes `getMethod()` internally use `getParsedBodyParam()` for determining the value of `_METHOD` in the request body, for purposes of overriding the body.

Question though: wouldn't this type of method-juggling be more appropriately implemented as a middleware rather than living in the core Request object logic, so it becomes an opt-in behaviour?