### PR TITLE
Update php-coveralls vendor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.9",
         "phpunit/phpunit": "^5.7|^6.2",
-        "satooshi/php-coveralls": "^1.0"
+        "php-coveralls/php-coveralls": "^1.0"
     },
     "provide": {
         "psr/http-message-implementation": "1.0"


### PR DESCRIPTION
php-coveralls vendor was renamed to `php-coveralls/php-coveralls`
See https://github.com/php-coveralls/php-coveralls/pull/228