### PR TITLE
2.x - Allow for mcrypt polyfils

### DIFF
--- a/Slim/Slim.php
+++ b/Slim/Slim.php
@@ -33,10 +33,8 @@
 namespace Slim;
 
 // Ensure mcrypt constants are defined even if mcrypt extension is not loaded
-if (!extension_loaded('mcrypt')) {
-    define('MCRYPT_MODE_CBC', 0);
-    define('MCRYPT_RIJNDAEL_256', 0);
-}
+if (!defined('MCRYPT_MODE_CBC')) define('MCRYPT_MODE_CBC', 0);
+if (!defined('MCRYPT_RIJNDAEL_256')) define('MCRYPT_RIJNDAEL_256', 0);
 
 /**
  * Slim

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": ">=5.3.0"
     },
     "suggest": {
-        "ext-mcrypt": "Required for HTTP cookie encryption"
+        "ext-mcrypt": "Required for HTTP cookie encryption",
+        "phpseclib/mcrypt_compat": "Polyfil for mcrypt extension"
     },
     "autoload": {
         "psr-0": { "Slim": "." }


### PR DESCRIPTION
The php extension mcrypt has been deprectated in php 7.1, and as such users may be using a polyfil instead of the extension. In those cases the constants will exist but the extension won't be loaded, resulting in the constant attempting to be redefined and a Notice been thrown.