### PR TITLE
Remove references to dead class

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -19,7 +19,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Slim\Exception\InvalidMethodException;
 use Slim\Exception\MethodNotAllowedException;
 use Slim\Exception\NotFoundException;
-use Slim\Exception\SlimException;
 use Slim\Handlers\Error;
 use Slim\Handlers\NotAllowed;
 use Slim\Handlers\NotFound;
@@ -876,9 +875,6 @@ class App
         } elseif ($e instanceof NotFoundException) {
             $handler = $this->getNotFoundHandler();
             $params = [$e->getRequest(), $e->getResponse()];
-        } elseif ($e instanceof SlimException) {
-            // This is a Stop exception and contains the response
-            return $e->getResponse();
         } else {
             // Other exception, use $request and $response params
             $handler = $this->getErrorHandler();


### PR DESCRIPTION
Class `Slim\Exception\SlimException` was removed in https://github.com/slimphp/Slim/pull/2124.  This PR removes the last remaining reference to it.