### PR TITLE
Switching from Container-Interop to PSR-11

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -10,7 +10,7 @@ namespace Slim;
 
 use Exception;
 use FastRoute\Dispatcher;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Exception\InvalidMethodException;

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -9,7 +9,7 @@
 namespace Slim;
 
 use RuntimeException;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Slim\Interfaces\CallableResolverInterface;
 
 /**

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -8,8 +8,8 @@
  */
 namespace Slim;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface;
 use Pimple\Container as PimpleContainer;
 use Slim\Exception\ContainerValueNotFoundException;
 use Slim\Exception\ContainerException as SlimContainerException;
@@ -17,7 +17,7 @@ use Slim\Exception\ContainerException as SlimContainerException;
 /**
  * Slim's default DI container is Pimple.
  *
- * Slim\App expects a container that implements Interop\Container\ContainerInterface
+ * Slim\App expects a container that implements Psr\Container\ContainerInterface
  * with these service keys configured and ready for use:
  *
  *  - settings: an array or instance of \ArrayAccess
@@ -110,7 +110,7 @@ class Container extends PimpleContainer implements ContainerInterface
      * @param string $id Identifier of the entry to look for.
      *
      * @throws ContainerValueNotFoundException  No entry was found for this identifier.
-     * @throws ContainerException               Error while retrieving the entry.
+     * @throws ContainerExceptionInterface      Error while retrieving the entry.
      *
      * @return mixed Entry.
      */

--- a/Slim/Exception/ContainerException.php
+++ b/Slim/Exception/ContainerException.php
@@ -9,12 +9,12 @@
 namespace Slim\Exception;
 
 use InvalidArgumentException;
-use Interop\Container\Exception\ContainerException as InteropContainerException;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * Container Exception
  */
-class ContainerException extends InvalidArgumentException implements InteropContainerException
+class ContainerException extends InvalidArgumentException implements ContainerExceptionInterface
 {
 
 }

--- a/Slim/Exception/ContainerValueNotFoundException.php
+++ b/Slim/Exception/ContainerValueNotFoundException.php
@@ -9,12 +9,12 @@
 namespace Slim\Exception;
 
 use RuntimeException;
-use Interop\Container\Exception\NotFoundException as InteropNotFoundException;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Not Found Exception
  */
-class ContainerValueNotFoundException extends RuntimeException implements InteropNotFoundException
+class ContainerValueNotFoundException extends RuntimeException implements NotFoundExceptionInterface
 {
 
 }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "pimple/pimple": "^3.0",
         "psr/http-message": "^1.0",
         "nikic/fast-route": "^1.0",
-        "container-interop/container-interop": "^1.1"
+        "psr/container": "^1.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -10,6 +10,7 @@
 namespace Slim\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Slim\App;
 use Slim\Exception\MethodNotAllowedException;

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -10,7 +10,7 @@ namespace Slim\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Slim\Container;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 class ContainerTest extends TestCase
 {
@@ -37,7 +37,7 @@ class ContainerTest extends TestCase
     /**
      * Test `get()` throws error if item does not exist
      *
-     * @expectedException \Interop\Container\Exception\NotFoundException
+     * @expectedException \Psr\Container\NotFoundExceptionInterface
      */
     public function testGetWithValueNotFoundError()
     {
@@ -48,7 +48,7 @@ class ContainerTest extends TestCase
      * Test `get()` throws something that is a ContainerExpception - typically a NotFoundException, when there is a DI
      * config error
      *
-     * @expectedException \Interop\Container\Exception\ContainerException
+     * @expectedException \Psr\Container\NotFoundExceptionInterface
      */
     public function testGetWithDiConfigErrorThrownAsContainerValueNotFoundException()
     {
@@ -62,10 +62,10 @@ class ContainerTest extends TestCase
     }
 
     /**
-     * Test `get()` recasts \InvalidArgumentException as ContainerInterop-compliant exceptions when an error is present
+     * Test `get()` recasts \InvalidArgumentException as PSR-11 compliant exceptions when an error is present
      * in the DI config
      *
-     * @expectedException \Interop\Container\Exception\ContainerException
+     * @expectedException \Psr\Container\ContainerExceptionInterface
      */
     public function testGetWithDiConfigErrorThrownAsInvalidArgumentException()
     {


### PR DESCRIPTION
Container-Interop has now been [deprecated](https://github.com/container-interop/container-interop/tree/79cbf1341c22ec75643d841642dd5d6acd83bdb8#deprecation-warning).  This PR suggests Slim 4 should implement PSR-11 instead.

N.b.: Container-Interop v1.2 interfaces now extend PSR-11 interfaces, so no real code changes should be required.