### PR TITLE
Update docblocks to include missing @throws

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -119,6 +119,8 @@ class App
      * @param  string $method
      * @param  array $args
      * @return mixed
+     *
+     * @throws BadMethodCallException
      */
     public function __call($method, $args)
     {
@@ -594,6 +596,8 @@ class App
      *
      * @param ResponseInterface $response
      * @return ResponseInterface
+     *
+     * @throws RuntimeException
      */
     protected function finalize(ResponseInterface $response)
     {

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -52,6 +52,9 @@ class Route extends Routable implements RouteInterface
      */
     protected $groups;
 
+    /**
+     * @var bool
+     */
     private $finalized = false;
 
     /**
@@ -59,7 +62,7 @@ class Route extends Routable implements RouteInterface
      *
      * One of: false, 'prepend' or 'append'
      *
-     * @var boolean|string
+     * @var bool|string
      */
     protected $outputBuffering = 'append';
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -125,6 +125,8 @@ class Router implements RouterInterface
      * @param string $basePath
      *
      * @return self
+     *
+     * @throws InvalidArgumentException
      */
     public function setBasePath($basePath)
     {
@@ -143,6 +145,9 @@ class Router implements RouterInterface
      * @param string|false $cacheFile
      *
      * @return self
+     *
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
      */
     public function setCacheFile($cacheFile)
     {


### PR DESCRIPTION
Update docblocks to include missing `@throws`

This PR also adds a missing `@var` dockblock and changes one `@var boolean` to `@var bool` for consistency.