### PR TITLE
Fix output buffering issue that was creating a risky test in PHPUnit.

### DIFF
--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -153,8 +153,7 @@ class DefaultServicesProvider
              */
             $container['errorHandler'] = function ($container) {
                 return new Error(
-                    $container->get('settings')['displayErrorDetails'],
-                    $container->get('settings')['outputBuffering']
+                    $container->get('settings')['displayErrorDetails']
                 );
             };
         }

--- a/Slim/Handlers/AbstractError.php
+++ b/Slim/Handlers/AbstractError.php
@@ -19,19 +19,13 @@ abstract class AbstractError extends AbstractHandler
     protected $displayErrorDetails;
 
     /**
-     * @var bool|string
-     */
-    protected $outputBuffering;
-
-    /**
      * Constructor
      *
      * @param bool $displayErrorDetails Set to true to display full details
      */
-    public function __construct($displayErrorDetails = false, $outputBuffering = false)
+    public function __construct($displayErrorDetails = false)
     {
         $this->displayErrorDetails = (bool) $displayErrorDetails;
-        $this->outputBuffering = $outputBuffering;
     }
 
     /**

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -55,19 +55,7 @@ class Error extends AbstractError
         $this->writeToErrorLog($exception);
 
         $body = new Body(fopen('php://temp', 'r+'));
-
-        if ($this->outputBuffering === 'prepend') {
-            // prepend output buffer content
-            $body->write(ob_get_clean() . $output);
-        } elseif ($this->outputBuffering === 'append') {
-            // append output buffer content
-            $body->write($output . ob_get_clean());
-        } else {
-            // outputBuffering is false or some other unknown setting
-            // delete anything in the output buffer.
-            ob_get_clean();
-            $body->write($output);
-        }
+        $body->write($output);
 
         return $response
                 ->withStatus(500)

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -13,7 +13,6 @@ use Throwable;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Slim\Exception\SlimException;
 use Slim\Handlers\Strategies\RequestResponse;
 use Slim\Interfaces\InvocationStrategyInterface;
 use Slim\Interfaces\RouteInterface;
@@ -342,13 +341,15 @@ class Route extends Routable implements RouteInterface
             try {
                 ob_start();
                 $newResponse = $handler($this->callable, $request, $response, $this->arguments);
-                $output = ob_get_clean();
+                $output = ob_get_contents();
             // @codeCoverageIgnoreStart
             } catch (Throwable $e) {
                 throw $e;
             // @codeCoverageIgnoreEnd
             } catch (Exception $e) {
                 throw $e;
+            } finally {
+                ob_end_clean();
             }
         }
 

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -8,8 +8,6 @@
  */
 namespace Slim;
 
-use Exception;
-use Throwable;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -334,24 +332,7 @@ class Route extends Routable implements RouteInterface
         /** @var InvocationStrategyInterface $handler */
         $handler = isset($this->container) ? $this->container->get('foundHandler') : new RequestResponse();
 
-        // invoke route callable
-        if ($this->outputBuffering === false) {
-            $newResponse = $handler($this->callable, $request, $response, $this->arguments);
-        } else {
-            try {
-                ob_start();
-                $newResponse = $handler($this->callable, $request, $response, $this->arguments);
-                $output = ob_get_contents();
-            // @codeCoverageIgnoreStart
-            } catch (Throwable $e) {
-                throw $e;
-            // @codeCoverageIgnoreEnd
-            } catch (Exception $e) {
-                throw $e;
-            } finally {
-                ob_end_clean();
-            }
-        }
+        $newResponse = $handler($this->callable, $request, $response, $this->arguments);
 
         if ($newResponse instanceof ResponseInterface) {
             // if route callback returns a ResponseInterface, then use it
@@ -360,18 +341,6 @@ class Route extends Routable implements RouteInterface
             // if route callback returns a string, then append it to the response
             if ($response->getBody()->isWritable()) {
                 $response->getBody()->write($newResponse);
-            }
-        }
-
-        if (!empty($output) && $response->getBody()->isWritable()) {
-            if ($this->outputBuffering === 'prepend') {
-                // prepend output buffer content
-                $body = new Http\Body(fopen('php://temp', 'r+'));
-                $body->write($output . $response->getBody());
-                $response = $response->withBody($body);
-            } elseif ($this->outputBuffering === 'append') {
-                // append output buffer content
-                $response->getBody()->write($output);
             }
         }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -2258,26 +2258,13 @@ end;
         $app = $this->appFactory();
         $app->getContainer()['settings']['outputBuffering'] = 'append';
         $app->get("/foo", function ($request, $response, $args) {
-            $test = [1,2,3];
-            var_dump($test);
+            echo 'output buffer test';
             throw new \Exception("oops");
         });
 
