### PR TITLE
Allow all valid HTTP methods

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -111,23 +111,6 @@ class Request extends Message implements ServerRequestInterface
     protected $uploadedFiles;
 
     /**
-     * Valid request methods
-     *
-     * @var string[]
-     */
-    protected $validMethods = [
-        'CONNECT' => 1,
-        'DELETE' => 1,
-        'GET' => 1,
-        'HEAD' => 1,
-        'OPTIONS' => 1,
-        'PATCH' => 1,
-        'POST' => 1,
-        'PUT' => 1,
-        'TRACE' => 1,
-    ];
-
-    /**
      * Create new HTTP request with data extracted from the application
      * Environment object
      *
@@ -349,7 +332,7 @@ class Request extends Message implements ServerRequestInterface
         }
 
         $method = strtoupper($method);
-        if (!isset($this->validMethods[$method])) {
+        if (preg_match("/^[!#$%&'*+.^_`|~0-9a-z-]+$/i", $method) !== 1) {
             throw new InvalidMethodException($this, $method);
         }
 

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -74,12 +74,20 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals('PUT', 'originalMethod', $request);
     }
 
+    public function testWithAllAllowedCharactersMethod()
+    {
+        $request = $this->requestFactory()->withMethod("!#$%&'*+.^_`|~09AZ-");
+
+        $this->assertAttributeEquals("!#$%&'*+.^_`|~09AZ-", 'method', $request);
+        $this->assertAttributeEquals("!#$%&'*+.^_`|~09AZ-", 'originalMethod', $request);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */
     public function testWithMethodInvalid()
     {
-        $this->requestFactory()->withMethod('FOO');
+        $this->requestFactory()->withMethod('B@R');
     }
 
     public function testWithMethodNull()
@@ -208,7 +216,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $cookies = [];
         $serverParams = [];
         $body = new RequestBody();
-        $request = new Request('FOO', $uri, $headers, $cookies, $serverParams, $body);
+        $request = new Request('B@R', $uri, $headers, $cookies, $serverParams, $body);
     }
 
     /**


### PR DESCRIPTION
As suggested on #2156, Slim should allow all valid HTTP Methods instead of a closed list.

Thx to @Zegnat too.