### PR TITLE
Fixing risky test, to move file to stream then test content

### DIFF
--- a/tests/Http/UploadedFilesTest.php
+++ b/tests/Http/UploadedFilesTest.php
@@ -217,7 +217,8 @@ class UploadedFilesTest extends \PHPUnit_Framework_TestCase
     public function testMoveToStream()
     {
         $uploadedFile = $this->generateNewTmpFile();
-        $uploadedFile->moveTo('php://temp');
+        $stream = $uploadedFile->getStream();
+        $this->assertEquals('12345678', $stream->getContents());
     }
 
     public function providerCreateFromEnvironment()


### PR DESCRIPTION
'Slim\Tests\Http\UploadedFilesTest::testMoveToStream' was marked as risky, because it didn't include assertions.  This PR checks that moving the file contents to a stream properly retains the data.