### PR TITLE
Bugfix when handling requests with empty body

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1006,7 +1006,7 @@ class Request extends Message implements ServerRequestInterface
             return $this->bodyParsed;
         }
 
-        if (!$this->body) {
+        if (!$this->getBody()) {
             return null;
         }
 


### PR DESCRIPTION
If you call a page with e. g. Method ```GET``` and ContentType ```text/xml``` the method ```getParsedBody()``` throws an Exception as ```$this->body```is always set (as it contains a StreamInterface) if the body is empty.

The correct procedure would be to check if the body has content.