### PR TITLE
Add support for PSR-15 middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This will install Slim and all required dependencies. Slim requires PHP 7.1 or n
 Before you can get up and running with Slim you will need to choose a PSR-7 implementation that best fits your application. A few notable ones:
 - [Nyholm/psr7](https://github.com/Nyholm/psr7) - This is the fastest, strictest and most lightweight implementation at the moment
 - [Guzzle/psr7](https://github.com/guzzle/psr7) - This is the implementation used by the Guzzle Client. It is not as strict but adds some nice functionality for Streams and file handling. It is the second fastest implementation but is a bit bulkier
-- [zend-diactoros](https://github.com/zendframework/zend-diactoros) - This is the Zend implementation. It is the slowest implementation of the 3. 
+- [zend-diactoros](https://github.com/zendframework/zend-diactoros) - This is the Zend implementation. It is the slowest implementation of the 3.
 - [Slim-Psr7](https://github.com/slimphp/Slim-Psr7) - This is the Slim Framework projects PSR-7 implementation.
 
 

--- a/Slim/Adapter/PsrMiddleware.php
+++ b/Slim/Adapter/PsrMiddleware.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2018 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Adapter;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * This class wraps a PSR-15 style single pass middleware,
+ * into an invokable double pass middleware.
+ *
+ * This is an internal class. This class is an implementation detail
+ * and is used only inside of the Slim  application; it is not visible
+ * to—and should not be used by—end users.
+ *
+ * @link https://github.com/php-fig/http-server-middleware/blob/master/src/MiddlewareInterface.php
+ * @link https://github.com/php-fig/http-server-handler/blob/master/src/RequestHandlerInterface.php
+ */
+final class PsrMiddleware implements RequestHandlerInterface
+{
+    /**
+     * @var MiddlewareInterface
+     */
+    private $middleware;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    /**
+     * @var callable
+     */
+    private $next;
+
+    public function __construct(MiddlewareInterface $middleware)
+    {
+        $this->middleware = $middleware;
+    }
+
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ): ResponseInterface {
+        $this->response = $response;
+        $this->next = $next;
+
+        /* Call the PSR-15 middleware and let it return to our handle()
+         * method by passing `$this` as RequestHandler. */
+        return $this->middleware->process($request, $this);
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return ($this->next)($request, $this->response);
+    }
+}

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
+use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
@@ -119,14 +120,14 @@ class App implements RequestHandlerInterface
      *
      * This method prepends new middleware to the app's middleware stack.
      *
-     * @param  callable|string    $callable The callback routine
+     * @param  MiddlewareInterface|callable|string    $middleware The middleware routine
      *
      * @return static
      */
-    public function add($callable)
+    public function add($middleware)
     {
         return $this->addMiddleware(
-            new DeferredCallable($callable, $this->getCallableResolver())
+            new DeferredCallable($middleware, $this->getCallableResolver(), true)
         );
     }
 

--- a/Slim/DeferredCallable.php
+++ b/Slim/DeferredCallable.php
@@ -11,12 +11,13 @@ declare(strict_types=1);
 
 namespace Slim;
 
+use Psr\Http\Server\MiddlewareInterface;
 use Slim\Interfaces\CallableResolverInterface;
 
 class DeferredCallable
 {
     /**
-     * @var callable|string
+     * @var MiddlewareInterface|callable|string
      */
     protected $callable;
 
@@ -26,15 +27,22 @@ class DeferredCallable
     protected $callableResolver;
 
     /**
+     * @var bool
+     */
+    protected $resolveMiddleware;
+
+    /**
      * DeferredMiddleware constructor.
      *
-     * @param callable|string $callable
+     * @param MiddlewareInterface|callable|string $callable
      * @param CallableResolverInterface|null $resolver
+     * @param bool $resolveMiddleware
      */
-    public function __construct($callable, CallableResolverInterface $resolver = null)
+    public function __construct($callable, CallableResolverInterface $resolver = null, $resolveMiddleware = false)
     {
         $this->callable = $callable;
         $this->callableResolver = $resolver;
+        $this->resolveMiddleware = $resolveMiddleware;
     }
 
     public function __invoke(...$args)
@@ -42,7 +50,7 @@ class DeferredCallable
         /** @var callable $callable */
         $callable = $this->callable;
         if ($this->callableResolver) {
-            $callable = $this->callableResolver->resolve($callable);
+            $callable = $this->callableResolver->resolve($callable, $this->resolveMiddleware);
         }
 
         return $callable(...$args);

--- a/Slim/DeferredCallable.php
+++ b/Slim/DeferredCallable.php
@@ -37,15 +37,14 @@ class DeferredCallable
         $this->callableResolver = $resolver;
     }
 
-    public function __invoke()
+    public function __invoke(...$args)
     {
         /** @var callable $callable */
         $callable = $this->callable;
         if ($this->callableResolver) {
             $callable = $this->callableResolver->resolve($callable);
         }
-        $args = func_get_args();
 
-        return call_user_func_array($callable, $args);
+        return $callable(...$args);
     }
 }

--- a/Slim/Handlers/Strategies/RequestResponse.php
+++ b/Slim/Handlers/Strategies/RequestResponse.php
@@ -41,6 +41,6 @@ class RequestResponse implements InvocationStrategyInterface
             $request = $request->withAttribute($k, $v);
         }
 
-        return call_user_func($callable, $request, $response, $routeArguments);
+        return $callable($request, $response, $routeArguments);
     }
 }

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -38,8 +38,6 @@ class RequestResponseArgs implements InvocationStrategyInterface
         ResponseInterface $response,
         array $routeArguments
     ): ResponseInterface {
-        array_unshift($routeArguments, $request, $response);
-
-        return call_user_func_array($callable, $routeArguments);
+        return $callable($request, $response, ...array_values($routeArguments));
     }
 }

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -23,8 +23,9 @@ interface CallableResolverInterface
      * Resolve $toResolve into a callable
      *
      * @param mixed $toResolve
