### PR TITLE
Handle invalid XML better

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -207,15 +207,27 @@ class Request extends Message implements ServerRequestInterface
 
         $this->registerMediaTypeParser('application/xml', function ($input) {
             $backup = libxml_disable_entity_loader(true);
+            $backup_errors = libxml_use_internal_errors(TRUE);
             $result = simplexml_load_string($input);
             libxml_disable_entity_loader($backup);
+            libxml_clear_errors();
+            libxml_use_internal_errors($backup_errors);
+            if ($result === false) {
+                return null;
+            }
             return $result;
         });
 
         $this->registerMediaTypeParser('text/xml', function ($input) {
             $backup = libxml_disable_entity_loader(true);
+            $backup_errors = libxml_use_internal_errors(TRUE);
             $result = simplexml_load_string($input);
             libxml_disable_entity_loader($backup);
+            libxml_clear_errors();
+            libxml_use_internal_errors($backup_errors);
+            if ($result === false) {
+                return null;
+            }
             return $result;
         });
 

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -207,7 +207,7 @@ class Request extends Message implements ServerRequestInterface
 
         $this->registerMediaTypeParser('application/xml', function ($input) {
             $backup = libxml_disable_entity_loader(true);
-            $backup_errors = libxml_use_internal_errors(TRUE);
+            $backup_errors = libxml_use_internal_errors(true);
             $result = simplexml_load_string($input);
             libxml_disable_entity_loader($backup);
             libxml_clear_errors();
@@ -220,7 +220,7 @@ class Request extends Message implements ServerRequestInterface
 
         $this->registerMediaTypeParser('text/xml', function ($input) {
             $backup = libxml_disable_entity_loader(true);
-            $backup_errors = libxml_use_internal_errors(TRUE);
+            $backup_errors = libxml_use_internal_errors(true);
             $result = simplexml_load_string($input);
             libxml_disable_entity_loader($backup);
             libxml_clear_errors();

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -847,6 +847,43 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Josh', $request->getParsedBody()->name);
     }
 
+    /**
+     * Will fail if a simple_xml warning is created
+     */
+    public function testInvalidXmlIsQuietForTextXml()
+    {
+        $method = 'GET';
+        $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
+        $headers = new Headers();
+        $headers->set('Content-Type', 'text/xml');
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('<person><name>Josh</name></invalid]>');
+        $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
+
+        $this->assertEquals(null, $request->getParsedBody());
+    }
+
+    /**
+     * Will fail if a simple_xml warning is created
+     */
+    public function testInvalidXmlIsQuietForApplicationXml()
+    {
+        $method = 'GET';
+        $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
+        $headers = new Headers();
+        $headers->set('Content-Type', 'application/xml');
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('<person><name>Josh</name></invalid]>');
+        $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
+
+        $this->assertEquals(null, $request->getParsedBody());
+    }
+
+
     public function testGetParsedBodyWhenAlreadyParsed()
     {
         $request = $this->requestFactory();


### PR DESCRIPTION
If the request's body contains invalid XML, don't throw an exception or
PHP warning. Instead, just return NULL from the medica parser.
This matches the way we handle JSON.

Fixes #2106