### PR TITLE
Allowing use of PSR-11 containers

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -17,7 +17,7 @@ use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use FastRoute\Dispatcher;
 use Slim\Exception\SlimException;
 use Slim\Exception\MethodNotAllowedException;

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -9,7 +9,7 @@
 namespace Slim;
 
 use RuntimeException;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Slim\Interfaces\CallableResolverInterface;
 
 /**

--- a/Slim/CallableResolverAwareTrait.php
+++ b/Slim/CallableResolverAwareTrait.php
@@ -9,7 +9,7 @@
 namespace Slim;
 
 use RuntimeException;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Slim\Interfaces\CallableResolverInterface;
 
 /**

--- a/Slim/DeferredCallable.php
+++ b/Slim/DeferredCallable.php
@@ -10,7 +10,7 @@
 namespace Slim;
 
 use Closure;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class DeferredCallable
 {

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -8,7 +8,7 @@
  */
 namespace Slim;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * A routable, middleware-aware object

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -9,7 +9,7 @@
 namespace Slim;
 
 use FastRoute\Dispatcher;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use InvalidArgumentException;
 use RuntimeException;
 use Psr\Http\Message\ServerRequestInterface;

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "pimple/pimple": "^3.0",
         "psr/http-message": "^1.0",
         "nikic/fast-route": "^1.0",
-        "container-interop/container-interop": "^1.1"
+        "container-interop/container-interop": "^1.2",
+        "psr/container": "1.0.x-dev@dev|^1.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/http-message": "^1.0",
         "nikic/fast-route": "^1.0",
         "container-interop/container-interop": "^1.2",
-        "psr/container": "1.0.x-dev@dev|^1.0"
+        "psr/container": "^1.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -9,7 +9,6 @@
 
 namespace Slim\Tests;
 
-use Interop\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Slim\App;
 use Slim\Container;

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -9,7 +9,7 @@
 namespace Slim\Tests;
 
 use Slim\Container;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class ContainerTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Allows users to swap in a PSR-11 container. This means that containers (e.g. Symfony, Ultra-Lite) that support PSR-11 only, can be used without an adapter.

Note that since v1.2, all Container-Interop containers are automatically PSR-11 compliant, but that the reverse is not true.