### PR TITLE
Remove application base url concept. Fixes #2054.

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -310,9 +310,6 @@ class App
     {
         // Ensure basePath is set
         $router = $this->container->get('router');
-        if (is_callable([$request->getUri(), 'getBasePath']) && is_callable([$router, 'setBasePath'])) {
-            $router->setBasePath($request->getUri()->getBasePath());
-        }
 
         // Dispatch the Router first if the setting for this is on
         if ($this->container->get('settings')['determineRouteBeforeAppMiddleware'] === true) {

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -469,9 +469,8 @@ class Request extends Message implements ServerRequestInterface
             return '/';
         }
 
-        $basePath = $this->uri->getBasePath();
         $path = $this->uri->getPath();
-        $path = $basePath . '/' . ltrim($path, '/');
+        $path = '/' . ltrim($path, '/');
 
         $query = $this->uri->getQuery();
         if ($query) {

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -70,13 +70,6 @@ class Uri implements UriInterface
     protected $port;
 
     /**
-     * Uri base path
-     *
-     * @var string
-     */
-    protected $basePath = '';
-
-    /**
      * Uri path
      *
      * @var string
@@ -227,9 +220,6 @@ class Uri implements UriInterface
 
         // Build Uri
         $uri = new static($scheme, $host, $port, $virtualPath, $queryString, $fragment, $username, $password);
-        if ($basePath) {
-            $uri = $uri->withBasePath($basePath);
-        }
 
         return $uri;
     }
@@ -558,51 +548,6 @@ class Uri implements UriInterface
         $clone = clone $this;
         $clone->path = $this->filterPath($path);
 
-        // if the path is absolute, then clear basePath
-        if (substr($path, 0, 1) == '/') {
-            $clone->basePath = '';
-        }
-
-        return $clone;
-    }
-
-    /**
-     * Retrieve the base path segment of the URI.
-     *
-     * Note: This method is not part of the PSR-7 standard.
-     *
-     * This method MUST return a string; if no path is present it MUST return
-     * an empty string.
-     *
-     * @return string The base path segment of the URI.
-     */
-    public function getBasePath()
-    {
-        return $this->basePath;
-    }
-
-    /**
-     * Set base path.
-     *
-     * Note: This method is not part of the PSR-7 standard.
-     *
-     * @param  string $basePath
-     * @return self
-     */
-    public function withBasePath($basePath)
-    {
-        if (!is_string($basePath)) {
-            throw new InvalidArgumentException('Uri path must be a string');
-        }
-        if (!empty($basePath)) {
-            $basePath = '/' . trim($basePath, '/'); // <-- Trim on both sides
-        }
-        $clone = clone $this;
-
-        if ($basePath !== '/') {
-            $clone->basePath = $this->filterPath($basePath);
-        }
-
         return $clone;
     }
 
@@ -784,12 +729,11 @@ class Uri implements UriInterface
     {
         $scheme = $this->getScheme();
         $authority = $this->getAuthority();
-        $basePath = $this->getBasePath();
         $path = $this->getPath();
         $query = $this->getQuery();
         $fragment = $this->getFragment();
 
-        $path = $basePath . '/' . ltrim($path, '/');
+        $path = '/' . ltrim($path, '/');
 
         return ($scheme ? $scheme . ':' : '')
             . ($authority ? '//' . $authority : '')
@@ -811,14 +755,8 @@ class Uri implements UriInterface
     {
         $scheme = $this->getScheme();
         $authority = $this->getAuthority();
-        $basePath = $this->getBasePath();
-
-        if ($authority && substr($basePath, 0, 1) !== '/') {
-            $basePath = $basePath . '/' . $basePath;
-        }
 
         return ($scheme ? $scheme . ':' : '')
-            . ($authority ? '//' . $authority : '')
-            . rtrim($basePath, '/');
+            . ($authority ? '//' . $authority : '');
     }
 }

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -272,42 +272,6 @@ class UriTest extends \PHPUnit_Framework_TestCase
      * Path
      *******************************************************************************/
 
-    public function testGetBasePathNone()
-    {
-        $this->assertEquals('', $this->uriFactory()->getBasePath());
-    }
-
-    public function testWithBasePath()
-    {
-        $uri = $this->uriFactory()->withBasePath('/base');
-
-        $this->assertAttributeEquals('/base', 'basePath', $uri);
-    }
-
-    /**
-     * @covers Slim\Http\Uri::withBasePath
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Uri path must be a string
-     */
-    public function testWithBasePathInvalidType()
-    {
-        $this->uriFactory()->withBasePath(['foo']);
-    }
-
-    public function testWithBasePathAddsPrefix()
-    {
-        $uri = $this->uriFactory()->withBasePath('base');
-
-        $this->assertAttributeEquals('/base', 'basePath', $uri);
-    }
-
-    public function testWithBasePathIgnoresSlash()
-    {
-        $uri = $this->uriFactory()->withBasePath('/');
-
-        $this->assertAttributeEquals('', 'basePath', $uri);
-    }
-
     public function testGetPath()
     {
         $this->assertEquals('/foo/bar', $this->uriFactory()->getPath());
@@ -451,9 +415,6 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $uri = $uri->withPath('bar');
         $this->assertEquals('https://josh:sekrit@example.com/bar?abc=123#section3', (string) $uri);
 
-        $uri = $uri->withBasePath('foo/');
-        $this->assertEquals('https://josh:sekrit@example.com/foo/bar?abc=123#section3', (string) $uri);
-
         $uri = $uri->withPath('/bar');
         $this->assertEquals('https://josh:sekrit@example.com/bar?abc=123#section3', (string) $uri);
 
@@ -465,7 +426,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
             'HTTP_HOST' => 'example.com',
         ]);
         $uri = Uri::createFromEnvironment($environment);
-        $this->assertEquals('http://example.com/foo/', (string) $uri);
+        $this->assertEquals('http://example.com/', (string) $uri);
     }
 
     /**
@@ -537,24 +498,6 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $uri->getFragment());
     }
 
-    /**
-     * @covers Slim\Http\Uri::createFromEnvironment
-     * @ticket 1375
-     */
-    public function testCreateEnvironmentWithBasePath()
-    {
-        $environment = Environment::mock([
-            'SCRIPT_NAME' => '/foo/index.php',
-            'REQUEST_URI' => '/foo/bar',
-        ]);
-        $uri = Uri::createFromEnvironment($environment);
-
-        $this->assertEquals('/foo', $uri->getBasePath());
-        $this->assertEquals('bar', $uri->getPath());
-
-        $this->assertEquals('http://localhost/foo/bar', (string) $uri);
-    }
-
     public function testGetBaseUrl()
     {
         $environment = Environment::mock([
@@ -566,7 +509,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
         ]);
         $uri = Uri::createFromEnvironment($environment);
 
-        $this->assertEquals('http://example.com/foo', $uri->getBaseUrl());
+        $this->assertEquals('http://example.com', $uri->getBaseUrl());
     }
 
     public function testGetBaseUrlWithNoBasePath()
@@ -596,7 +539,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
         ]);
         $uri = Uri::createFromEnvironment($environment);
 
-        $this->assertEquals('http://josh:sekrit@example.com:8080/foo', $uri->getBaseUrl());
+        $this->assertEquals('http://josh:sekrit@example.com:8080', $uri->getBaseUrl());
     }
 
     /**
@@ -630,7 +573,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
                 ]
             )
         );
-        $this->assertSame('/foo/index.php', $uri->getBasePath());
+        $this->assertSame('bar/baz', $uri->getPath());
     }
 
     public function testRequestURICanContainParams()


### PR DESCRIPTION
This PR removes the concept of an app-wide "base path". I did leave the Router's base path stuff intact so that one could manually set a base path on the Router object... seemed like the logical thing to do,  but I do encourage feedback and careful review on this PR before merge.

Thanks!

/cc @akrabat @silentworks 