### PR TITLE
cookies parser fix

### DIFF
--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -174,7 +174,7 @@ class Cookies implements CookiesInterface
         }
 
         $header = rtrim($header, "\r\n");
-        $pieces = preg_split('@\s*[;,]\s*@', $header);
+        $pieces = preg_split('@[;]\s*@', $header);
         $cookies = [];
 
         foreach ($pieces as $cookie) {

--- a/tests/Http/CookiesTest.php
+++ b/tests/Http/CookiesTest.php
@@ -161,6 +161,13 @@ class CookiesTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Josh', $cookies['name']);
     }
 
+    public function testParseHeaderWithJsonArray()
+    {
+        $cookies = Cookies::parseHeader('foo=bar; testarray=["someVar1","someVar2","someVar3"]');
+        $this->assertEquals('bar', $cookies['foo']);
+        $this->assertContains( 'someVar3', json_decode($cookies['testarray']) );
+    }
+
     public function testToHeaders()
     {
         $cookies = new Cookies;

--- a/tests/Http/CookiesTest.php
+++ b/tests/Http/CookiesTest.php
@@ -165,7 +165,7 @@ class CookiesTest extends \PHPUnit_Framework_TestCase
     {
         $cookies = Cookies::parseHeader('foo=bar; testarray=["someVar1","someVar2","someVar3"]');
         $this->assertEquals('bar', $cookies['foo']);
-        $this->assertContains( 'someVar3', json_decode($cookies['testarray']) );
+        $this->assertContains('someVar3', json_decode($cookies['testarray']));
     }
 
     public function testToHeaders()


### PR DESCRIPTION
`$header = "foo=bar; testarray=[\"someVar1\",\"someVar2\",\"someVar3\"]";`

```php
Cookies.php parseHeaderOriginal(): ["someVar1"
Cookies.php parseHeaderFixed(): ["someVar1","someVar2","someVar3"]
then fixed json_decode: Array
(
    [0] => someVar1
    [1] => someVar2
    [2] => someVar3
)

```