### PR TITLE
Revert #1946

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -203,7 +203,6 @@ class Uri implements UriInterface
         // parse_url() requires a full URL. As we don't extract the domain name or scheme,
         // we use a stand-in.
         $requestUri = parse_url('http://example.com' . $env->get('REQUEST_URI'), PHP_URL_PATH);
-        $requestUri = rawurldecode($requestUri);
 
         $basePath = '';
         $virtualPath = $requestUri;

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -562,20 +562,6 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://localhost/foo/bar', (string) $uri);
     }
 
-    public function testCreateEnvironmentWithBasePathContainingSpace()
-    {
-        $environment = Environment::mock([
-            'SCRIPT_NAME' => "/f'oo bar/index.php",
-            'REQUEST_URI' => "/f'oo%20bar/baz",
-        ]);
-        $uri = Uri::createFromEnvironment($environment);
-
-        $this->assertEquals("/f%27oo%20bar", $uri->getBasePath());
-        $this->assertEquals('baz', $uri->getPath());
-
-        $this->assertEquals('http://localhost/f%27oo%20bar/baz', (string) $uri);
-    }
-
     public function testGetBaseUrl()
     {
         $environment = Environment::mock([


### PR DESCRIPTION
Revert #1946 as it breaks the case when a slash is URL-encoded within a segment. See issue #2176

This reverts commit c2d7ae48f836b70b1f9624bcb1c4f0ca18fdd18c, reversing
changes made to 7aabd47614448326ecb3908eec2a6440f36b50b9.