### PR TITLE
Change visibility of register method and vars

### DIFF
--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -49,7 +49,7 @@ class Container extends PimpleContainer implements ContainerInterface
      *
      * @var array
      */
-    private $defaultSettings = [
+    protected $defaultSettings = [
         'httpVersion' => '1.1',
         'responseChunkSize' => 4096,
         'outputBuffering' => 'append',
@@ -82,7 +82,7 @@ class Container extends PimpleContainer implements ContainerInterface
      *
      * @return void
      */
-    private function registerDefaultServices($userSettings)
+    protected function registerDefaultServices($userSettings)
     {
         $defaultSettings = $this->defaultSettings;
 


### PR DESCRIPTION
When I want to reuse the Slim's Container class from other project,
registerDefaultServices() registers default service providers unless
overritten by configuration. The method and defaultSettings property
is private which prevent overwritten by sub class.