### PR TITLE
Fix issue #2091 - PSR-7 contract violation

### DIFF
--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -56,7 +56,7 @@ class Headers extends Collection implements HeadersInterface
             $key = strtoupper($key);
             if (isset(static::$special[$key]) || strpos($key, 'HTTP_') === 0) {
                 if ($key !== 'HTTP_CONTENT_LENGTH') {
-                    $data[$key] =  $value;
+                    $data[static::reconstructOriginalKey($key)] =  $value;
                 }
             }
         }
@@ -218,5 +218,27 @@ class Headers extends Collection implements HeadersInterface
         }
 
         return $key;
+    }
+
+    /**
+     * Reconstruct original header name
+     *
+     * This method takes an HTTP header name from the Environment
+     * and returns it as it was probably formatted by the actual client.
+     *
+     * @param string $key An HTTP header key from the $_SERVER global variable
+     *
+     * @return string The reconstructed key
+     *
+     * @example CONTENT_TYPE => Content-Type
+     * @example HTTP_USER_AGENT => User-Agent
+     */
+    private static function reconstructOriginalKey($key)
+    {
+        if (strpos($key, 'HTTP_') === 0) {
+            $key = substr($key, 5);
+        }
+
+        return strtr(ucwords(strtr(strtolower($key), '_', ' ')), ' ', '-');
     }
 }

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -56,7 +56,7 @@ class Headers extends Collection implements HeadersInterface
             $key = strtoupper($key);
             if (isset(static::$special[$key]) || strpos($key, 'HTTP_') === 0) {
                 if ($key !== 'HTTP_CONTENT_LENGTH') {
-                    $data[static::reconstructOriginalKey($key)] =  $value;
+                    $data[self::reconstructOriginalKey($key)] = $value;
                 }
             }
         }

--- a/tests/Http/HeadersTest.php
+++ b/tests/Http/HeadersTest.php
@@ -25,6 +25,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(is_array($prop->getValue($h)['accept']));
         $this->assertEquals('application/json', $prop->getValue($h)['accept']['value'][0]);
+        $this->assertEquals('Accept', $prop->getValue($h)['accept']['originalKey']);
     }
 
     public function testCreateFromEnvironmentWithSpecialHeaders()
@@ -38,6 +39,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue(is_array($prop->getValue($h)['content-type']));
         $this->assertEquals('application/json', $prop->getValue($h)['content-type']['value'][0]);
+        $this->assertEquals('Content-Type', $prop->getValue($h)['content-type']['originalKey']);
     }
 
     public function testCreateFromEnvironmentIgnoresHeaders()
@@ -51,6 +53,7 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
         $prop->setAccessible(true);
 
         $this->assertNotContains('content-length', $prop->getValue($h));
+        $this->assertEquals('Content-Type', $prop->getValue($h)['content-type']['originalKey']);
     }
 
     public function testConstructor()


### PR DESCRIPTION
Fixes #2091

As far as I know in PHP it is impossible to get a hold of the HTTP header names exactly as they were sent by the actual client (unless you use the ```getallheaders()``` function, which is only available in an Apache-based setup). So I had to settle with a plausible reconstruction of the name.

Cheers