### PR TITLE
Changing PHP_EOL to "\r\n"

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -455,17 +455,18 @@ class Response extends Message implements ResponseInterface
      */
     public function __toString()
     {
+        $eol = "\r\n";
         $output = sprintf(
             'HTTP/%s %s %s',
             $this->getProtocolVersion(),
             $this->getStatusCode(),
             $this->getReasonPhrase()
         );
-        $output .= PHP_EOL;
+        $output .= $eol;
         foreach ($this->getHeaders() as $name => $values) {
-            $output .= sprintf('%s: %s', $name, $this->getHeaderLine($name)) . PHP_EOL;
+            $output .= sprintf('%s: %s', $name, $this->getHeaderLine($name)) . $eol;
         }
-        $output .= PHP_EOL;
+        $output .= $eol;
         $output .= (string)$this->getBody();
 
         return $output;


### PR DESCRIPTION
The HTTP standard specifies that CR LF ("\r\n") should be used for separating elements in an HTTP request/response.
https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2

Using PHP_EOL could potentially break some applications as PHP_EOL is not guaranteed to be "\r\n".