+     * @param bool  $resolveMiddleware
      *
      * @return callable
      */
-    public function resolve($toResolve): callable;
+    public function resolve($toResolve, $resolveMiddleware = false): callable;
 }

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -20,7 +20,7 @@ namespace Slim\Interfaces;
 interface CallableResolverInterface
 {
     /**
-     * Invoke the resolved callable.
+     * Resolve $toResolve into a callable
      *
      * @param mixed $toResolve
      *

--- a/Slim/MiddlewareAwareTrait.php
+++ b/Slim/MiddlewareAwareTrait.php
@@ -70,7 +70,7 @@ trait MiddlewareAwareTrait
             $callable,
             $next
         ) {
-            $result = call_user_func($callable, $request, $response, $next);
+            $result = $callable($request, $response, $next);
             if ($result instanceof ResponseInterface === false) {
                 throw new UnexpectedValueException(
                     'Middleware must return instance of \Psr\Http\Message\ResponseInterface'

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Slim;
 
+use Psr\Http\Server\MiddlewareInterface;
 use Slim\Interfaces\CallableResolverInterface;
 
 /**
@@ -90,13 +91,13 @@ abstract class Routable
     /**
      * Prepend middleware to the middleware collection
      *
-     * @param callable|string $callable The callback routine
+     * @param MiddlewareInterface|callable|string $middleware The middleware routine
      *
      * @return static
      */
-    public function add($callable)
+    public function add($middleware)
     {
-        $this->middleware[] = new DeferredCallable($callable, $this->callableResolver);
+        $this->middleware[] = new DeferredCallable($middleware, $this->callableResolver, true);
         return $this;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "psr/container": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
-        "psr/http-server-handler": "^1.0"
+        "psr/http-server-handler": "^1.0",
+        "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "ext-simplexml": "*",

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -20,6 +20,7 @@ use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Handlers\Strategies\RequestResponseArgs;
 use Slim\Router;
 use Slim\Tests\Mocks\MockAction;
+use Slim\Tests\Mocks\Psr15MiddlewareTest;
 
 class AppTest extends TestCase
 {
@@ -972,6 +973,26 @@ class AppTest extends TestCase
         );
 
         $this->assertSame($called, 1);
+    }
+
+    public function testAddPsr15Middleware()
+    {
+        $responseFactory = $this->getResponseFactory();
+        $app = new App($responseFactory);
+        $method = new \ReflectionMethod('Slim\App', 'seedMiddlewareStack');
+        $method->setAccessible(true);
+        $method->invoke($app, function ($req, $res) {
+            return $res;
+        });
+
+        $app->add(new Psr15MiddlewareTest);
+
+        $app->callMiddlewareStack(
+            $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->disableOriginalConstructor()->getMock()
+        );
+
+        $this->assertSame(Psr15MiddlewareTest::$CalledCount, 1);
     }
 
     public function testAddMiddlewareOnRoute()

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -146,6 +146,16 @@ class CallableResolverTest extends TestCase
         $this->assertEquals("1", RequestHandlerTest::$CalledCount);
     }
 
