### PR TITLE
Check ini_set

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -572,7 +572,9 @@ class App
     protected function finalize(ResponseInterface $response)
     {
         // stop PHP sending a Content-Type automatically
-        ini_set('default_mimetype', '');
+        if (!empty(ini_get('default_mimetype'))) {
+            ini_set('default_mimetype', '');
+        }
 
         if ($this->isEmptyResponse($response)) {
             return $response->withoutHeader('Content-Type')->withoutHeader('Content-Length');


### PR DESCRIPTION
If default_mimetype is already set to empty, ini_set is not executed.
Ini_set is not allowed on my shared server for security reasons.

