### PR TITLE
Support HTTP "2" as a valid protocol version (i.e no minor version)

### DIFF
--- a/Slim/Http/Message.php
+++ b/Slim/Http/Message.php
@@ -39,7 +39,7 @@ abstract class Message implements MessageInterface
     protected static $validProtocolVersions = [
         '1.0' => true,
         '1.1' => true,
-        '2.0' => true,
+        '2' => true,
     ];
 
     /**

--- a/tests/Http/MessageTest.php
+++ b/tests/Http/MessageTest.php
@@ -49,6 +49,20 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $message->withProtocolVersion('3.0');
     }
 
+    /**
+     * @covers Slim\Http\Message::withProtocolVersion
+     * @expectedException \InvalidArgumentException
+     */
+    public function testWithProtocolVersionInvalidMinorVersionThrowsException()
+    {
+        $message = new MessageStub();
+
+        /**
+         * @see https://http2.github.io/faq/#is-it-http20-or-http2
+         */
+        $message->withProtocolVersion('2.0');
+    }
+
     /*******************************************************************************
      * Headers
      ******************************************************************************/


### PR DESCRIPTION
`ValidProtocolVersions` for HTTP "2" no longer include minor version.
@see https://http2.github.io/faq/#is-it-http20-or-http2
Closes #2296