### PR TITLE
Support rendering Exceptions with previous Errors

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -81,7 +81,7 @@ class Error extends AbstractError
 
             while ($exception = $exception->getPrevious()) {
                 $html .= '<h2>Previous exception</h2>';
-                $html .= $this->renderHtmlException($exception);
+                $html .= $this->renderHtmlExceptionOrError($exception);
             }
         } else {
             $html = '<p>A website error has occurred. Sorry for the temporary inconvenience.</p>';
@@ -103,12 +103,30 @@ class Error extends AbstractError
     /**
      * Render exception as HTML.
      *
+     * Provided for backwards compatibility; use renderHtmlExceptionOrError().
+     *
      * @param \Exception $exception
      *
      * @return string
      */
     protected function renderHtmlException(\Exception $exception)
     {
+        return $this->renderHtmlExceptionOrError($exception);
+    }
+
+    /**
+     * Render exception or error as HTML.
+     *
+     * @param \Exception|\Error $exception
+     *
+     * @return string
+     */
+    protected function renderHtmlExceptionOrError($exception)
+    {
+        if (!$exception instanceof \Exception && !$exception instanceof \Error) {
+            throw new \RuntimeException("Unexpected type. Expected Exception or Error.");
+        }
+
         $html = sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
 
         if (($code = $exception->getCode())) {

--- a/tests/Handlers/ErrorTest.php
+++ b/tests/Handlers/ErrorTest.php
@@ -97,6 +97,22 @@ class ErrorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * If someone extends the Error handler and calls renderHtmlExceptionOrError with
+     * a parameter that isn't an Exception or Error, then we thrown an Exception.
+     */
+    public function testRenderHtmlExceptionorErrorTypeChecksParameter()
+    {
+        $class = new \ReflectionClass(Error::class);
+        $renderHtmlExceptionorError = $class->getMethod('renderHtmlExceptionOrError');
+        $renderHtmlExceptionorError->setAccessible(true);
+
+        $this->setExpectedException(\RuntimeException::class);
+
+        $error = new Error();
+        $renderHtmlExceptionorError->invokeArgs($error, ['foo']);
+    }
+
+    /**
      * @param string $method
      * @return \PHPUnit_Framework_MockObject_MockObject|\Slim\Http\Request
      */


### PR DESCRIPTION
If an Exception is thrown with an Error set as it's previous then we
need to render this correctly in the error handler. This simply requires
removing the type hint, however we can't do that for BC, so I've created
the method `renderHtmlExceptionOrError` which is now used.

Fixes #1943