### PR TITLE
conflicts with slim/http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
         "squizlabs/php_codesniffer": "^2.5",
         "phpunit/phpunit": "^4.0"
     },
+    "conflict": {
+        "slim/http": "0.*"
+    },
     "provide": {
         "psr/http-message-implementation": "1.0"
     },


### PR DESCRIPTION
Hi, 

I have been working on a test project with `http-interop/http-factory`.

The aim of test project was to showcase using the test-project with any psr-7 framework. But due to slim 3.x is not using the same Request / Response classes this makes composer hard to understand the correct class what I need. So instead of requiring slim/http it will take slim/slim and viseversa. 

I would love if conflict is actually added in the 3.x

Have also initiated one in : https://github.com/http-interop/http-factory-slim/pull/5

Thank you for the consideration.