### PR TITLE
Set status to 302 if Location header set

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -250,6 +250,34 @@ class Response extends Message implements ResponseInterface
     }
 
     /*******************************************************************************
+     * Headers
+     ******************************************************************************/
+
+    /**
+     * Return an instance with the provided value replacing the specified header.
+     *
+     * If a Location header is set and the status code is 200, then set the status
+     * code to 302 to mimic what PHP does. See https://github.com/slimphp/Slim/issues/1730
+     *
+     * @param string $name Case-insensitive header field name.
+     * @param string|string[] $value Header value(s).
+     * @return static
+     * @throws \InvalidArgumentException for invalid header names or values.
+     */
+    public function withHeader($name, $value)
+    {
+        $clone = clone $this;
+        $clone->headers->set($name, $value);
+
+        if (200 == $clone->getStatusCode() && 'location' == strtolower($name)) {
+            $clone = $clone->withStatus(302);
+        }
+
+        return $clone;
+    }
+
+
+    /*******************************************************************************
      * Body
      ******************************************************************************/
 

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -269,7 +269,7 @@ class Response extends Message implements ResponseInterface
         $clone = clone $this;
         $clone->headers->set($name, $value);
 
-        if (200 == $clone->getStatusCode() && 'location' == strtolower($name)) {
+        if (200 === $clone->getStatusCode() && 'location' === strtolower($name)) {
             $clone = $clone->withStatus(302);
         }
 

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -269,7 +269,7 @@ class Response extends Message implements ResponseInterface
         $clone = clone $this;
         $clone->headers->set($name, $value);
 
-        if (200 === $clone->getStatusCode() && 'location' === strtolower($name)) {
+        if ($clone->getStatusCode() === 200 && strtolower($name) === 'location') {
             $clone = $clone->withStatus(302);
         }
 

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -337,4 +337,20 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         // must have been caught earlier by the test framework
         $this->assertFalse(true);
     }
+
+    public function testStatusIsSetTo302IfLocationIsSetWhenStatusis200()
+    {
+        $response = new Response();
+        $response = $response->withHeader('Location', '/foo');
+
+        $this->assertSame(302, $response->getStatusCode());
+    }
+
+    public function testStatusIsNotSetTo302IfLocationIsSetWhenStatusisNot200()
+    {
+        $response = new Response();
+        $response = $response->withStatus(201)->withHeader('Location', '/foo');
+
+        $this->assertSame(201, $response->getStatusCode());
+    }
 }


### PR DESCRIPTION
If the Location header is set, then set to the status code to 302 if
it is 200. This ensures that code like this still works:

    return $response->withHeader('Location', '/login');

However if the status code is set to something other than 200, when we
assume intent by the user, so do not override their code. e.g. this
code works does not change the status code from 201:

    return $response->withStatus(201)->withHeader('Location', '/item/1');

Closes #2344