### PR TITLE
Build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,29 @@ language: php
 
 dist: trusty
 
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - hhvm
+matrix:
+  include:
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: ANALYSIS='true'
+    - php: hhvm
+    - php: 5.6
+      env: COMPOSER_ARGS='--prefer-lowest'
+    - php: nightly
+  allow_failures:
+    - php: nightly
 
 before_script:
-  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then composer require satooshi/php-coveralls:1.* squizlabs/php_codesniffer:2.* -n ; fi
-  - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then composer install -n ; fi
+  - composer update $COMPOSER_ARGS
 
 script:
-  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
-  - if [[ "$TRAVIS_PHP_VERSION" != '5.6' ]]; then vendor/bin/phpunit ; fi
-  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then vendor/bin/phpcs ; fi
+  - if [[ "$ANALYSIS" != 'true' ]]; then vendor/bin/phpunit ; fi
+  - if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
+  - if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/phpcs ; fi
 
 after_script:
-  - if [[ "$TRAVIS_PHP_VERSION" == '5.6' ]]; then php vendor/bin/coveralls --coverage_clover=clover.xml -v ; fi
+  - if [[ "$ANALYSIS" == 'true' ]]; then php vendor/bin/coveralls --coverage_clover=clover.xml -v ; fi
 
 notifications:
   slack: slimphp:0RNzx2JuhkAqIf0MXcUZ0asT

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,9 @@
         "psr/container": "^1.0"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^2.5",
-        "phpunit/phpunit": "^5.7|^6.0"
+        "squizlabs/php_codesniffer": "^2.9",
+        "phpunit/phpunit": "^5.7|^6.2",
+        "satooshi/php-coveralls": "^1.0"
     },
     "provide": {
         "psr/http-message-implementation": "1.0"


### PR DESCRIPTION
Several build process changes.

These are as follows:

- Add `satooshi/php-coveralls` as a dev dependency, as `squizlabs/php_codesniffer` is, rather than installing it indirectly in the `.travis.yml` process.
- Add a 'canary build' with Travis' `php: nightly`.  It won't break the build if this one fails, but it will tell us if there are any incompatibilities with PHP 7.2 that we need to be aware of.
- Use PHP 7.1 to compute code coverage and run the 'phpcs' static analyser.  This makes it run faster than using PHP 5.6.
- Add a 'prefer lowest' test with Composer.  This checks that we are telling the truth about the minimum necessary versions of dependencies in our `composer.json` file.