### PR TITLE
Encode user info

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -378,10 +378,29 @@ class Uri implements UriInterface
     public function withUserInfo($user, $password = null)
     {
         $clone = clone $this;
-        $clone->user = $user;
-        $clone->password = $password ? $password : '';
+        $clone->user = $this->filterUserInfo($user);
+        if ($clone->user) {
+            $clone->password = $password ? $this->filterUserInfo($password) : '';
+        }
 
         return $clone;
+    }
+
+    /**
+     * Filters the user info string.
+     *
+     * @param string $query The raw uri query string.
+     * @return string The percent-encoded query string.
+     */
+    protected function filterUserInfo($query)
+    {
+        return preg_replace_callback(
+            '/(?:[^a-zA-Z0-9_\-\.~!\$&\'\(\)\*\+,;=]+|%(?![A-Fa-f0-9]{2}))/u',
+            function ($match) {
+                return rawurlencode($match[0]);
+            },
+            $query
+        );
     }
 
     /**

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -180,12 +180,27 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $uri->getUserInfo());
     }
 
+    public function testGetUserInfoWithUsernameAndPasswordEncodesCorrectly()
+    {
+        $uri = Uri::createFromString('https://bob%40example.com:pass%3Aword@example.com:443/foo/bar?abc=123#section3');
+
+        $this->assertEquals('bob%40example.com:pass%3Aword', $uri->getUserInfo());
+    }
+
     public function testWithUserInfo()
     {
         $uri = $this->uriFactory()->withUserInfo('bob', 'pass');
 
         $this->assertAttributeEquals('bob', 'user', $uri);
         $this->assertAttributeEquals('pass', 'password', $uri);
+    }
+
+    public function testWithUserInfoEncodesCorrectly()
+    {
+        $uri = $this->uriFactory()->withUserInfo('bob@example.com', 'pass:word');
+
+        $this->assertAttributeEquals('bob%40example.com', 'user', $uri);
+        $this->assertAttributeEquals('pass%3Aword', 'password', $uri);
     }
 
     public function testWithUserInfoRemovesPassword()


### PR DESCRIPTION
If the username or password includes an `@`, `:` or other reserved
characters, they need to be encoded.

Fixes #2201