### PR TITLE
adding MOCK_POST_DATA variable to `Environment`

### DIFF
--- a/Slim/Http/Environment.php
+++ b/Slim/Http/Environment.php
@@ -45,6 +45,7 @@ class Environment extends Collection implements EnvironmentInterface
             'REMOTE_ADDR'          => '127.0.0.1',
             'REQUEST_TIME'         => time(),
             'REQUEST_TIME_FLOAT'   => microtime(true),
+            'MOCK_POST_DATA'       => null
         ], $userData);
 
         return new static($data);

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -146,7 +146,8 @@ class Request extends Message implements ServerRequestInterface
         $request = new static($method, $uri, $headers, $cookies, $serverParams, $body, $uploadedFiles);
 
         if ($method === 'POST' &&
-            in_array($request->getMediaType(), ['application/x-www-form-urlencoded', 'multipart/form-data'])
+            in_array($request->getMediaType(), ['application/x-www-form-urlencoded', 'multipart/form-data']) &&
+            !$environment["MOCK_POST_DATA"]
         ) {
             // parsed body must be $_POST
             $request = $request->withParsedBody($_POST);

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -140,7 +140,7 @@ class Request extends Message implements ServerRequestInterface
         $headers = Headers::createFromEnvironment($environment);
         $cookies = Cookies::parseHeader($headers->get('Cookie', []));
         $serverParams = $environment->all();
-        $body = new RequestBody();
+        $body = new RequestBody($environment);
         $uploadedFiles = UploadedFile::createFromEnvironment($environment);
 
         $request = new static($method, $uri, $headers, $cookies, $serverParams, $body, $uploadedFiles);

--- a/Slim/Http/RequestBody.php
+++ b/Slim/Http/RequestBody.php
@@ -15,11 +15,17 @@ class RequestBody extends Body
 {
     /**
      * Create a new RequestBody.
+     *
+     * @param Environment $environment The Slim application Environment
      */
-    public function __construct()
+    public function __construct(Environment $environment = null)
     {
         $stream = fopen('php://temp', 'w+');
-        stream_copy_to_stream(fopen('php://input', 'r'), $stream);
+        if ($environment != null && $environment["MOCK_POST_DATA"] != null) {
+            fwrite($stream, $environment["MOCK_POST_DATA"]);
+        } else {
+            stream_copy_to_stream(fopen('php://input', 'r'), $stream);
+        }
         rewind($stream);
 
         parent::__construct($stream);

--- a/tests/Http/EnvironmentTest.php
+++ b/tests/Http/EnvironmentTest.php
@@ -9,6 +9,7 @@
 namespace Slim\Tests\Http;
 
 use Slim\Http\Environment;
+use Slim\Http\Request;
 
 class EnvironmentTest extends \PHPUnit_Framework_TestCase
 {
@@ -54,5 +55,18 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/foo/bar/index.php', $env->get('SCRIPT_NAME'));
         $this->assertEquals('/foo/bar?abc=123', $env->get('REQUEST_URI'));
         $this->assertEquals('localhost', $env->get('HTTP_HOST'));
+    }
+
+    /**
+     * Test mock post data
+     */
+    public function testMockPostData()
+    {
+        $env = Environment::mock([
+            'MOCK_POST_DATA' => 'data'
+        ]);
+
+        $request = Request::createFromEnvironment($env);
+        $this->assertEquals($request->getBody(),"data");
     }
 }

--- a/tests/Http/EnvironmentTest.php
+++ b/tests/Http/EnvironmentTest.php
@@ -67,6 +67,6 @@ class EnvironmentTest extends \PHPUnit_Framework_TestCase
         ]);
 
         $request = Request::createFromEnvironment($env);
-        $this->assertEquals($request->getBody(),"data");
+        $this->assertEquals($request->getBody(), "data");
     }
 }


### PR DESCRIPTION
I need to mock the POST request body (for unit testing). Relevant stackoverflow question: http://stackoverflow.com/questions/40867377/mock-slim-endpoint-post-requests-with-phpunit
I'm aware of https://github.com/slimphp/Slim/issues/1955, but the solution provided there can not be used to test endpoints (as the `Request` is manually contructed).

It seems as this is impossible with Slim 3 so far (as the RequestBody directly reads from php://input which is read only). I therefore made this pull request to enable this behaviour.

What I've done:
 - I've added a new variable `MOCK_POST_DATA` to the environment
 - I'm passing the `Environment` to the constructor of the `RequestBody`
 - The `RequestBody` constructor checks if `MOCK_POST_DATA` is defined, and uses its value if true
 - I've added a unit test to confirm it works as expected
 - I tried it successfully in an actual project.

Introduced overhead: 
 - The `RequestBody` constructor executes additional logic with each request, even if no testing is done

If there is a better way to archive this functionality I'm very open for suggestions, and will improve the code if necessary.

I'm choosing the 3.x branch for merging as there is currently no development branch, and this change will not break compatibility.