+    public function testResolutionToAPsrRequestHandlerClassWithCustomMethod()
+    {
+        $request = $this->createServerRequest('/', 'GET');
+        $resolver = new CallableResolver(); // No container injected
+        $callable = $resolver->resolve(RequestHandlerTest::class . ':custom');
+        $this->assertInternalType('array', $callable);
+        $this->assertInstanceOf(RequestHandlerTest::class, $callable[0]);
+        $this->assertEquals('custom', $callable[1]);
+    }
+
     /**
      * @expectedException \RuntimeException
      */

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -13,6 +13,7 @@ use Pimple\Psr11\Container;
 use Slim\CallableResolver;
 use Slim\Tests\Mocks\CallableTest;
 use Slim\Tests\Mocks\InvokableTest;
+use Slim\Tests\Mocks\Psr15MiddlewareTest;
 use Slim\Tests\Mocks\RequestHandlerTest;
 
 class CallableResolverTest extends TestCase
@@ -115,6 +116,31 @@ class CallableResolverTest extends TestCase
         $callable = $resolver->resolve('Slim\Tests\Mocks\InvokableTest');
         $callable();
         $this->assertEquals(1, InvokableTest::$CalledCount);
+    }
+
+    public function testResolutionToAPsr15Middleware()
+    {
+        $resolver = new CallableResolver(); // No container injected
+        $middleware = new Psr15MiddlewareTest;
+        $callable = $resolver->resolve($middleware, true);
+        $this->assertInstanceOf('Slim\Adapter\PsrMiddleware', $callable);
+    }
+
+    public function testResolutionToAPsr15MiddlewareFromString()
+    {
+        $resolver = new CallableResolver(); // No container injected
+        $callable = $resolver->resolve('Slim\Tests\Mocks\Psr15MiddlewareTest', true);
+        $this->assertInstanceOf('Slim\Adapter\PsrMiddleware', $callable);
+    }
+
+    public function testResolutionToAPsr15MiddlewareInContainer()
+    {
+        $this->pimple['a_psr15_middleware'] = function ($c) {
+            return new Psr15MiddlewareTest();
+        };
+        $resolver = new CallableResolver($this->container);
+        $callable = $resolver->resolve('a_psr15_middleware', true);
+        $this->assertInstanceOf('Slim\Adapter\PsrMiddleware', $callable);
     }
 
     public function testResolutionToAPsrRequestHandlerClass()

--- a/tests/DeferredCallableTest.php
+++ b/tests/DeferredCallableTest.php
@@ -16,6 +16,12 @@ use Slim\Tests\Mocks\CallableTest;
 
 class DeferredCallableTest extends TestCase
 {
+
+    public function setUp()
+    {
+        CallableTest::$CalledCount = 0;
+    }
+
     public function testItResolvesCallable()
     {
         $pimple = new Pimple();

--- a/tests/Mocks/Psr15MiddlewareTest.php
+++ b/tests/Mocks/Psr15MiddlewareTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2018 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Mocks;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Mock object
+ */
+class Psr15MiddlewareTest implements MiddlewareInterface
+{
+    public static $CalledCount = 0;
+
+    /**
+     * Process a request in PSR-15 style and return a response
+     *
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        static::$CalledCount++;
+
+        return $handler->handle($request);
+    }
+}

--- a/tests/Mocks/RequestHandlerTest.php
+++ b/tests/Mocks/RequestHandlerTest.php
@@ -42,4 +42,9 @@ class RequestHandlerTest implements RequestHandlerInterface
 
         return $response;
     }
+
+    public function custom(ServerRequestInterface $request) : ResponseInterface
+    {
+        return $responseFactory->createResponse();
+    }
 }


### PR DESCRIPTION
PSR-15 middlewares can be registered using the existing API:
`App::add()` and `Routable::add()`
Those methods are extended to accept objects that implement
the MiddlewareInterface (or class names that refer to classes
which implement the MiddlewareInterface).

We do not add new entry points for middleware registration, as the type
of the middleware can be detecting through the MiddlewareInterface
which all PSR-15 middlewares implement.

Both, classes that do not implement MiddlewareInterface, and closures will
be handled as single pass middleware – as before.
That means there's no support for closures with a PSR-15 single-pass
signature.

The detection of the middleware type is implemented
in the callable resolver. While that might look like
something which is out of scope for the CallableResolver, reasons are:

1. The internal slim middleware stack stays at is – it handles callables only.
    (and in cannot be changed anyway as long double-pass middlewares
    need to be supported. Double-pass middlewares expect a Response object
    that needs to be passed along the middleware stack. Therefore we'd need to
    wrap PSR-15 middleware's in any case – which is what this change provides)
2. the CallableResolver resolves (in terms for transforms) a callable
    from PSR-15 style middleware.

TODO: Add more tests for:

- [ ] Adapter\SinglePassMiddleware
- [ ] Routable with PSR-15 Middlewares


Resolves #2050