### PR TITLE
Adding plain not found response for OPTIONS requests

### DIFF
--- a/Slim/Handlers/NotFound.php
+++ b/Slim/Handlers/NotFound.php
@@ -32,23 +32,28 @@ class NotFound extends AbstractHandler
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
-        $contentType = $this->determineContentType($request);
-        switch ($contentType) {
-            case 'application/json':
-                $output = $this->renderJsonNotFoundOutput();
-                break;
+        if ($request->getMethod() === 'OPTIONS') {
+            $contentType = 'text/plain';
+            $output = $this->renderPlainNotFoundOutput();
+        } else {
+            $contentType = $this->determineContentType($request);
+            switch ($contentType) {
+                case 'application/json':
+                    $output = $this->renderJsonNotFoundOutput();
+                    break;
 
-            case 'text/xml':
-            case 'application/xml':
-                $output = $this->renderXmlNotFoundOutput();
-                break;
+                case 'text/xml':
+                case 'application/xml':
+                    $output = $this->renderXmlNotFoundOutput();
+                    break;
 
-            case 'text/html':
-                $output = $this->renderHtmlNotFoundOutput($request);
-                break;
+                case 'text/html':
+                    $output = $this->renderHtmlNotFoundOutput($request);
+                    break;
 
-            default:
-                throw new UnexpectedValueException('Cannot render unknown content type ' . $contentType);
+                default:
+                    throw new UnexpectedValueException('Cannot render unknown content type ' . $contentType);
+            }
         }
 
         $body = new Body(fopen('php://temp', 'r+'));
@@ -57,6 +62,16 @@ class NotFound extends AbstractHandler
         return $response->withStatus(404)
                         ->withHeader('Content-Type', $contentType)
                         ->withBody($body);
+    }
+
+    /**
+     * Render plain not found message
+     *
+     * @return ResponseInterface
+     */
+    protected function renderPlainNotFoundOutput()
+    {
+        return 'Not found';
     }
 
     /**


### PR DESCRIPTION
OPTIONS requests are being sent by browsers with the `Accept: */*` header (as opposed to this [MDN article](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS)).

This is causing AbstractHandler::determineContentType method to evaluate response format as `text/html` and so NotFound handler creates a HTML response.

Such HTML response is not necessary for simple preflight request and my slow down communication (both on client side by downloading large payload and on server side by generating it; for example I'm rendering a 4Kb html page with stylesheets and suff).

So I've added a check similar to the [one in NotAllowed handler](https://github.com/slimphp/Slim/blob/3.8.1/Slim/Handlers/NotAllowed.php#L36-L39) and corresponding `renderPlainNotFoundOutput` method. NotFound response body for OPTIONS requests will now be just `Not found`.

This is very similar to https://github.com/slimphp/Slim/commit/a2cc9d9801c037f886b9253f936ef5f0994c5f1a when such behavior has been added to `NotAllowed` handler.