### PR TITLE
Ensure Request::withUri preserves host correctly

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -567,7 +567,7 @@ class Request extends Message implements ServerRequestInterface
                 $clone->headers->set('Host', $uri->getHost());
             }
         } else {
-            if ($this->uri->getHost() !== '' && (!$this->hasHeader('Host') || $this->getHeader('Host') === null)) {
+            if ($this->uri->getHost() == '' && $uri->getHost()) {
                 $clone->headers->set('Host', $uri->getHost());
             }
         }

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -567,7 +567,7 @@ class Request extends Message implements ServerRequestInterface
                 $clone->headers->set('Host', $uri->getHost());
             }
         } else {
-            if ($this->uri->getHost() == '' && $uri->getHost()) {
+            if ($uri->getHost() !== '' && (!$this->hasHeader('Host') || $this->getHeaderLine('Host') === '')) {
                 $clone->headers->set('Host', $uri->getHost());
             }
         }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -413,7 +413,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         // - If a Host header is present and non-empty, this method MUST NOT update
         //   the Host header in the returned request.
-        $request = $request->withUri(Uri::createFromString('http://example.com'));
+        $request = $request->withHeader('Host', 'example.com');
         $clone = $request->withUri($uri2, true);
         $this->assertSame('example.com', $clone->getHeaderLine('Host'));
     }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -382,6 +382,42 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeSame($uri2, 'uri', $clone);
     }
 
+    public function testWithUriPreservesHost()
+    {
+        // When `$preserveHost` is set to `true`, this method interacts with
+        // the Host header in the following ways:
+
+        // - If the the Host header is missing or empty, and the new URI contains
+        //   a host component, this method MUST update the Host header in the returned
+        //   request.
+        $uri1 = Uri::createFromString('');
+        $uri2 = Uri::createFromString('http://example2.com/test');
+
+        // Request
+        $headers = new Headers();
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $request = new Request('GET', $uri1, $headers, $cookies, $serverParams, $body);
+
+        $clone = $request->withUri($uri2, true);
+        $this->assertSame('example2.com', $clone->getHeaderLine('Host'));
+
+        // - If the Host header is missing or empty, and the new URI does not contain a
+        //   host component, this method MUST NOT update the Host header in the returned
+        //   request.
+        $uri3 = Uri::createFromString('');
+
+        $clone = $request->withUri($uri3, true);
+        $this->assertSame('', $clone->getHeaderLine('Host'));
+
+        // - If a Host header is present and non-empty, this method MUST NOT update
+        //   the Host header in the returned request.
+        $request = $request->withUri(Uri::createFromString('http://example.com'));
+        $clone = $request->withUri($uri2, true);
+        $this->assertSame('example.com', $clone->getHeaderLine('Host'));
+    }
+
     public function testGetContentType()
     {
         $headers = new Headers([


### PR DESCRIPTION
The rules for dealing with the Host header in `withUri()` when `$preserveHost` is `true` state this:

> If the the Host header is missing or empty, and the new URI contains
> a host component, this method MUST update the Host header in the returned
> request.

This now works - it didn't before as we didn't have a test for it…