### PR TITLE
Dropping PHP 5.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Slim is a PHP micro-framework that helps you quickly write simple yet powerful w
 It's recommended that you use [Composer](https://getcomposer.org/) to install Slim.
 
 ```bash
-$ composer require slim/slim "^3.0"
+$ composer require slim/slim "^4.0"
 ```
 
-This will install Slim and all required dependencies. Slim requires PHP 5.5.0 or newer.
+This will install Slim and all required dependencies. Slim requires PHP 5.6.0 or newer.
 
 ## Usage
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "pimple/pimple": "^3.0",
         "psr/http-message": "^1.0",
         "nikic/fast-route": "^1.0",


### PR DESCRIPTION
Per discussion in https://github.com/slimphp/Slim/issues/2175 , this PR explicitly drops PHP 5.5 support in the `composer.json` file.  It also removes a build, and updates the docs.