-        $expectedOutput = <<<end
-array(3) {
-  [0] =>
-  int(1)
-  [1] =>
-  int(2)
-  [2] =>
-  int(3)
-}
-end;
-
         $resOut = $app->run(true);
         $output = (string)$resOut->getBody();
-        $strPos = strpos($output, $expectedOutput);
-        $this->assertNotFalse($strPos);
+        $this->assertStringEndsWith('output buffer test', $output);
     }
 
     public function testExceptionOutputBufferingPrepend()
@@ -2290,26 +2277,13 @@ end;
         $app = $this->appFactory();
         $app->getContainer()['settings']['outputBuffering'] = 'prepend';
         $app->get("/foo", function ($request, $response, $args) {
-            $test = [1,2,3];
-            var_dump($test);
+            echo 'output buffer test';
             throw new \Exception("oops");
         });
 
-        $expectedOutput = <<<end
-array(3) {
-  [0] =>
-  int(1)
-  [1] =>
-  int(2)
-  [2] =>
-  int(3)
-}
-end;
-
         $resOut = $app->run(true);
         $output = (string)$resOut->getBody();
-        $strPos = strpos($output, $expectedOutput);
-        $this->assertNotFalse($strPos);
+        $this->assertStringStartsWith('output buffer test', $output);
     }
 
     protected function skipIfPhp70()

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -276,33 +276,6 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Ensure that anything echo'd in a route callable is added to the response
-     * object that is returned by __invoke().
-     */
-    public function testInvokeWhenEchoingOutput()
-    {
-        $callable = function ($req, $res, $args) {
-            echo "foo";
-            return $res->withStatus(201);
-        };
-        $route = new Route(['GET'], '/', $callable);
-
-        $env = Environment::mock();
-        $uri = Uri::createFromString('https://example.com:80');
-        $headers = new Headers();
-        $cookies = [];
-        $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
-        $request = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
-        $response = new Response;
-
-        $response = $route->__invoke($request, $response);
-
-        $this->assertEquals('foo', (string)$response->getBody());
-        $this->assertEquals(201, $response->getStatusCode());
-    }
-
-    /**
      * Ensure that if a string is returned by a route callable, then it is
      * added to the response object that is returned by __invoke().
      */
@@ -325,33 +298,6 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $response = $route->__invoke($request, $response);
 
         $this->assertEquals('foo', (string)$response->getBody());
-    }
-
-    /**
-     * Ensure that if `outputBuffering` property is set to `prepend` correct response
-     * body is returned by __invoke().
-     */
-    public function testInvokeWhenPrependingOutputBuffer()
-    {
-        $callable = function ($req, $res, $args) {
-            echo 'foo';
-            return $res->write('bar');
-        };
-        $route = new Route(['GET'], '/', $callable);
-        $route->setOutputBuffering('prepend');
-
-        $env = Environment::mock();
-        $uri = Uri::createFromString('https://example.com:80');
-        $headers = new Headers();
-        $cookies = [];
-        $serverParams = $env->all();
-        $body = new Body(fopen('php://temp', 'r+'));
-        $request = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
-        $response = new Response;
-
-        $response = $route->__invoke($request, $response);
-
-        $this->assertEquals('foobar', (string)$response->getBody());
     }
 
     /**


### PR DESCRIPTION
Same problem as here but at the Route level:
https://github.com/slimphp/Slim/pull/2333

It fixes the risky test for `RouteTest::testInvokeWithException`.