### PR TITLE
Add `only` restriction to getParams()

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1202,14 +1202,22 @@ class Request extends Message implements ServerRequestInterface
      *
      * Note: This method is not part of the PSR-7 standard.
      *
-     * @return array
+     * @param array|null $only list the keys to retrieve.
+     * @return array|null
      */
-    public function getParams()
+    public function getParams($only = null)
     {
         $params = $this->getQueryParams();
         $postParams = $this->getParsedBody();
         if ($postParams) {
             $params = array_merge($params, (array)$postParams);
+        }
+        if ($only) {
+            $onlyParams = [];
+            foreach ($only as $key) {
+                $onlyParams[$key] = isset($params[$key]) ? $params[$key] : null;
+            }
+            return $onlyParams;
         }
 
         return $params;

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1205,7 +1205,7 @@ class Request extends Message implements ServerRequestInterface
      * @param array|null $only list the keys to retrieve.
      * @return array|null
      */
-    public function getParams($only = null)
+    public function getParams(array $only = null)
     {
         $params = $this->getQueryParams();
         $postParams = $this->getParsedBody();

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -1153,6 +1153,30 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['abc' => 'xyz', 'foo' => 'bar'], $request->getParams());
     }
 
+    public function testGetParametersWithSpecificKeys()
+    {
+        $body = new RequestBody();
+        $body->write('foo=bar&abc=xyz');
+        $body->rewind();
+        $request = $this->requestFactory()
+            ->withBody($body)
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded');
+
+        $this->assertEquals(['abc' => 'xyz'], $request->getParams(['abc']));
+    }
+
+    public function testGetParametersWithSpecificKeysDefaultToNull()
+    {
+        $body = new RequestBody();
+        $body->write('foo=bar');
+        $body->rewind();
+        $request = $this->requestFactory()
+            ->withBody($body)
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded');
+
+        $this->assertEquals(['foo' => 'bar', 'bar' => null], $request->getParams(['foo', 'bar']));
+    }
+
     /*******************************************************************************
      * Protocol
      ******************************************************************************/


### PR DESCRIPTION
## Proposal

Enhanced `Request::getParams()` method with an extra argument to filter keys.

```
$request->getParams(['name', 'content']);
```

This will filter parameters exporting only the specified keys (defaulting to null if the key doesn't exist). I am unsure for the "defaulting to null" so feel free to comment or discard the whole PR if you think this feature should not be included by Slim.

## Possible changes 

- Do not default to null if a key doesn't exist (let PHP throw an error or create a custom exception ?)
- Replace the array argument with a spread operator or `func_get_args` so we can write `$request->getParams('name', 'content');` 