### PR TITLE
Add app param into callable function

### DIFF
--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -42,6 +42,6 @@ class RouteGroup extends Routable implements RouteGroupInterface
             $callable = $callable->bindTo($app);
         }
 
-        $callable();
+        $callable($app);
     }
 }


### PR DESCRIPTION
if you sure the callable function has no param,I suggest add the $app as a param to $callable, and then you can create router like this:
`
class ApiRouter
{
    public function __invoke(App $app)
    {
        $app->add(AuthMiddleware::class);
        
        $app->get('/', function (Request $request, Response $response, $args) {
            $response->getBody()->write('Hello world');
            return $response->withHeader('Content-Type', 'text/html');
        })
        ->setName('api.index');
    }
}
`
and use it in app:
`
$app->group('/api', ApiRouter::class);
`