### PR TITLE
Fixed HTTP EOL

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -455,17 +455,18 @@ class Response extends Message implements ResponseInterface
      */
     public function __toString()
     {
+        $eol = "\r\n";
         $output = sprintf(
             'HTTP/%s %s %s',
             $this->getProtocolVersion(),
             $this->getStatusCode(),
             $this->getReasonPhrase()
         );
-        $output .= PHP_EOL;
+        $output .= $eol;
         foreach ($this->getHeaders() as $name => $values) {
-            $output .= sprintf('%s: %s', $name, $this->getHeaderLine($name)) . PHP_EOL;
+            $output .= sprintf('%s: %s', $name, $this->getHeaderLine($name)) . $eol;
         }
-        $output .= PHP_EOL;
+        $output .= $eol;
         $output .= (string)$this->getBody();
 
         return $output;

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -118,6 +118,13 @@ class Response extends Message implements ResponseInterface
     ];
 
     /**
+     * EOL characters used for HTTP response.
+     *
+     * @var string
+     */
+     const EOL = "\r\n";
+
+    /**
      * Create new HTTP response.
      *
      * @param int                   $status  The response status code.
@@ -455,18 +462,17 @@ class Response extends Message implements ResponseInterface
      */
     public function __toString()
     {
-        $eol = "\r\n";
         $output = sprintf(
             'HTTP/%s %s %s',
             $this->getProtocolVersion(),
             $this->getStatusCode(),
             $this->getReasonPhrase()
         );
-        $output .= $eol;
+        $output .= Response::EOL;
         foreach ($this->getHeaders() as $name => $values) {
-            $output .= sprintf('%s: %s', $name, $this->getHeaderLine($name)) . $eol;
+            $output .= sprintf('%s: %s', $name, $this->getHeaderLine($name)) . Response::EOL;
         }
-        $output .= $eol;
+        $output .= Response::EOL;
         $output .= (string)$this->getBody();
 
         return $output;

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -273,8 +273,8 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
     public function testToString()
     {
-        $output = 'HTTP/1.1 404 Not Found' . PHP_EOL .
-                  'X-Foo: Bar' . PHP_EOL . PHP_EOL .
+        $output = 'HTTP/1.1 404 Not Found' . Response::EOL .
+                  'X-Foo: Bar' . Response::EOL . Response::EOL .
                   'Where am I?';
         $this->expectOutputString($output);
         $response = new Response();


### PR DESCRIPTION
The HTTP standard specifies that CR LF ("\r\n") should be used for separating elements in an HTTP request/response.
https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2

Using PHP_EOL could potentially break some applications as PHP_EOL is not guaranteed to be "\r\n".

I added a class constant of EOL to the Response class and used that constant instead of PHP_EOL when converting the Response to a string and in the unit tests.