### PR TITLE
Error handlers should respect `outputBuffering` setting

### DIFF
--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -152,7 +152,10 @@ class DefaultServicesProvider
              * @return callable
              */
             $container['errorHandler'] = function ($container) {
-                return new Error($container->get('settings')['displayErrorDetails']);
+                return new Error(
+                    $container->get('settings')['displayErrorDetails'],
+                    $container->get('settings')['outputBuffering']
+                );
             };
         }
 

--- a/Slim/Handlers/AbstractError.php
+++ b/Slim/Handlers/AbstractError.php
@@ -19,13 +19,19 @@ abstract class AbstractError extends AbstractHandler
     protected $displayErrorDetails;
 
     /**
+     * @var bool|string
+     */
+    protected $outputBuffering;
+
+    /**
      * Constructor
      *
      * @param bool $displayErrorDetails Set to true to display full details
      */
-    public function __construct($displayErrorDetails = false)
+    public function __construct($displayErrorDetails = false, $outputBuffering = false)
     {
         $this->displayErrorDetails = (bool) $displayErrorDetails;
+        $this->outputBuffering = $outputBuffering;
     }
 
     /**

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -68,9 +68,6 @@ class Error extends AbstractError
             $body->write($output . ob_get_clean());
         }
 
-        // Implicitly flush the buffer (HHVM requirement).
-        flush();
-
         return $response
                 ->withStatus(500)
                 ->withHeader('Content-type', $contentType)

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -68,6 +68,9 @@ class Error extends AbstractError
             $body->write($output . ob_get_clean());
         }
 
+        // Implicitly flush the buffer (HHVM requirement).
+        flush();
+
         return $response
                 ->withStatus(500)
                 ->withHeader('Content-type', $contentType)

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -55,7 +55,18 @@ class Error extends AbstractError
         $this->writeToErrorLog($exception);
 
         $body = new Body(fopen('php://temp', 'r+'));
-        $body->write($output);
+
+        if ($this->outputBuffering === false) {
+            // delete anything in the output buffer.
+            ob_get_clean();
+            $body->write($output);
+        } elseif ($this->outputBuffering === 'prepend') {
+            // prepend output buffer content
+            $body->write(ob_get_clean() . $output);
+        } elseif ($this->outputBuffering === 'append') {
+            // append output buffer content
+            $body->write($output . ob_get_clean());
+        }
 
         return $response
                 ->withStatus(500)

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -345,11 +345,9 @@ class Route extends Routable implements RouteInterface
                 $output = ob_get_clean();
             // @codeCoverageIgnoreStart
             } catch (Throwable $e) {
-                ob_end_clean();
                 throw $e;
             // @codeCoverageIgnoreEnd
             } catch (Exception $e) {
-                ob_end_clean();
                 throw $e;
             }
         }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -2210,18 +2210,20 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, strpos((string)$res->getBody(), '<html>'));
     }
 
-// @codingStandardsIgnoreStart
     public function testExceptionOutputBufferingOn()
     {
+        // https://github.com/facebook/hhvm/issues/7444
+        if (defined('HHVM_VERSION')) {
+            ob_implicit_flush(true);
+        }
+
         $app = $this->appFactory();
         $app->get("/foo", function ($request, $response, $args) {
             $test = [1,2,3];
-            // var_dump($test);
-            echo "foobar";
+            var_dump($test);
             throw new \Exception("oops");
         });
 
-        /*
         $expectedOutput = <<<end
 array(3) {
   [0] =>
@@ -2232,8 +2234,7 @@ array(3) {
   int(3)
 }
 end;
-*/
-        $expectedOutput = 'foobar';
+
         $resOut = $app->run(true);
         $output = (string)$resOut->getBody();
         $strPos = strpos($output, $expectedOutput);
@@ -2242,17 +2243,20 @@ end;
 
     public function testExceptionOutputBufferingOff()
     {
+        // https://github.com/facebook/hhvm/issues/7444
+        if (defined('HHVM_VERSION')) {
+            ob_implicit_flush(true);
+        }
+
         $app = $this->appFactory();
         $app->getContainer()['settings']['outputBuffering'] = false;
 
         $app->get("/foo", function ($request, $response, $args) {
             $test = [1,2,3];
-            // var_dump($test);
-            echo 'foobar';
+            var_dump($test);
             throw new \Exception("oops");
         });
 
-        /*
         $unExpectedOutput = <<<end
 array(3) {
   [0] =>
@@ -2263,14 +2267,12 @@ array(3) {
   int(3)
 }
 end;
-*/
-        $unExpectedOutput = 'foobar';
+
         $resOut = $app->run(true);
         $output = (string)$resOut->getBody();
         $strPos = strpos($output, $unExpectedOutput);
         $this->assertFalse($strPos);
     }
