### PR TITLE
Fixed regression, removing user info with Uri::withUserInfo('') is not clearing password anymore

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -381,6 +381,8 @@ class Uri implements UriInterface
         $clone->user = $this->filterUserInfo($user);
         if ($clone->user) {
             $clone->password = $password ? $this->filterUserInfo($password) : '';
+        } else {
+            $clone->password = '';
         }
 
         return $clone;


### PR DESCRIPTION
Unfortunately, Slim 3.9 broke redirects with user authority as the password isn't cleared when `Uri::withUserInfo('')`  is called.

Url: `user:password@domain.com/path` became: `Location: //:password@/path`.