### PR TITLE
Add public getter for the routes pattern

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -145,6 +145,16 @@ class Route extends Routable implements RouteInterface
     {
         return $this->methods;
     }
+    
+    /**
+     * Get route pattern
+     *
+     * @return string[]
+     */
+    public function getPattern()
+    {
+        return $this->pattern;
+    }
 
     /**
      * Get parent route groups


### PR DESCRIPTION
Simple PR to add a public getter method to the Route class so it can be used elsewhere in the app.