### PR TITLE
Addressing PHP 7.1 build issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ php:
   - 7.1
   - hhvm
 
-matrix:
-  allow_failures:
-    - php: 7.1
-
 before_script:
   - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls:1.* squizlabs/php_codesniffer:2.* -n ; fi
   - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then composer install -n ; fi

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1585,9 +1585,22 @@ class AppTest extends \PHPUnit_Framework_TestCase
     public function testRespondWithPaddedStreamFilterOutput()
     {
         $availableFilter = stream_get_filters();
-        if (in_array('mcrypt.*', $availableFilter) && in_array('mdecrypt.*', $availableFilter)) {
+
+        if (version_compare(phpversion(), '7.0.0', '>=')) {
+            $filterName           = 'string.rot13';
+            $unfilterName         = 'string.rot13';
+            $specificFilterName   = 'string.rot13';
+            $specificUnfilterName = 'string.rot13';
+        } else {
+            $filterName           = 'mcrypt.*';
+            $unfilterName         = 'mdecrypt.*';
+            $specificFilterName   = 'mcrypt.rijndael-128';
+            $specificUnfilterName = 'mdecrypt.rijndael-128';
+        }
+
+        if (in_array($filterName, $availableFilter) && in_array($unfilterName, $availableFilter)) {
             $app = new App();
-            $app->get('/foo', function ($req, $res) {
+            $app->get('/foo', function ($req, $res) use ($specificFilterName, $specificUnfilterName) {
                 $key = base64_decode('xxxxxxxxxxxxxxxx');
                 $iv = base64_decode('Z6wNDk9LogWI4HYlRu0mng==');
 
@@ -1596,7 +1609,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
                 $stream = fopen('php://temp', 'r+');
 
-                $filter = stream_filter_append($stream, 'mcrypt.rijndael-128', STREAM_FILTER_WRITE, [
+                $filter = stream_filter_append($stream, $specificFilterName, STREAM_FILTER_WRITE, [
                     'key' => $key,
                     'iv' => $iv
                 ]);
@@ -1605,7 +1618,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
                 rewind($stream);
                 stream_filter_remove($filter);
 
-                stream_filter_append($stream, 'mdecrypt.rijndael-128', STREAM_FILTER_READ, [
+                stream_filter_append($stream, $specificUnfilterName, STREAM_FILTER_READ, [
                     'key' => $key,
                     'iv' => $iv
                 ]);


### PR DESCRIPTION
Travis config previously listed PHP 7.1 build as an acceptable failure.  This PR fixes the build in 7.1, and removes 7.1 from the acceptable failure list.  This is for Slim 4.