### PR TITLE
Fixed return type in phpdoc

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1134,7 +1134,7 @@ class Request extends Message implements ServerRequestInterface
      * @param      $key
      * @param null $default
      *
-     * @return null
+     * @return mixed
      */
     public function getParsedBodyParam($key, $default = null)
     {
@@ -1157,7 +1157,7 @@ class Request extends Message implements ServerRequestInterface
      * @param      $key
      * @param null $default
      *
-     * @return null
+     * @return mixed
      */
     public function getQueryParam($key, $default = null)
     {


### PR DESCRIPTION
Hi,

I just noticed it in my IDE, the phpdoc return types seem wrong in the class Request for the methods getParsedBodyParam and getQueryParam (it says it returns "null" type).

I fixed it by using "mixed" instead.

Regards,

David Dallet