### PR TITLE
Minor optimizations

### DIFF
--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -59,7 +59,7 @@ interface RouterInterface
     /**
      * Removes the last route group from the array
      *
-     * @return bool True if successful, else False
+     * @return RouteGroupInterface|null
      */
     public function popGroup();
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -355,7 +355,7 @@ class Router implements RouterInterface
     public function pushGroup($pattern, $callable)
     {
         $group = new RouteGroup($pattern, $callable);
-        array_push($this->routeGroups, $group);
+        $this->routeGroups[] = $group;
         return $group;
     }
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -362,12 +362,11 @@ class Router implements RouterInterface
     /**
      * Removes the last route group from the array
      *
-     * @return RouteGroup|bool The RouteGroup if successful, else False
+     * @return RouteGroup|null The last RouteGroup, if one exists
      */
     public function popGroup()
     {
-        $group = array_pop($this->routeGroups);
-        return $group instanceof RouteGroup ? $group : false;
+        return array_pop($this->routeGroups);
     }
 
     /**

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -234,7 +234,7 @@ class Router implements RouterInterface
      * @param  string   $pattern The route pattern
      * @param  callable $callable The route callable
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return Route
      */
     protected function createRoute($methods, $pattern, $callable)
     {


### PR DESCRIPTION
* Avoid function call overhead when adding a single group to an array
* Fix documented return type of `Router::createRoute`
* Simplify `Router::popGroup` implementation
    * Avoid `instanceof` check by directly returning result of `array_pop`.
    * The `RouterInterface` method was incorrectly documented as returning bool, when in fact the last group is returned if one exists.
    * It might actually be better for this method to not return anything at all, since Slim never uses the returned value.