### PR TITLE
Add null check for HHVM compatability

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -398,15 +398,17 @@ class Util
     public static function parseCookieHeader($header)
     {
         $cookies = array();
-        $header = rtrim($header, "\r\n");
-        $headerPieces = preg_split('@\s*[;,]\s*@', $header);
-        foreach ($headerPieces as $c) {
-            $cParts = explode('=', $c, 2);
-            if (count($cParts) === 2) {
-                $key = urldecode($cParts[0]);
-                $value = urldecode($cParts[1]);
-                if (!isset($cookies[$key])) {
-                    $cookies[$key] = $value;
+        if ($header) {
+            $header = rtrim($header, "\r\n");
+            $headerPieces = preg_split('@\s*[;,]\s*@', $header);
+            foreach ($headerPieces as $c) {
+                $cParts = explode('=', $c, 2);
+                if (count($cParts) === 2) {
+                    $key = urldecode($cParts[0]);
+                    $value = urldecode($cParts[1]);
+                    if (!isset($cookies[$key])) {
+                        $cookies[$key] = $value;
+                    }
                 }
             }
         }


### PR DESCRIPTION
`rtrim` will error if passed null on HHVM, this patches that issue