### PR TITLE
determineAuthorization(): HTTP_AUTHORIZATION may be null or an empty string

### DIFF
--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -77,7 +77,7 @@ class Headers extends Collection implements HeadersInterface
     {
         $authorization = $environment->get('HTTP_AUTHORIZATION');
 
-        if (null === $authorization && is_callable('getallheaders')) {
+        if ((null === $authorization || $authorization === '') && is_callable('getallheaders')) {
             $headers = getallheaders();
             $headers = array_change_key_case($headers, CASE_LOWER);
             if (isset($headers['authorization'])) {

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -77,7 +77,7 @@ class Headers extends Collection implements HeadersInterface
     {
         $authorization = $environment->get('HTTP_AUTHORIZATION');
 
-        if ((null === $authorization || $authorization === '') && is_callable('getallheaders')) {
+        if (empty($authorization) && is_callable('getallheaders')) {
             $headers = getallheaders();
             $headers = array_change_key_case($headers, CASE_LOWER);
             if (isset($headers['authorization'])) {


### PR DESCRIPTION
* `determineAuthorization()` should check if HTTP_AUTHORIZATION is null *OR* an empty string
* Closes issue #2204 