### PR TITLE
Adding link(), unlink() shorthand functions

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -244,7 +244,7 @@ class App
      */
     public function any($pattern, $callable)
     {
-        return $this->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], $pattern, $callable);
+        return $this->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'LINK', 'UNLINK'], $pattern, $callable);
     }
 
     /**

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -209,6 +209,32 @@ class App
     }
 
     /**
+     * Add LINK route
+     *
+     * @param  string $pattern  The route URI pattern
+     * @param  callable|string  $callable The route callback routine
+     *
+     * @return \Slim\Interfaces\RouteInterface
+     */
+    public function link($pattern, $callable)
+    {
+        return $this->map(['LINK'], $pattern, $callable);
+    }
+    
+    /**
+     * Add UNLINK route
+     *
+     * @param  string $pattern  The route URI pattern
+     * @param  callable|string  $callable The route callback routine
+     *
+     * @return \Slim\Interfaces\RouteInterface
+     */
+    public function unlink($pattern, $callable)
+    {
+        return $this->map(['UNLINK'], $pattern, $callable);
+    }
+    
+    /**
      * Add route for any HTTP method
      *
      * @param  string $pattern  The route URI pattern

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -133,6 +133,32 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeContains('OPTIONS', 'methods', $route);
     }
 
+    public function testLinkRoute()
+    {
+    	$path = '/foo';
+    	$callable = function ($req, $res) {
+    		// Do something
+    	};
+    	$app = new App();
+    	$route = $app->link($path, $callable);
+    	
+    	$this->assertInstanceOf('\Slim\Route', $route);
+    	$this->assertAttributeContains('LINK', 'methods', $route);
+    }
+    
+    public function testUnlinkRoute()
+    {
+    	$path = '/foo';
+    	$callable = function ($req, $res) {
+    		// Do something
+    	};
+    	$app = new App();
+    	$route = $app->unlink($path, $callable);
+    	
+    	$this->assertInstanceOf('\Slim\Route', $route);
+    	$this->assertAttributeContains('UNLINK', 'methods', $route);
+    }
+    
     public function testAnyRoute()
     {
         $path = '/foo';

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -135,28 +135,28 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testLinkRoute()
     {
-    	$path = '/foo';
-    	$callable = function ($req, $res) {
-    		// Do something
-    	};
-    	$app = new App();
-    	$route = $app->link($path, $callable);
-    	
-    	$this->assertInstanceOf('\Slim\Route', $route);
-    	$this->assertAttributeContains('LINK', 'methods', $route);
+        $path = '/foo';
+        $callable = function ($req, $res) {
+            // Do something
+        };
+        $app = new App();
+        $route = $app->link($path, $callable);
+        
+        $this->assertInstanceOf('\Slim\Route', $route);
+        $this->assertAttributeContains('LINK', 'methods', $route);
     }
     
     public function testUnlinkRoute()
     {
-    	$path = '/foo';
-    	$callable = function ($req, $res) {
-    		// Do something
-    	};
-    	$app = new App();
-    	$route = $app->unlink($path, $callable);
-    	
-    	$this->assertInstanceOf('\Slim\Route', $route);
-    	$this->assertAttributeContains('UNLINK', 'methods', $route);
+        $path = '/foo';
+        $callable = function ($req, $res) {
+            // Do something
+        };
+        $app = new App();
+        $route = $app->unlink($path, $callable);
+        
+        $this->assertInstanceOf('\Slim\Route', $route);
+        $this->assertAttributeContains('UNLINK', 'methods', $route);
     }
     
     public function testAnyRoute()

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -175,6 +175,8 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeContains('PATCH', 'methods', $route);
         $this->assertAttributeContains('DELETE', 'methods', $route);
         $this->assertAttributeContains('OPTIONS', 'methods', $route);
+        $this->assertAttributeContains('LINK', 'methods', $route);
+        $this->assertAttributeContains('UNLINK', 'methods', $route);
     }
 
     public function testMapRoute()


### PR DESCRIPTION
As LINK and UNLINK have been accepted as allowed method, this PR for shorthand routing functions for them.