### PR TITLE
Avoid deleting output buffer to fix 14 tests that PHPUnit have considered risky

### DIFF
--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -58,14 +58,16 @@ class Error extends AbstractError
 
         if ($this->outputBuffering === 'prepend') {
             // prepend output buffer content
-            $body->write(ob_get_clean() . $output);
+            $body->write(ob_get_contents() . $output);
+            ob_clean();
         } elseif ($this->outputBuffering === 'append') {
             // append output buffer content
-            $body->write($output . ob_get_clean());
+            $body->write($output . ob_get_contents());
+            ob_clean();
         } else {
             // outputBuffering is false or some other unknown setting
             // delete anything in the output buffer.
-            ob_get_clean();
+            ob_clean();
             $body->write($output);
         }
 


### PR DESCRIPTION
When my projects updated from 3.8.1 to 3.9.0, many of my phpunit tests started resulting into risky tests. It turned out that reverting back to 3.8.1 caused phpunit to stop classifying the tests as risky. Running phpunit on Slim, I also saw that 3.8.1 had only one risky test while 3.9.0 have 18 risky tests.

The 17 new risky tests have the message: "Test code or tested code did not (only) close its own output buffers".

This commit uses `ob_get_contents` and `ob_clean` instead of `ob_get_clean` to avoid destroying the current output buffer.

All the tests are still passing but now, only 3 of the 17 tests are classified as Risky due to  "Test code or tested code did not (only) close its own output buffers".

Here is the lisf of risky tests on 3.9.0

```
dmelo@merov2:~/proj2/Slim$ git checkout 3.9.0
Previous HEAD position was 53853027... Uppdate App:VERSION to 3.8.1
HEAD is now at 575a8b53... Version 3.9.0
dmelo@merov2:~/proj2/Slim$ ./vendor/bin/phpunit --stderr --verbose
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Runtime:	PHP 7.1.9 with Xdebug 2.5.1
Configuration:	/home/dmelo/proj2/Slim/phpunit.xml.dist

...............................................................  63 / 588 ( 10%)
..................R.........R.............SR................... 126 / 588 ( 21%)
.............................RRRRRRRRRRRR.R.................... 189 / 588 ( 32%)
.........SSSSSSSSSSSSS......................................... 252 / 588 ( 42%)
............................................................... 315 / 588 ( 53%)
............................................................... 378 / 588 ( 64%)
............................................................... 441 / 588 ( 75%)
............................R.................................. 504 / 588 ( 85%)
........................................................R...... 567 / 588 ( 96%)
.....................

Time: 973 ms, Memory: 16.00MB

There were 18 risky tests:

1) Slim\Tests\AppTest::testExceptionErrorHandlerDoesNotDisplayErrorDetails
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

2) Slim\Tests\AppTest::testExceptionErrorHandlerDisplaysErrorDetails
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

3) Slim\Tests\AppTest::testExceptionOutputBufferingOff
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

4) Slim\Tests\Handlers\ErrorTest::testError with data set #0 ('application/json', 'application/json', '{')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

5) Slim\Tests\Handlers\ErrorTest::testError with data set #1 ('application/vnd.api+json', 'application/json', '{')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

6) Slim\Tests\Handlers\ErrorTest::testError with data set #2 ('application/xml', 'application/xml', '<error>')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

7) Slim\Tests\Handlers\ErrorTest::testError with data set #3 ('application/hal+xml', 'application/xml', '<error>')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

8) Slim\Tests\Handlers\ErrorTest::testError with data set #4 ('text/xml', 'text/xml', '<error>')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

9) Slim\Tests\Handlers\ErrorTest::testError with data set #5 ('text/html', 'text/html', '<html>')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

10) Slim\Tests\Handlers\ErrorTest::testErrorDisplayDetails with data set #0 ('application/json', 'application/json', '{')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

11) Slim\Tests\Handlers\ErrorTest::testErrorDisplayDetails with data set #1 ('application/vnd.api+json', 'application/json', '{')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

12) Slim\Tests\Handlers\ErrorTest::testErrorDisplayDetails with data set #2 ('application/xml', 'application/xml', '<error>')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

13) Slim\Tests\Handlers\ErrorTest::testErrorDisplayDetails with data set #3 ('application/hal+xml', 'application/xml', '<error>')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

14) Slim\Tests\Handlers\ErrorTest::testErrorDisplayDetails with data set #4 ('text/xml', 'text/xml', '<error>')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

15) Slim\Tests\Handlers\ErrorTest::testErrorDisplayDetails with data set #5 ('text/html', 'text/html', '<html>')
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

16) Slim\Tests\Handlers\ErrorTest::testPreviousException
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

17) Slim\Tests\Http\UploadedFilesTest::testMoveToStream
This test did not perform any assertions

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

18) Slim\Tests\RouteTest::testInvokeWithException
Test code or tested code did not (only) close its own output buffers

/home/dmelo/proj2/Slim/vendor/phpunit/phpunit/phpunit:52

dmelo@merov2:~/proj2/Slim$ php -v
PHP 7.1.9 (cli) (built: Sep 23 2017 12:09:20) ( NTS DEBUG )
Copyright (c) 1997-2017 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2017 Zend Technologies
    with Xdebug v2.5.1, Copyright (c) 2002-2017, by Derick Rethans
```