### PR TITLE
Improve request parsing with invalid json

### DIFF
--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -751,6 +751,36 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'bar'], $request->getParsedBody());
     }
 
+    public function testGetParsedBodyInvalidJson()
+    {
+        $method = 'GET';
+        $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
+        $headers = new Headers();
+        $headers->set('Content-Type', 'application/json;charset=utf8');
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('{foo}bar');
+        $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
+
+        $this->assertNull($request->getParsedBody());
+    }
+
+    public function testGetParsedBodySemiValidJson()
+    {
+        $method = 'GET';
+        $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
+        $headers = new Headers();
+        $headers->set('Content-Type', 'application/json;charset=utf8');
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('"foo bar"');
+        $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
+
+        $this->assertNull($request->getParsedBody());
+    }
+
     public function testGetParsedBodyWithJsonStructuredSuffix()
     {
         $method = 'GET';


### PR DESCRIPTION
Slim throws a runtime exception if json Request sends "semi valid" json code.

Here you expect json parsing to be an object, array or null:
[https://github.com/slimphp/Slim/blob/3.x/Slim/Http/Request.php#L1015](https://github.com/slimphp/Slim/blob/3.x/Slim/Http/Request.php#L1015)

If i send invalid json everything is fine, because the result ist null. If i send "semi valid" json like `"foobar"`
the runtime exception gets triggered.
The Problem is that the php function json_decode ([called here](https://github.com/slimphp/Slim/blob/3.x/Slim/Http/Request.php#L197)) decodes a little more than valid json as mentioned here:
[http://php.net/manual/en/function.json-decode.php](http://php.net/manual/en/function.json-decode.php)
So `"foobar"` gets decoded as string, which is not an object, array or null.

I think ether you should accept "semi valid" json as result like php does or you should handle it like invalid json (i think better). But a RuntimeException looks totally wrong here.

I don't know how this should be fixed. The pull request just has tests for what i would expect.