### PR TITLE
Separate routing from dispatching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 
 ### Added
 
+- [#2288](https://github.com/slimphp/Slim/pull/2288) Separate routing from dispatching
 - [#2254](https://github.com/slimphp/Slim/pull/2254) Added Middleware\ContentLengthMiddleware
 - [#2166](https://github.com/slimphp/Slim/pull/2166) Added Middleware\OutputBufferingMiddleware
-- [#2288](https://github.com/slimphp/Slim/pull/2288) Separate routing from dispatching
 
 ### Deprecated
 
@@ -15,6 +15,7 @@
 
 ### Removed
 
+- [#2288](https://github.com/slimphp/Slim/pull/2288) `determineRouteBeforeAppMiddleware` setting is removed. Add RoutingMiddleware() where you need it now.
 - [#2254](https://github.com/slimphp/Slim/pull/2254) `addContentLengthHeader` setting is removed
 - [#2166](https://github.com/slimphp/Slim/pull/2166) `outputBuffering` setting is removed
 - [#2067](https://github.com/slimphp/Slim/pull/2067) Remove App::VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - [#2254](https://github.com/slimphp/Slim/pull/2254) Added Middleware\ContentLengthMiddleware
 - [#2166](https://github.com/slimphp/Slim/pull/2166) Added Middleware\OutputBufferingMiddleware
+- [#2288](https://github.com/slimphp/Slim/pull/2288) Separate routing from dispatching
 
 ### Deprecated
 

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -24,7 +24,7 @@ use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouterInterface;
-use Slim\Middleware\Routing;
+use Slim\Middleware\RoutingMiddleware;
 use Throwable;
 
 /**
@@ -739,7 +739,7 @@ class App
 
         // If router hasn't been run, then run it
         if (null === $routeInfo) {
-            $routingMiddleware = new Routing($router);
+            $routingMiddleware = new RoutingMiddleware($router);
             $request = $routingMiddleware->doRouting($request);
             $routeInfo = $request->getAttribute('routeInfo');
         }

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -737,10 +737,10 @@ class App
         /** @var \Slim\Interfaces\RouterInterface $router */
         $router = $this->getRouter();
 
-        // If router hasn't been run, then run it
+        // If routing hasn't been done, then do it now so we can dispatch
         if (null === $routeInfo) {
             $routingMiddleware = new RoutingMiddleware($router);
-            $request = $routingMiddleware->doRouting($request);
+            $request = $routingMiddleware->performRouting($request);
             $routeInfo = $request->getAttribute('routeInfo');
         }
 

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -51,7 +51,6 @@ class Container extends PimpleContainer implements ContainerInterface
         'httpVersion' => '1.1',
         'responseChunkSize' => 4096,
         'outputBuffering' => 'append',
-        'determineRouteBeforeAppMiddleware' => false,
         'displayErrorDetails' => false,
         'routerCacheFile' => false,
     ];

--- a/Slim/Middleware/Routing.php
+++ b/Slim/Middleware/Routing.php
@@ -1,0 +1,62 @@
+<?php
+namespace Slim\Middleware;
+
+use FastRoute\Dispatcher;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Interfaces\RouterInterface;
+
+/**
+ * Perform routing and store matched route to the request's attributes
+ */
+class Routing
+{
+    protected $router;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * Invoke
+     *
+     * @param  ServerRequestInterface $request   PSR7 server request
+     * @param  ResponseInterface      $response  PSR7 response
+     * @param  callable               $next      Middleware callable
+     * @return ResponseInterface                 PSR7 response
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
+    {
+        $request = $this->doRouting($request);
+        return $next($request, $response);
+    }
+
+    /**
+     * Perform routing
+     *
+     * @param  ServerRequestInterface $request   PSR7 server request
+     * @return ServerRequestInterface
+     */
+    public function doRouting(ServerRequestInterface $request)
+    {
+        $routeInfo = $this->router->dispatch($request);
+
+        if ($routeInfo[0] === Dispatcher::FOUND) {
+            $routeArguments = [];
+            foreach ($routeInfo[2] as $k => $v) {
+                $routeArguments[$k] = urldecode($v);
+            }
+
+            $route = $this->router->lookupRoute($routeInfo[1]);
+            $route->prepare($request, $routeArguments);
+
+            // add route to the request's attributes
+            $request = $request->withAttribute('route', $route);
+        }
+
+        // routeInfo to the request's attributes
+        $routeInfo['request'] = [$request->getMethod(), (string) $request->getUri()];
+        return $request->withAttribute('routeInfo', $routeInfo);
+    }
+}

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -9,7 +9,7 @@ use Slim\Interfaces\RouterInterface;
 /**
  * Perform routing and store matched route to the request's attributes
  */
-class Routing
+class RoutingMiddleware
 {
     protected $router;
 

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -28,7 +28,7 @@ class RoutingMiddleware
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
-        $request = $this->doRouting($request);
+        $request = $this->performRouting($request);
         return $next($request, $response);
     }
 
@@ -38,7 +38,7 @@ class RoutingMiddleware
      * @param  ServerRequestInterface $request   PSR7 server request
      * @return ServerRequestInterface
      */
-    public function doRouting(ServerRequestInterface $request)
+    public function performRouting(ServerRequestInterface $request)
     {
         $routeInfo = $this->router->dispatch($request);
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,10 +1,13 @@
 # How to upgrade
 
+
+* [2288] - If you were using `determineRouteBeforeAppMiddleware`, you need to add the `Middleware\RoutingMiddleware` middleware to your application just before your call `run()` to maintain the previous behaviour.
 * [2254] - You need to add the `Middleware\ContentLengthMiddleware` middleware if you want Slim to add the Content-Length header this automatically.
 * [2166] - You need to add the `Middleware\OutputBufferingMiddleware` middleware to capture echo'd or var_dump'd output from your code.
 * [2098] - You need to add the App's router to the container for a straight upgrade. If you've created your own router factory in the container though, then you need to set it into the $app.
 * [2102] - You must inject custom route invocation strategy with `$app->getRouter()->setDefaultInvocationStrategy($myStrategy)`
 
+[2288]: https://github.com/slimphp/Slim/pull/2288
 [2254]: https://github.com/slimphp/Slim/pull/2254
 [2166]: https://github.com/slimphp/Slim/pull/2166
 [2098]: https://github.com/slimphp/Slim/pull/2098

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1895,19 +1895,6 @@ class AppTest extends TestCase
 //        $res = $app->run(true);
 //    }
 
-    public function testAppRunWithdetermineRouteBeforeAppMiddleware()
-    {
-        $app = $this->appFactory();
-        $app->addSetting('determineRouteBeforeAppMiddleware', true);
-        $app->get('/foo', function ($req, $res) {
-            return $res->write("Test");
-        });
-
-        $resOut = $app->run(true);
-        $resOut->getBody()->rewind();
-        $this->assertEquals("Test", $resOut->getBody()->getContents());
-    }
-
     public function testExceptionErrorHandlerDisplaysErrorDetails()
     {
         $app = new App([

--- a/tests/Middleware/RoutingTest.php
+++ b/tests/Middleware/RoutingTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2017 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Middleware;
+
+use Closure;
+use FastRoute\Dispatcher;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Http\Body;
+use Slim\Http\Headers;
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Slim\Http\Uri;
+use Slim\Middleware\Routing;
+use Slim\Router;
+
+class RoutingTest extends TestCase
+{
+    protected function getRouter()
+    {
+        $router = new Router();
+        $router->map(['GET'], '/hello/{name}', null);
+
+        return $router;
+    }
+
+    public function testRouteIsStoredOnSuccessfulMatch()
+    {
+        $router = $this->getRouter();
+        $mw = new Routing($router);
+
+        $uri = Uri::createFromString('https://example.com:443/hello/foo');
+        $body = new Body(fopen('php://temp', 'r+'));
+        $request = new Request('GET', $uri, new Headers(), [], [], $body);
+        $response = new Response();
+
+        $next = function (ServerRequestInterface $req, ResponseInterface $res) {
+            // route is available
+            $route = $req->getAttribute('route');
+            $this->assertNotNull($route);
+            $this->assertEquals('foo', $route->getArgument('name'));
+
+            // routeInfo is available
+            $routeInfo = $req->getAttribute('routeInfo');
+            $this->assertInternalType('array', $routeInfo);
+            return $res;
+        };
+        Closure::bind($next, $this); // bind test class so we can test request object
+
+        $result = $mw($request, $response, $next);
+    }
+
+    public function testRouteIsNotStoredOnMethodNotAllowed()
+    {
+        $router = $this->getRouter();
+        $mw = new Routing($router);
+
+        $uri = Uri::createFromString('https://example.com:443/hello/foo');
+        $body = new Body(fopen('php://temp', 'r+'));
+        $request = new Request('POST', $uri, new Headers(), [], [], $body);
+        $response = new Response();
+
+        $next = function (ServerRequestInterface $req, ResponseInterface $res) {
+            // route is not available
+            $route = $req->getAttribute('route');
+            $this->assertNull($route);
+
+            // routeInfo is available
+            $routeInfo = $req->getAttribute('routeInfo');
+            $this->assertInternalType('array', $routeInfo);
+            $this->assertEquals(Dispatcher::METHOD_NOT_ALLOWED, $routeInfo[0]);
+
+
+            return $res;
+        };
+        Closure::bind($next, $this); // bind test class so we can test request object
+        $result = $mw($request, $response, $next);
+    }
+}

--- a/tests/Middleware/RoutingTest.php
+++ b/tests/Middleware/RoutingTest.php
@@ -18,10 +18,10 @@ use Slim\Http\Headers;
 use Slim\Http\Request;
 use Slim\Http\Response;
 use Slim\Http\Uri;
-use Slim\Middleware\Routing;
+use Slim\Middleware\RoutingMiddleware;
 use Slim\Router;
 
-class RoutingTest extends TestCase
+class RoutingMiddlewareTest extends TestCase
 {
     protected function getRouter()
     {
@@ -34,7 +34,7 @@ class RoutingTest extends TestCase
     public function testRouteIsStoredOnSuccessfulMatch()
     {
         $router = $this->getRouter();
-        $mw = new Routing($router);
+        $mw = new RoutingMiddleware($router);
 
         $uri = Uri::createFromString('https://example.com:443/hello/foo');
         $body = new Body(fopen('php://temp', 'r+'));
@@ -60,7 +60,7 @@ class RoutingTest extends TestCase
     public function testRouteIsNotStoredOnMethodNotAllowed()
     {
         $router = $this->getRouter();
-        $mw = new Routing($router);
+        $mw = new RoutingMiddleware($router);
 
         $uri = Uri::createFromString('https://example.com:443/hello/foo');
         $body = new Body(fopen('php://temp', 'r+'));


### PR DESCRIPTION
Move the routing to middleware so that the user can add it wherever they want it to be within the middleware stack. This gives us the new capability to allow for some middleware to run before routing and some after.

If the `Routing` middleware isn't added by the user, then automatically call it in `App::__invoke()` as a last resort.

Also, remove `determineRouteBeforeAppMiddleware` setting as it's no longer necessary.
