### PR TITLE
Call not-found/bad-method handlers on invalid HTTP method

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -289,15 +289,13 @@ class App
      */
     public function run($silent = false)
     {
-        try {
-            $request = $this->container->get('request');
-        } catch (InvalidMethodException $e) {
-            $request = $e->getRequest();
-        }
-
         $response = $this->container->get('response');
 
-        $response = !isset($e) ? $this->process($request, $response) : $this->processInvalidMethod($request, $response);
+        try {
+            $response = $this->process($this->container->get('request'), $response);
+        } catch (InvalidMethodException $e) {
+            $response = $this->processInvalidMethod($e->getRequest(), $response);
+        }
 
         if (!$silent) {
             $this->respond($response);

--- a/Slim/Exception/InvalidMethodException.php
+++ b/Slim/Exception/InvalidMethodException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Slim\Exception;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class InvalidMethodException extends \InvalidArgumentException
+{
+    protected $request;
+
+    public function __construct(ServerRequestInterface $request, $method)
+    {
+        $this->request = $request;
+        parent::__construct(sprintf('Unsupported HTTP method "%s" provided', $method));
+    }
+
+    public function getRequest()
+    {
+        return $this->request;
+    }
+}

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -20,6 +20,10 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 interface RouterInterface
 {
+    // array keys from route result
+    const DISPATCH_STATUS = 0;
+    const ALLOWED_METHODS = 1;
+
     /**
      * Add route
      *

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -2102,6 +2102,32 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $response = $method->invoke($app, $response);
     }
 
+    public function testUnsupportedMethodWithoutRoute()
+    {
+        $app = new App();
+        $c = $app->getContainer();
+        $c['environment'] = Environment::mock(['REQUEST_URI' => '/', 'REQUEST_METHOD' => 'BADMTHD']);
+
+        $resOut = $app->run(true);
+
+        $this->assertInstanceOf(ResponseInterface::class, $resOut);
+        $this->assertEquals(404, $resOut->getStatusCode());
+    }
+
+    public function testUnsupportedMethodWithRoute()
+    {
+        $app = new App();
+        $app->get('/', function () {
+            // stubbed action to give us a route at /
+        });
+        $c = $app->getContainer();
+        $c['environment'] = Environment::mock(['REQUEST_URI' => '/', 'REQUEST_METHOD' => 'BADMTHD']);
+
+        $resOut = $app->run(true);
+
+        $this->assertInstanceOf(ResponseInterface::class, $resOut);
+        $this->assertEquals(405, $resOut->getStatusCode());
+    }
 
     public function testContainerSetToRoute()
     {


### PR DESCRIPTION
Partially resolves #2005. Router map() calls don't have method checking,
and we still don't link the valid methods in the request to valid
methods at the application level (which IMO should be since the router
doesn't enforce any sort of method limitation at this point), but now
you won't get an uncaught exception when someone hits you with an HTTP
message with verb CHICKEN.

Also revised tests to check app run handling rather than request create
handling, since internally to the request a bad method should still be
invalid/throw an exception, so we don't want to weaken that guarantee.
But we do want the application not to 500 at runtime.

Along with that, behavior (as tested) differs between whether we have a
route or not, since in any other case the former would give you a bad
method exception, while the latter would give you a not-found. So these
tweaks match up that behavior for obscure HTTP methods as well.

Finally, RouterInterface now has constants for route info array returns.
They're only used on the exceptional path, but they make it a bit
clearer why we're pulling various numeric keys out of the route, rather
than having a non-obvious contract with FastRoute.

Took extra care here to respect order of execution for the existing code
so anything relying on that order will still work. Likewise,
InvalidMethodException subclasses InvalidArgumentException and returns
the same message and code, so anything checking for exception strings
etc., as well as instanceof checks, will still work.

Credit to @nickdnk for building the first red test for this issue.