### PR TITLE
Strip leading slash from getPath() output when index.php is in webroot

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -201,7 +201,7 @@ class Uri implements UriInterface
         $virtualPath = $requestUri;
         if (stripos($requestUri, $requestScriptName) === 0) {
             $basePath = $requestScriptName;
-        } elseif ($requestScriptDir !== '/' && stripos($requestUri, $requestScriptDir) === 0) {
+        } elseif (stripos($requestUri, $requestScriptDir) === 0) {
             $basePath = $requestScriptDir;
         }
 

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -477,7 +477,7 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('josh:sekrit', $uri->getUserInfo());
         $this->assertEquals('example.com', $uri->getHost());
         $this->assertEquals('8080', $uri->getPort());
-        $this->assertEquals('/foo/bar', $uri->getPath());
+        $this->assertEquals('foo/bar', $uri->getPath());
         $this->assertEquals('abc=123', $uri->getQuery());
         $this->assertEquals('', $uri->getFragment());
     }
@@ -500,10 +500,58 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('josh:sekrit', $uri->getUserInfo());
         $this->assertEquals('[2001:db8::1]', $uri->getHost());
         $this->assertEquals('8080', $uri->getPort());
-        $this->assertEquals('/foo/bar', $uri->getPath());
+        $this->assertEquals('foo/bar', $uri->getPath());
         $this->assertEquals('abc=123', $uri->getQuery());
         $this->assertEquals('', $uri->getFragment());
     }
+
+
+    public function testCreateEnvironmentIndexInSubdirectory()
+    {
+        $environment = Environment::mock([
+            'SCRIPT_NAME' => '/public/index.php',
+            'REQUEST_URI' => '/public/foo/bar',
+            'PHP_AUTH_USER' => 'josh',
+            'PHP_AUTH_PW' => 'sekrit',
+            'QUERY_STRING' => 'abc=123',
+            'HTTP_HOST' => 'example.com:8080',
+            'SERVER_PORT' => 8080,
+        ]);
+
+        $uri = Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('josh:sekrit', $uri->getUserInfo());
+        $this->assertEquals('example.com', $uri->getHost());
+        $this->assertEquals('8080', $uri->getPort());
+        $this->assertEquals('foo/bar', $uri->getPath());
+        $this->assertEquals('abc=123', $uri->getQuery());
+        $this->assertEquals('', $uri->getFragment());
+    }
+
+    public function testCreateEnvironmentWithIPv6HostIndexInSubdirectory()
+    {
+        $environment = Environment::mock([
+            'SCRIPT_NAME' => '/public/index.php',
+            'REQUEST_URI' => '/public/foo/bar',
+            'PHP_AUTH_USER' => 'josh',
+            'PHP_AUTH_PW' => 'sekrit',
+            'QUERY_STRING' => 'abc=123',
+            'HTTP_HOST' => '[2001:db8::1]:8080',
+            'REMOTE_ADDR' => '2001:db8::1',
+            'SERVER_PORT' => 8080,
+        ]);
+
+        $uri = Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('josh:sekrit', $uri->getUserInfo());
+        $this->assertEquals('[2001:db8::1]', $uri->getHost());
+        $this->assertEquals('8080', $uri->getPort());
+        $this->assertEquals('foo/bar', $uri->getPath());
+        $this->assertEquals('abc=123', $uri->getQuery());
+        $this->assertEquals('', $uri->getFragment());
+    }
+
+
 
     public function testGetBaseUrl()
     {


### PR DESCRIPTION
Previously, the leading slash in getPath() output was significant: its presence indicated that the base path is not set.  This caused confusion, because the slash would appear when index.php is in webroot, but would not appear when it's in a subdirectory. The base path concept was removed in #2054, so now '/' no longer needs to be treated as a special case.

Fixes #1554, #1724, #1794