### PR TITLE
Add code to allow the CallableResolver to resolve constructor dependencies.

### DIFF
--- a/tests/Mocks/ResolvingCallableDependencies/MockDependency.php
+++ b/tests/Mocks/ResolvingCallableDependencies/MockDependency.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Slim\Tests\Mocks\ResolvingCallableDependencies;
+
+
+class MockDependency
+{
+
+    public function process()
+    {
+        return "processed";
+    }
+
+}

--- a/tests/Mocks/ResolvingCallableDependencies/MultipleDependencyTest.php
+++ b/tests/Mocks/ResolvingCallableDependencies/MultipleDependencyTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Slim\Tests\Mocks\ResolvingCallableDependencies;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Mock object for Slim\Tests\CallableResolverTest
+ */
+class MultipleDependencyTest
+{
+    private $dependency;
+    private $container;
+
+    public function __construct(MockDependency $dependency, ContainerInterface $container = null)
+    {
+        $this->dependency = $dependency;
+        $this->container = $container;
+    }
+
+    public function getContainer()
+    {
+        return $this->container;
+    }
+
+    public function getDependency()
+    {
+        return $this->dependency;
+    }
+
+    public function getInstance()
+    {
+        return $this;
+    }
+}

--- a/tests/Mocks/ResolvingCallableDependencies/MultipleUnTypedDependencyTest.php
+++ b/tests/Mocks/ResolvingCallableDependencies/MultipleUnTypedDependencyTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Slim\Tests\Mocks\ResolvingCallableDependencies;
+
+/**
+ * Mock object for Slim\Tests\CallableResolverTest
+ */
+class MultipleUnTypedDependencyTest
+{
+    public function __construct($dependencyA, $dependencyB)
+    {
+    }
+}

--- a/tests/Mocks/ResolvingCallableDependencies/SingleContainerDependencyTest.php
+++ b/tests/Mocks/ResolvingCallableDependencies/SingleContainerDependencyTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Slim\Tests\Mocks\ResolvingCallableDependencies;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Mock object for Slim\Tests\CallableResolverTest
+ */
+class SingleContainerDependencyTest
+{
+    private $container;
+
+    public function __construct(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function getContainer()
+    {
+        return $this->container;
+    }
+}

--- a/tests/Mocks/ResolvingCallableDependencies/SingleUnTypeHintedContainerDependencyTest.php
+++ b/tests/Mocks/ResolvingCallableDependencies/SingleUnTypeHintedContainerDependencyTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Slim\Tests\Mocks\ResolvingCallableDependencies;
+
+/**
+ * Mock object for Slim\Tests\CallableResolverTest
+ */
+class SingleUnTypeHintedContainerDependencyTest
+{
+    private $container;
+
+    public function __construct($container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function getContainer()
+    {
+        return $this->container;
+    }
+}


### PR DESCRIPTION
This PR makes it nice and easy to ensure a Controller receives all of it's required dependencies without having to interact with the container itself.

See how `tests/Mocks/ResolvingCallableDependencies/MultipleDependencyTest.php` interacts with the `MockDependency` in the modified files below.
Without this change the following would have been required to get an instance of that dependency.

    public function __construct(ContainerInterface $container = null)
    {
        $this->container = $container;
        $this->dependency = $container->get(MockDependency::class);
    }

This functionality means the controllers will no longer need direct access to the Container instance, which in itself isn't a problem, it can become annoying when your dependencies start building up.