-// @codingStandardsIgnoreEnd
 
     protected function skipIfPhp70()
     {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -2212,10 +2212,8 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionOutputBufferingOn()
     {
-        // https://github.com/facebook/hhvm/issues/7444
-        if (defined('HHVM_VERSION')) {
-            ob_implicit_flush(true);
-        }
+        // HHVM issue see https://github.com/facebook/hhvm/issues/7444
+        ob_implicit_flush(true);
 
         $app = $this->appFactory();
         $app->get("/foo", function ($request, $response, $args) {
@@ -2243,10 +2241,8 @@ end;
 
     public function testExceptionOutputBufferingOff()
     {
-        // https://github.com/facebook/hhvm/issues/7444
-        if (defined('HHVM_VERSION')) {
-            ob_implicit_flush(true);
-        }
+        // HHVM issue see https://github.com/facebook/hhvm/issues/7444
+        ob_implicit_flush(true);
 
         $app = $this->appFactory();
         $app->getContainer()['settings']['outputBuffering'] = false;

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -2210,6 +2210,60 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, strpos((string)$res->getBody(), '<html>'));
     }
 
+    public function testExceptionOutputBufferingOn()
+    {
+        $app = $this->appFactory();
+        $app->get("/foo", function ($request, $response, $args) {
+            $test = [1,2,3];
+            var_dump($test);
+            throw new \Exception("oops");
+        });
+
+        $expectedOutput = <<<end
+array(3) {
+  [0] =>
+  int(1)
+  [1] =>
+  int(2)
+  [2] =>
+  int(3)
+}
+end;
+
+        $resOut = $app->run(true);
+        $output = (string)$resOut->getBody();
+        $strPos = strpos($output, $expectedOutput);
+        $this->assertNotFalse($strPos);
+    }
+
+    public function testExceptionOutputBufferingOff()
+    {
+        $app = $this->appFactory();
+        $app->getContainer()['settings']['outputBuffering'] = false;
+
+        $app->get("/foo", function ($request, $response, $args) {
+            $test = [1,2,3];
+            var_dump($test);
+            throw new \Exception("oops");
+        });
+
+        $unExpectedOutput = <<<end
+array(3) {
+  [0] =>
+  int(1)
+  [1] =>
+  int(2)
+  [2] =>
+  int(3)
+}
+end;
+
+        $resOut = $app->run(true);
+        $output = (string)$resOut->getBody();
+        $strPos = strpos($output, $unExpectedOutput);
+        $this->assertFalse($strPos);
+    }
+
     protected function skipIfPhp70()
     {
         if (version_compare(PHP_VERSION, '7.0', '>=')) {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -2210,15 +2210,18 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, strpos((string)$res->getBody(), '<html>'));
     }
 
+// @codingStandardsIgnoreStart
     public function testExceptionOutputBufferingOn()
     {
         $app = $this->appFactory();
         $app->get("/foo", function ($request, $response, $args) {
             $test = [1,2,3];
-            var_dump($test);
+            // var_dump($test);
+            echo "foobar";
             throw new \Exception("oops");
         });
 
+        /*
         $expectedOutput = <<<end
 array(3) {
   [0] =>
@@ -2229,7 +2232,8 @@ array(3) {
   int(3)
 }
 end;
-
+*/
+        $expectedOutput = 'foobar';
         $resOut = $app->run(true);
         $output = (string)$resOut->getBody();
         $strPos = strpos($output, $expectedOutput);
@@ -2243,10 +2247,12 @@ end;
 
         $app->get("/foo", function ($request, $response, $args) {
             $test = [1,2,3];
-            var_dump($test);
+            // var_dump($test);
+            echo 'foobar';
             throw new \Exception("oops");
         });
 
+        /*
         $unExpectedOutput = <<<end
 array(3) {
   [0] =>
@@ -2257,12 +2263,14 @@ array(3) {
   int(3)
 }
 end;
-
+*/
+        $unExpectedOutput = 'foobar';
         $resOut = $app->run(true);
         $output = (string)$resOut->getBody();
         $strPos = strpos($output, $unExpectedOutput);
         $this->assertFalse($strPos);
     }
+// @codingStandardsIgnoreEnd
 
     protected function skipIfPhp70()
     {


### PR DESCRIPTION
* `Route::__invoke()` no longer calls `ob_get_clean()`
* slim\Handlers\AbstractError `__constructor` has output buffering as an argument which is saved to a protected property.
* `slim\Handlers\Error now handles the output buffering setting correctly.
* `DefaultServicesProvider` is updated to pass in the output buffering setting for the error service object.
* Two unit tests are added to test exception handling with output buffering on (append) and off.

Closes #2208