### PR TITLE
Track only the stack tip in MiddlewareAwareTrait

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -787,29 +787,38 @@ class AppTest extends TestCase
     public function testBottomMiddlewareIsApp()
     {
         $app = new App();
-        $mw = function ($req, $res, $next) {
+        $bottom = null;
+        $mw = function ($req, $res, $next) use (&$bottom) {
+            $bottom = $next;
             return $res;
         };
         $app->add($mw);
 
-        $prop = new \ReflectionProperty($app, 'stack');
-        $prop->setAccessible(true);
+        $app->callMiddlewareStack(
+            $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->disableOriginalConstructor()->getMock()
+        );
 
-        $this->assertEquals($app, $prop->getValue($app)->bottom());
+        $this->assertEquals($app, $bottom);
     }
 
     public function testAddMiddleware()
     {
         $app = new App();
-        $mw = function ($req, $res, $next) {
+        $called = 0;
+
+        $mw = function ($req, $res, $next) use (&$called) {
+            $called++;
             return $res;
         };
         $app->add($mw);
 
-        $prop = new \ReflectionProperty($app, 'stack');
-        $prop->setAccessible(true);
+        $app->callMiddlewareStack(
+            $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->disableOriginalConstructor()->getMock()
+        );
 
-        $this->assertCount(2, $prop->getValue($app));
+        $this->assertSame($called, 1);
     }
 
     public function testAddMiddlewareOnRoute()

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -96,49 +96,64 @@ class RouteTest extends TestCase
     public function testBottomMiddlewareIsRoute()
     {
         $route = $this->routeFactory();
-        $mw = function ($req, $res, $next) {
+        $bottom = null;
+        $mw = function ($req, $res, $next) use (&$bottom) {
+            $bottom = $next;
             return $res;
         };
         $route->add($mw);
         $route->finalize();
 
-        $prop = new \ReflectionProperty($route, 'stack');
-        $prop->setAccessible(true);
+        $route->callMiddlewareStack(
+            $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->disableOriginalConstructor()->getMock()
+        );
 
-        $this->assertEquals($route, $prop->getValue($route)->bottom());
+        $this->assertEquals($route, $bottom);
     }
 
     public function testAddMiddleware()
     {
         $route = $this->routeFactory();
-        $mw = function ($req, $res, $next) {
+        $called = 0;
+
+        $mw = function ($req, $res, $next) use (&$called) {
+            $called++;
             return $res;
         };
+
         $route->add($mw);
         $route->finalize();
 
-        $prop = new \ReflectionProperty($route, 'stack');
-        $prop->setAccessible(true);
+        $route->callMiddlewareStack(
+            $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->disableOriginalConstructor()->getMock()
+        );
 
-        $this->assertCount(2, $prop->getValue($route));
+        $this->assertSame($called, 1);
     }
 
     public function testRefinalizing()
     {
         $route = $this->routeFactory();
+        $called = 0;
 
-        $mw = function ($req, $res, $next) {
+        $mw = function ($req, $res, $next) use (&$called) {
+            $called++;
             return $res;
         };
+
         $route->add($mw);
 
         $route->finalize();
         $route->finalize();
 
-        $prop = new \ReflectionProperty($route, 'stack');
-        $prop->setAccessible(true);
+        $route->callMiddlewareStack(
+            $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->disableOriginalConstructor()->getMock()
+        );
 
-        $this->assertCount(2, $prop->getValue($route));
+        $this->assertSame($called, 1);
     }
 
 


### PR DESCRIPTION
As the stack is stored recursively in
the closure of the stack tip,
there is no need to hold an explicit reference
to all middlewares on the stack.

The \SplStack data structure was actually unused
in runtime code, it was only used to fetch the
tip of the stack and to check stack interity in tests.

That means those tests have to change, as the
middlewares now need to be executed, to be able to check whether
the stack has been built correctly.
An advantage of these changes is that the tests
now actually test the recursive closure stack structure, not
the unusued linked-list structure of \SplStack.

TODO: variable naming: Is "tip" too generic? But stackTip/stackTop sounds
clumsy..