### PR TITLE
Remove App::VERSION

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -46,13 +46,6 @@ class App
     use MiddlewareAwareTrait;
 
     /**
-     * Current version
-     *
-     * @var string
-     */
-    const VERSION = '3.7.0-dev';
-
-    /**
      * Container
      *
      * @var ContainerInterface

--- a/tests/Handlers/ErrorTest.php
+++ b/tests/Handlers/ErrorTest.php
@@ -85,8 +85,8 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
         $error = $this->getMockBuilder('\Slim\Handlers\Error')->setMethods(['logError'])->getMock();
         $error->expects($this->once())->method('logError')->with(
             $this->logicalAnd(
-                $this->stringContains("Type: Exception\nMessage: Second Oops"),
-                $this->stringContains("Previous Error:\nType: Exception\nMessage: First Oops")
+                $this->stringContains("Message: Second Oops"),
+                $this->stringContains("Previous Error:" . PHP_EOL . "Type: Exception" . PHP_EOL . "Message: First Oops")
             )
         );
 


### PR DESCRIPTION
Removes VERSION constant which was never updated.

Also fixes a Error Handler unit test that assumed unix line returns, which was not true when executed on Windows systems.

Fixes #2058 