### PR TITLE
ipv6 address without port generates warning

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -185,7 +185,7 @@ class Uri implements UriInterface
         if (preg_match('/^(\[[a-fA-F0-9:.]+\])(:\d+)?\z/', $host, $matches)) {
             $host = $matches[1];
 
-            if ($matches[2]) {
+            if (isset($matches[2])) {
                 $port = (int) substr($matches[2], 1);
             }
         } else {

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -521,7 +521,30 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $uri->getFragment());
     }
 
-    public function testCreateEnvironmentWithIPv6Host()
+    public function testCreateEnvironmentWithIPv6HostNoPort()
+    {
+        $environment = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'PHP_AUTH_USER' => 'josh',
+            'PHP_AUTH_PW' => 'sekrit',
+            'QUERY_STRING' => 'abc=123',
+            'HTTP_HOST' => '[2001:db8::1]',
+            'REMOTE_ADDR' => '2001:db8::1',
+            'SERVER_PORT' => 8080,
+        ]);
+
+        $uri = Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('josh:sekrit', $uri->getUserInfo());
+        $this->assertEquals('[2001:db8::1]', $uri->getHost());
+        $this->assertEquals('8080', $uri->getPort());
+        $this->assertEquals('/foo/bar', $uri->getPath());
+        $this->assertEquals('abc=123', $uri->getQuery());
+        $this->assertEquals('', $uri->getFragment());
+    }
+
+    public function testCreateEnvironmentWithIPv6HostWithPort()
     {
         $environment = Environment::mock([
             'SCRIPT_NAME' => '/index.php',


### PR DESCRIPTION
If you query a Url with IPv6 host and no port Slim try to access a not existing array index. I added a testcase that shows how it looks like when the port is omitted and a possible fix for this.

fixes #2209 