### PR TITLE
4.x New Dispatcher & Routing Results

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -511,12 +511,12 @@ class App
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
         /**
-         * @var DispatcherResults $dispatcherResults
+         * @var RoutingResults $routingResults
          */
-        $dispatcherResults = $request->getAttribute('dispatcherResults');
+        $routingResults = $request->getAttribute('routingResults');
 
         // If routing hasn't been done, then do it now so we can dispatch
-        if ($dispatcherResults === null) {
+        if ($routingResults === null) {
             $router = $this->getRouter();
             $routingMiddleware = new RoutingMiddleware($router);
             $request = $routingMiddleware->performRouting($request);

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -13,6 +13,8 @@ use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
+use Slim\Exception\HttpMethodNotAllowedException;
+use Slim\Exception\HttpNotFoundException;
 use Slim\Http\Headers;
 use Slim\Http\Request;
 use Slim\Http\Response;
@@ -502,23 +504,25 @@ class App
      * @param  ResponseInterface      $response The most recent Response object
      *
      * @return ResponseInterface
+     *
+     * @throws HttpNotFoundException
+     * @throws HttpMethodNotAllowedException
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
     {
-        // Get the route info
-        $routeInfo = $request->getAttribute('routeInfo');
-
-        /** @var \Slim\Interfaces\RouterInterface $router */
-        $router = $this->getRouter();
+        /**
+         * @var DispatcherResults $dispatcherResults
+         */
+        $dispatcherResults = $request->getAttribute('dispatcherResults');
 
         // If routing hasn't been done, then do it now so we can dispatch
-        if ($routeInfo === null) {
+        if ($dispatcherResults === null) {
+            $router = $this->getRouter();
             $routingMiddleware = new RoutingMiddleware($router);
             $request = $routingMiddleware->performRouting($request);
-            $routeInfo = $request->getAttribute('routeInfo');
         }
 
-        $route = $router->lookupRoute($routeInfo[1]);
+        $route = $request->getAttribute('route');
         return $route->run($request, $response);
     }
 

--- a/Slim/Dispatcher.php
+++ b/Slim/Dispatcher.php
@@ -23,9 +23,9 @@ class Dispatcher extends GroupCountBased
     private $uri;
 
     /**
-     * @var array|null
+     * @var array
      */
-    private $allowedMethods;
+    private $allowedMethods = [];
 
     /**
      * @param string $httpMethod
@@ -70,8 +70,7 @@ class Dispatcher extends GroupCountBased
             return $this->dispatcherResultsFromVariableRouteResults($result);
         }
 
-        $this->allowedMethods = $this->getAllowedMethods($httpMethod, $uri);
-        if (count($this->allowedMethods)) {
+        if (count($this->getAllowedMethods($httpMethod, $uri))) {
             return $this->dispatcherResults(self::METHOD_NOT_ALLOWED);
         }
 
@@ -108,14 +107,14 @@ class Dispatcher extends GroupCountBased
      */
     public function getAllowedMethods($httpMethod, $uri)
     {
-        if ($this->allowedMethods !== null) {
-            return $this->allowedMethods;
+        if (isset($this->allowedMethods[$uri])) {
+            return $this->allowedMethods[$uri];
         }
 
-        $this->allowedMethods = [];
+        $this->allowedMethods[$uri] = [];
         foreach ($this->staticRouteMap as $method => $uriMap) {
             if ($method !== $httpMethod && isset($uriMap[$uri])) {
-                $this->allowedMethods[] = $method;
+                $this->allowedMethods[$uri][] = $method;
             }
         }
 
@@ -123,10 +122,10 @@ class Dispatcher extends GroupCountBased
         foreach ($varRouteData as $method => $routeData) {
             $result = $this->dispatchVariableRoute($routeData, $uri);
             if ($result[0] === self::FOUND) {
-                $this->allowedMethods[] = $method;
+                $this->allowedMethods[$uri][] = $method;
             }
         }
 
-        return $this->allowedMethods;
+        return $this->allowedMethods[$uri];
     }
 }

--- a/Slim/Dispatcher.php
+++ b/Slim/Dispatcher.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2017 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+namespace Slim;
+
+use FastRoute\Dispatcher\GroupCountBased;
+
+class Dispatcher extends GroupCountBased
+{
+    /**
+     * @var string
+     */
+    private $httpMethod;
+    /**
+     * @var string
+     */
+    private $uri;
+
+    /**
+     * @param string $httpMethod
+     * @param string $uri
+     * @return DispatcherResults
+     */
+    public function dispatch($httpMethod, $uri)
+    {
+        $this->httpMethod = $httpMethod;
+        $this->uri = $uri;
+
+        if (isset($this->staticRouteMap[$httpMethod][$uri])) {
+            return $this->dispatcherResults(self::FOUND, $this->staticRouteMap[$httpMethod][$uri]);
+        }
+
+        $varRouteData = $this->variableRouteData;
+        if (isset($varRouteData[$httpMethod])) {
+            $result = $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
+            return $this->dispatcherResultsFromVariableRouteResults($result);
+        }
+
+        // For HEAD requests, attempt fallback to GET
+        if ($httpMethod === 'HEAD') {
+            if (isset($this->staticRouteMap['GET'][$uri])) {
+                return $this->dispatcherResults(self::FOUND, $this->staticRouteMap['GET'][$uri]);
+            }
+            if (isset($varRouteData['GET'])) {
+                $result = $this->dispatchVariableRoute($varRouteData['GET'], $uri);
+                return $this->dispatcherResultsFromVariableRouteResults($result);
+            }
+        }
+
+        // If nothing else matches, try fallback routes
+        if (isset($this->staticRouteMap['*'][$uri])) {
+            return $this->dispatcherResults(self::FOUND, $this->staticRouteMap['*'][$uri]);
+        }
+        if (isset($varRouteData['*'])) {
+            $result = $this->dispatchVariableRoute($varRouteData['*'], $uri);
+            return $this->dispatcherResultsFromVariableRouteResults($result);
+        }
+
+        if (count($this->getAllowedMethods($httpMethod, $uri))) {
+            return $this->dispatcherResults(self::METHOD_NOT_ALLOWED);
+        }
+
+        return $this->dispatcherResults(self::NOT_FOUND);
+    }
+
+    /**
+     * @param $status
+     * @param null $handler
+     * @param array $arguments
+     * @return DispatcherResults
+     */
+    protected function dispatcherResults($status, $handler = null, $arguments = [])
+    {
+        return new DispatcherResults($this, $this->httpMethod, $this->uri, $status, $handler, $arguments);
+    }
+
+    /**
+     * @param array $result
+     * @return DispatcherResults
+     */
+    protected function dispatcherResultsFromVariableRouteResults($result)
+    {
+        if ($result[0] === self::FOUND) {
+            return $this->dispatcherResults(self::FOUND, $result[1], $result[2]);
+        }
+        return $this->dispatcherResults(self::NOT_FOUND);
+    }
+
+    /**
+     * @param string $httpMethod
+     * @param string $uri
+     * @param bool $includeRequestedMethod
+     * @return array
+     */
+    public function getAllowedMethods($httpMethod, $uri, $includeRequestedMethod = true)
+    {
+        $httpMethod = $includeRequestedMethod ? 'ArtificialMethod' : $httpMethod;
+
+        $allowedMethods = [];
+        foreach ($this->staticRouteMap as $method => $uriMap) {
+            if ($method !== $httpMethod && isset($uriMap[$uri])) {
+                $allowedMethods[] = $method;
+            }
+        }
+
+        $varRouteData = $this->variableRouteData;
+        foreach ($varRouteData as $method => $routeData) {
+            if ($method === $httpMethod) {
+                continue;
+            }
+            $result = $this->dispatchVariableRoute($routeData, $uri);
+            if ($result[0] === self::FOUND) {
+                $allowedMethods[] = $method;
+            }
+        }
+
+        return $allowedMethods;
+    }
+}

--- a/Slim/Dispatcher.php
+++ b/Slim/Dispatcher.php
@@ -30,7 +30,7 @@ class Dispatcher extends GroupCountBased
     /**
      * @param string $httpMethod
      * @param string $uri
-     * @return DispatcherResults
+     * @return RoutingResults
      */
     public function dispatch($httpMethod, $uri)
     {
@@ -38,66 +38,66 @@ class Dispatcher extends GroupCountBased
         $this->uri = $uri;
 
         if (isset($this->staticRouteMap[$httpMethod][$uri])) {
-            return $this->dispatcherResults(self::FOUND, $this->staticRouteMap[$httpMethod][$uri]);
+            return $this->routingResults(self::FOUND, $this->staticRouteMap[$httpMethod][$uri]);
         }
 
         $varRouteData = $this->variableRouteData;
         if (isset($varRouteData[$httpMethod])) {
             $result = $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
-            $dispatcherResults = $this->dispatcherResultsFromVariableRouteResults($result);
-            if ($dispatcherResults->getRouteStatus() === Dispatcher::FOUND) {
-                return $dispatcherResults;
+            $routingResults = $this->routingResultsFromVariableRouteResults($result);
+            if ($routingResults->getRouteStatus() === Dispatcher::FOUND) {
+                return $routingResults;
             }
         }
 
         // For HEAD requests, attempt fallback to GET
         if ($httpMethod === 'HEAD') {
             if (isset($this->staticRouteMap['GET'][$uri])) {
-                return $this->dispatcherResults(self::FOUND, $this->staticRouteMap['GET'][$uri]);
+                return $this->routingResults(self::FOUND, $this->staticRouteMap['GET'][$uri]);
             }
             if (isset($varRouteData['GET'])) {
                 $result = $this->dispatchVariableRoute($varRouteData['GET'], $uri);
-                return $this->dispatcherResultsFromVariableRouteResults($result);
+                return $this->routingResultsFromVariableRouteResults($result);
             }
         }
 
         // If nothing else matches, try fallback routes
         if (isset($this->staticRouteMap['*'][$uri])) {
-            return $this->dispatcherResults(self::FOUND, $this->staticRouteMap['*'][$uri]);
+            return $this->routingResults(self::FOUND, $this->staticRouteMap['*'][$uri]);
         }
         if (isset($varRouteData['*'])) {
             $result = $this->dispatchVariableRoute($varRouteData['*'], $uri);
-            return $this->dispatcherResultsFromVariableRouteResults($result);
+            return $this->routingResultsFromVariableRouteResults($result);
         }
 
         if (count($this->getAllowedMethods($httpMethod, $uri))) {
-            return $this->dispatcherResults(self::METHOD_NOT_ALLOWED);
+            return $this->routingResults(self::METHOD_NOT_ALLOWED);
         }
 
-        return $this->dispatcherResults(self::NOT_FOUND);
+        return $this->routingResults(self::NOT_FOUND);
     }
 
     /**
      * @param $status
      * @param null $handler
      * @param array $arguments
-     * @return DispatcherResults
+     * @return RoutingResults
      */
-    protected function dispatcherResults($status, $handler = null, $arguments = [])
+    protected function routingResults($status, $handler = null, $arguments = [])
     {
-        return new DispatcherResults($this, $this->httpMethod, $this->uri, $status, $handler, $arguments);
+        return new RoutingResults($this, $this->httpMethod, $this->uri, $status, $handler, $arguments);
     }
 
     /**
      * @param array $result
-     * @return DispatcherResults
+     * @return RoutingResults
      */
-    protected function dispatcherResultsFromVariableRouteResults($result)
+    protected function routingResultsFromVariableRouteResults($result)
     {
         if ($result[0] === self::FOUND) {
-            return $this->dispatcherResults(self::FOUND, $result[1], $result[2]);
+            return $this->routingResults(self::FOUND, $result[1], $result[2]);
         }
-        return $this->dispatcherResults(self::NOT_FOUND);
+        return $this->routingResults(self::NOT_FOUND);
     }
 
     /**

--- a/Slim/Dispatcher.php
+++ b/Slim/Dispatcher.php
@@ -3,7 +3,7 @@
  * Slim Framework (https://slimframework.com)
  *
  * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2017 Josh Lockhart
+ * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 namespace Slim;

--- a/Slim/Dispatcher.php
+++ b/Slim/Dispatcher.php
@@ -16,6 +16,7 @@ class Dispatcher extends GroupCountBased
      * @var string
      */
     private $httpMethod;
+
     /**
      * @var string
      */

--- a/Slim/Dispatcher.php
+++ b/Slim/Dispatcher.php
@@ -38,7 +38,10 @@ class Dispatcher extends GroupCountBased
         $varRouteData = $this->variableRouteData;
         if (isset($varRouteData[$httpMethod])) {
             $result = $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
-            return $this->dispatcherResultsFromVariableRouteResults($result);
+            $dispatcherResults = $this->dispatcherResultsFromVariableRouteResults($result);
+            if ($dispatcherResults->getRouteStatus() === Dispatcher::FOUND) {
+                return $dispatcherResults;
+            }
         }
 
         // For HEAD requests, attempt fallback to GET

--- a/Slim/DispatcherResults.php
+++ b/Slim/DispatcherResults.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2017 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+namespace Slim;
+
+class DispatcherResults
+{
+    /**
+     * @var Dispatcher
+     */
+    protected $dispatcher;
+    /**
+     * @var string
+     */
+    protected $httpMethod;
+    /**
+     * @var string
+     */
+    protected $uri;
+    /**
+     * @var int
+     *
+     * Not Found = 0
+     * Found = 1
+     * Method Not Allowed = 2
+     */
+    protected $routeStatus;
+    /**
+     * @var callable|null
+     */
+    protected $routeHandler;
+    /**
+     * @var array
+     */
+    protected $routeArguments;
+
+    /**
+     * DispatcherResults constructor.
+     * @param Dispatcher $dispatcher
+     * @param $httpMethod
+     * @param $uri
+     * @param int $routeStatus
+     * @param callable|null $routeHandler
+     * @param array $routeArguments
+     */
+    public function __construct(
+        Dispatcher $dispatcher,
+        $httpMethod,
+        $uri,
+        $routeStatus,
+        $routeHandler = null,
+        $routeArguments = []
+    ) {
+        $this->dispatcher = $dispatcher;
+        $this->httpMethod = $httpMethod;
+        $this->uri = $uri;
+        $this->routeStatus = $routeStatus;
+        $this->routeHandler = $routeHandler;
+        $this->routeArguments = $routeArguments;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDispatcher()
+    {
+        return $this->dispatcher;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHttpMethod()
+    {
+        return $this->httpMethod;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRouteStatus()
+    {
+        return $this->routeStatus;
+    }
+
+    /**
+     * @return callable|null
+     */
+    public function getRouteHandler()
+    {
+        return $this->routeHandler;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRouteArguments()
+    {
+        return $this->routeArguments;
+    }
+
+    /**
+     * @param bool $includeRequestedMethod
+     * @return array
+     */
+    public function getAllowedMethods($includeRequestedMethod = true)
+    {
+        return $this->dispatcher->getAllowedMethods($this->httpMethod, $this->uri, $includeRequestedMethod);
+    }
+}

--- a/Slim/DispatcherResults.php
+++ b/Slim/DispatcherResults.php
@@ -3,7 +3,7 @@
  * Slim Framework (https://slimframework.com)
  *
  * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2017 Josh Lockhart
+ * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 namespace Slim;

--- a/Slim/DispatcherResults.php
+++ b/Slim/DispatcherResults.php
@@ -27,10 +27,12 @@ class DispatcherResults
 
     /**
      * @var int
-     *
-     * Not Found = 0
-     * Found = 1
-     * Method Not Allowed = 2
+     * The following statuses are constants from Slim\Dispatcher
+     * Slim\Dispatcher extends FastRoute\Dispatcher\GroupCountBased
+     * Which implements the interface FastRoute\Dispatcher where the original constants are located
+     * Slim\Dispatcher::NOT_FOUND = 0
+     * Slim\Dispatcher::FOUND = 1
+     * Slim\Dispatcher::NOT_ALLOWED = 2
      */
     protected $routeStatus;
 
@@ -115,15 +117,16 @@ class DispatcherResults
      */
     public function getRouteArguments($urlDecode = true)
     {
-        if ($urlDecode) {
-            $routeArguments = [];
-            foreach ($this->routeArguments as $key => $value) {
-                $routeArguments[$key] = urldecode($value);
-            }
-            return $routeArguments;
+        if (!$urlDecode) {
+            return $this->routeArguments;
         }
 
-        return $this->routeArguments;
+        $routeArguments = [];
+        foreach ($this->routeArguments as $key => $value) {
+            $routeArguments[$key] = urldecode($value);
+        }
+
+        return $routeArguments;
     }
 
     /**

--- a/Slim/DispatcherResults.php
+++ b/Slim/DispatcherResults.php
@@ -14,14 +14,17 @@ class DispatcherResults
      * @var Dispatcher
      */
     protected $dispatcher;
+
     /**
      * @var string
      */
     protected $httpMethod;
+
     /**
      * @var string
      */
     protected $uri;
+
     /**
      * @var int
      *
@@ -30,10 +33,12 @@ class DispatcherResults
      * Method Not Allowed = 2
      */
     protected $routeStatus;
+
     /**
      * @var callable|null
      */
     protected $routeHandler;
+
     /**
      * @var array
      */
@@ -105,10 +110,19 @@ class DispatcherResults
     }
 
     /**
+     * @param bool $urlDecode
      * @return array
      */
-    public function getRouteArguments()
+    public function getRouteArguments($urlDecode = true)
     {
+        if ($urlDecode) {
+            $routeArguments = [];
+            foreach ($this->routeArguments as $key => $value) {
+                $routeArguments[$key] = urldecode($value);
+            }
+            return $routeArguments;
+        }
+
         return $this->routeArguments;
     }
 

--- a/Slim/DispatcherResults.php
+++ b/Slim/DispatcherResults.php
@@ -130,11 +130,10 @@ class DispatcherResults
     }
 
     /**
-     * @param bool $includeRequestedMethod
      * @return array
      */
-    public function getAllowedMethods($includeRequestedMethod = true)
+    public function getAllowedMethods()
     {
-        return $this->dispatcher->getAllowedMethods($this->httpMethod, $this->uri, $includeRequestedMethod);
+        return $this->dispatcher->getAllowedMethods($this->httpMethod, $this->uri);
     }
 }

--- a/Slim/Exception/HttpMethodNotAllowedException.php
+++ b/Slim/Exception/HttpMethodNotAllowedException.php
@@ -21,7 +21,7 @@ class HttpMethodNotAllowedException extends HttpSpecializedException
     protected $description = 'The request method is not supported for the requested resource.';
 
     /**
-     * @return string
+     * @return array
      */
     public function getAllowedMethods()
     {

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -11,6 +11,7 @@ namespace Slim\Interfaces;
 use RuntimeException;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
+use Slim\DispatcherResults;
 
 /**
  * Router Interface
@@ -40,7 +41,7 @@ interface RouterInterface
      *
      * @param  ServerRequestInterface $request The current HTTP request object
      *
-     * @return array
+     * @return DispatcherResults
      *
      * @link   https://github.com/nikic/FastRoute/blob/master/src/Dispatcher.php
      */

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -11,7 +11,7 @@ namespace Slim\Interfaces;
 use RuntimeException;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
-use Slim\DispatcherResults;
+use Slim\RoutingResults;
 
 /**
  * Router Interface
@@ -41,7 +41,7 @@ interface RouterInterface
      *
      * @param  ServerRequestInterface $request The current HTTP request object
      *
-     * @return DispatcherResults
+     * @return RoutingResults
      *
      * @link   https://github.com/nikic/FastRoute/blob/master/src/Dispatcher.php
      */

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -61,11 +61,7 @@ class RoutingMiddleware
         $dispatcherResults = $this->router->dispatch($request);
 
         if ($dispatcherResults->getRouteStatus() === Dispatcher::FOUND) {
-            $routeArguments = [];
-            foreach ($dispatcherResults->getRouteArguments() as $k => $v) {
-                $routeArguments[$k] = urldecode($v);
-            }
-
+            $routeArguments = $dispatcherResults->getRouteArguments();
             $route = $this->router->lookupRoute($dispatcherResults->getRouteHandler());
             $route->prepare($request, $routeArguments);
 

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
 use Slim\Interfaces\RouterInterface;
+use RuntimeException;
 
 /**
  * Perform routing and store matched route to the request's attributes
@@ -44,6 +45,7 @@ class RoutingMiddleware
      *
      * @throws HttpNotFoundException
      * @throws HttpMethodNotAllowedException
+     * @throws RuntimeException
      */
     public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
     {
@@ -66,7 +68,6 @@ class RoutingMiddleware
         $routeStatus = $dispatcherResults->getRouteStatus();
 
         switch ($routeStatus) {
-            default:
             case Dispatcher::FOUND:
                 $routeArguments = $dispatcherResults->getRouteArguments();
                 $route = $this->router->lookupRoute($dispatcherResults->getRouteHandler());
@@ -82,6 +83,9 @@ class RoutingMiddleware
                 $exception = new HttpMethodNotAllowedException($request);
                 $exception->setAllowedMethods($dispatcherResults->getAllowedMethods());
                 throw $exception;
+
+            default:
+                throw new RuntimeException('An unexpected error occurred while performing routing.');
         }
     }
 }

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -64,24 +64,24 @@ class RoutingMiddleware
      */
     public function performRouting(ServerRequestInterface $request)
     {
-        $dispatcherResults = $this->router->dispatch($request);
-        $routeStatus = $dispatcherResults->getRouteStatus();
+        $routingResults = $this->router->dispatch($request);
+        $routeStatus = $routingResults->getRouteStatus();
 
         switch ($routeStatus) {
             case Dispatcher::FOUND:
-                $routeArguments = $dispatcherResults->getRouteArguments();
-                $route = $this->router->lookupRoute($dispatcherResults->getRouteHandler());
+                $routeArguments = $routingResults->getRouteArguments();
+                $route = $this->router->lookupRoute($routingResults->getRouteHandler());
                 $route->prepare($request, $routeArguments);
                 return $request
                     ->withAttribute('route', $route)
-                    ->withAttribute('dispatcherResults', $dispatcherResults);
+                    ->withAttribute('routingResults', $routingResults);
 
             case Dispatcher::NOT_FOUND:
                 throw new HttpNotFoundException($request);
 
             case Dispatcher::METHOD_NOT_ALLOWED:
                 $exception = new HttpMethodNotAllowedException($request);
-                $exception->setAllowedMethods($dispatcherResults->getAllowedMethods());
+                $exception->setAllowedMethods($routingResults->getAllowedMethods());
                 throw $exception;
 
             default:

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -212,7 +212,7 @@ class Router implements RouterInterface
      *
      * @param  ServerRequestInterface $request The current HTTP request object
      *
-     * @return DispatcherResults
+     * @return RoutingResults
      */
     public function dispatch(ServerRequestInterface $request)
     {

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -8,7 +8,6 @@
  */
 namespace Slim;
 
-use FastRoute\Dispatcher;
 use InvalidArgumentException;
 use RuntimeException;
 use Psr\Http\Message\ServerRequestInterface;
@@ -85,7 +84,7 @@ class Router implements RouterInterface
     protected $routeGroups = [];
 
     /**
-     * @var \FastRoute\Dispatcher
+     * @var Dispatcher
      */
     protected $dispatcher;
 
@@ -213,9 +212,7 @@ class Router implements RouterInterface
      *
      * @param  ServerRequestInterface $request The current HTTP request object
      *
-     * @return array
-     *
-     * @link   https://github.com/nikic/FastRoute/blob/master/src/Dispatcher.php
+     * @return DispatcherResults
      */
     public function dispatch(ServerRequestInterface $request)
     {
@@ -250,7 +247,7 @@ class Router implements RouterInterface
     }
 
     /**
-     * @return \FastRoute\Dispatcher
+     * @return Dispatcher
      */
     protected function createDispatcher()
     {
@@ -266,11 +263,13 @@ class Router implements RouterInterface
 
         if ($this->cacheFile) {
             $this->dispatcher = \FastRoute\cachedDispatcher($routeDefinitionCallback, [
+                'dispatcher' => '\\Slim\\Dispatcher',
                 'routeParser' => $this->routeParser,
                 'cacheFile' => $this->cacheFile,
             ]);
         } else {
             $this->dispatcher = \FastRoute\simpleDispatcher($routeDefinitionCallback, [
+                'dispatcher' => '\\Slim\\Dispatcher',
                 'routeParser' => $this->routeParser,
             ]);
         }
@@ -279,7 +278,7 @@ class Router implements RouterInterface
     }
 
     /**
-     * @param \FastRoute\Dispatcher $dispatcher
+     * @param Dispatcher $dispatcher
      */
     public function setDispatcher(Dispatcher $dispatcher)
     {

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -216,12 +216,8 @@ class Router implements RouterInterface
      */
     public function dispatch(ServerRequestInterface $request)
     {
-        $uri = '/' . ltrim($request->getUri()->getPath(), '/');
-
-        return $this->createDispatcher()->dispatch(
-            $request->getMethod(),
-            $uri
-        );
+        $uri = '/' . ltrim(rawurldecode($request->getUri()->getPath()), '/');
+        return $this->createDispatcher()->dispatch($request->getMethod(), $uri);
     }
 
     /**

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -263,13 +263,13 @@ class Router implements RouterInterface
 
         if ($this->cacheFile) {
             $this->dispatcher = \FastRoute\cachedDispatcher($routeDefinitionCallback, [
-                'dispatcher' => '\\Slim\\Dispatcher',
+                'dispatcher' => Dispatcher::class,
                 'routeParser' => $this->routeParser,
                 'cacheFile' => $this->cacheFile,
             ]);
         } else {
             $this->dispatcher = \FastRoute\simpleDispatcher($routeDefinitionCallback, [
-                'dispatcher' => '\\Slim\\Dispatcher',
+                'dispatcher' => Dispatcher::class,
                 'routeParser' => $this->routeParser,
             ]);
         }

--- a/Slim/RoutingResults.php
+++ b/Slim/RoutingResults.php
@@ -8,7 +8,7 @@
  */
 namespace Slim;
 
-class DispatcherResults
+class RoutingResults
 {
     /**
      * @var Dispatcher
@@ -47,7 +47,7 @@ class DispatcherResults
     protected $routeArguments;
 
     /**
-     * DispatcherResults constructor.
+     * RoutingResults constructor.
      * @param Dispatcher $dispatcher
      * @param $httpMethod
      * @param $uri
@@ -123,7 +123,7 @@ class DispatcherResults
 
         $routeArguments = [];
         foreach ($this->routeArguments as $key => $value) {
-            $routeArguments[$key] = urldecode($value);
+            $routeArguments[$key] = rawurldecode($value);
         }
 
         return $routeArguments;

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -281,6 +281,25 @@ class AppTest extends TestCase
         $this->assertEquals($destination, $response->getHeaderLine('Location'));
     }
 
+    public function testRouteWithInternationalCharacters()
+    {
+        $app = new App();
+        $app->get('/новости', function ($req, $res) {
+            $res->write('Hello');
+            return $res;
+        });
+
+        // Prepare request and response objects
+        $request = $this->requestFactory('/новости');
+        $response = new Response();
+
+        // Invoke app
+        $resOut = $app($request, $response);
+
+        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
+        $this->assertEquals('Hello', (string)$resOut->getBody());
+    }
+
     /********************************************************************************
      * Route Patterns
      *******************************************************************************/

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Slim\Tests;
 
+use FastRoute\DataGenerator\GroupCountBased;
 use FastRoute\RouteCollector;
 use PHPUnit\Framework\TestCase;
 use Slim\Dispatcher;
@@ -14,12 +15,12 @@ class DispatcherTest extends TestCase
 {
     protected function getDispatcherClass()
     {
-        return 'Slim\\Dispatcher';
+        return Dispatcher::class;
     }
 
     protected function getDataGeneratorClass()
     {
-        return 'FastRoute\\DataGenerator\\GroupCountBased';
+        return GroupCountBased::class;
     }
 
     /**

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -1,0 +1,592 @@
+<?php
+namespace Slim\Tests;
+
+use FastRoute\RouteCollector;
+use PHPUnit\Framework\TestCase;
+use Slim\DispatcherResults;
+
+/**
+ * Class DispatcherTest
+ * @package Slim\Tests
+ */
+class DispatcherTest extends TestCase
+{
+    protected function getDispatcherClass()
+    {
+        return 'Slim\\Dispatcher';
+    }
+
+    protected function getDataGeneratorClass()
+    {
+        return 'FastRoute\\DataGenerator\\GroupCountBased';
+    }
+
+    /**
+     * Set appropriate options for the specific Dispatcher class we're testing
+     */
+    private function generateDispatcherOptions()
+    {
+        return [
+            'dataGenerator' => $this->getDataGeneratorClass(),
+            'dispatcher' => $this->getDispatcherClass()
+        ];
+    }
+
+    /**
+     * @dataProvider provideFoundDispatchCases
+     */
+    public function testFoundDispatches($method, $uri, $callback, $handler, $argDict)
+    {
+        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+
+        /**
+         * @var DispatcherResults $results
+         */
+        $results = $dispatcher->dispatch($method, $uri);
+
+        $this->assertSame($dispatcher::FOUND, $results->getRouteStatus());
+        $this->assertSame($handler, $results->getRouteHandler());
+        $this->assertSame($argDict, $results->getRouteArguments());
+    }
+
+    /**
+     * @dataProvider provideNotFoundDispatchCases
+     */
+    public function testNotFoundDispatches($method, $uri, $callback)
+    {
+        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+
+        /**
+         * @var DispatcherResults $results
+         */
+        $results = $dispatcher->dispatch($method, $uri);
+
+        $this->assertSame($dispatcher::NOT_FOUND, $results->getRouteStatus());
+    }
+
+    /**
+     * @dataProvider provideMethodNotAllowedDispatchCases
+     */
+    public function testMethodNotAllowedDispatches($method, $uri, $callback, $availableMethods)
+    {
+        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+
+        /**
+         * @var DispatcherResults $results
+         */
+        $results = $dispatcher->dispatch($method, $uri);
+
+        $this->assertSame($dispatcher::METHOD_NOT_ALLOWED, $results->getRouteStatus());
+        $this->assertSame($availableMethods, $results->getAllowedMethods(false));
+    }
+
+    /**
+     * @expectedException \FastRoute\BadRouteException
+     * @expectedExceptionMessage Cannot use the same placeholder "test" twice
+     */
+    public function testDuplicateVariableNameError()
+    {
+        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/foo/{test}/{test:\d+}', 'handler0');
+        }, $this->generateDispatcherOptions());
+    }
+
+    /**
+     * @expectedException \FastRoute\BadRouteException
+     * @expectedExceptionMessage Cannot register two routes matching "/user/([^/]+)" for method "GET"
+     */
+    public function testDuplicateVariableRoute()
+    {
+        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{id}', 'handler0'); // oops, forgot \d+ restriction ;)
+            $r->addRoute('GET', '/user/{name}', 'handler1');
+        }, $this->generateDispatcherOptions());
+    }
+
+    /**
+     * @expectedException \FastRoute\BadRouteException
+     * @expectedExceptionMessage Cannot register two routes matching "/user" for method "GET"
+     */
+    public function testDuplicateStaticRoute()
+    {
+        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/user', 'handler0');
+            $r->addRoute('GET', '/user', 'handler1');
+        }, $this->generateDispatcherOptions());
+    }
+
+    /**
+     * @expectedException \FastRoute\BadRouteException
+     * @expectedExceptionMessage Static route "/user/nikic" is shadowed by previously defined variable route "/user/([^/]+)" for method "GET"
+     */
+    public function testShadowedStaticRoute()
+    {
+        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('GET', '/user/nikic', 'handler1');
+        }, $this->generateDispatcherOptions());
+    }
+
+    /**
+     * @expectedException \FastRoute\BadRouteException
+     * @expectedExceptionMessage Regex "(en|de)" for parameter "lang" contains a capturing group
+     */
+    public function testCapturing()
+    {
+        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/{lang:(en|de)}', 'handler0');
+        }, $this->generateDispatcherOptions());
+    }
+
+    public function provideFoundDispatchCases()
+    {
+        $cases = [];
+
+        // 0 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/resource/123/456', 'handler0');
+        };
+
+        $method = 'GET';
+        $uri = '/resource/123/456';
+        $handler = 'handler0';
+        $argDict = [];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 1 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/handler0', 'handler0');
+            $r->addRoute('GET', '/handler1', 'handler1');
+            $r->addRoute('GET', '/handler2', 'handler2');
+        };
+
+        $method = 'GET';
+        $uri = '/handler2';
+        $handler = 'handler2';
+        $argDict = [];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 2 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler0');
+            $r->addRoute('GET', '/user/{id:[0-9]+}', 'handler1');
+            $r->addRoute('GET', '/user/{name}', 'handler2');
+        };
+
+        $method = 'GET';
+        $uri = '/user/rdlowrey';
+        $handler = 'handler2';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 3 -------------------------------------------------------------------------------------->
+
+        // reuse $callback from #2
+
+        $method = 'GET';
+        $uri = '/user/12345';
+        $handler = 'handler1';
+        $argDict = ['id' => '12345'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 4 -------------------------------------------------------------------------------------->
+
+        // reuse $callback from #3
+
+        $method = 'GET';
+        $uri = '/user/NaN';
+        $handler = 'handler2';
+        $argDict = ['name' => 'NaN'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 5 -------------------------------------------------------------------------------------->
+
+        // reuse $callback from #4
+
+        $method = 'GET';
+        $uri = '/user/rdlowrey/12345';
+        $handler = 'handler0';
+        $argDict = ['name' => 'rdlowrey', 'id' => '12345'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 6 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{id:[0-9]+}', 'handler0');
+            $r->addRoute('GET', '/user/12345/extension', 'handler1');
+            $r->addRoute('GET', '/user/{id:[0-9]+}.{extension}', 'handler2');
+        };
+
+        $method = 'GET';
+        $uri = '/user/12345.svg';
+        $handler = 'handler2';
+        $argDict = ['id' => '12345', 'extension' => 'svg'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 7 ----- Test GET method fallback on HEAD route miss ------------------------------------>
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler1');
+            $r->addRoute('GET', '/static0', 'handler2');
+            $r->addRoute('GET', '/static1', 'handler3');
+            $r->addRoute('HEAD', '/static1', 'handler4');
+        };
+
+        $method = 'HEAD';
+        $uri = '/user/rdlowrey';
+        $handler = 'handler0';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 8 ----- Test GET method fallback on HEAD route miss ------------------------------------>
+
+        // reuse $callback from #7
+
+        $method = 'HEAD';
+        $uri = '/user/rdlowrey/1234';
+        $handler = 'handler1';
+        $argDict = ['name' => 'rdlowrey', 'id' => '1234'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 9 ----- Test GET method fallback on HEAD route miss ------------------------------------>
+
+        // reuse $callback from #8
+
+        $method = 'HEAD';
+        $uri = '/static0';
+        $handler = 'handler2';
+        $argDict = [];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 10 ---- Test existing HEAD route used if available (no fallback) ----------------------->
+
+        // reuse $callback from #9
+
+        $method = 'HEAD';
+        $uri = '/static1';
+        $handler = 'handler4';
+        $argDict = [];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 11 ---- More specified routes are not shadowed by less specific of another method ------>
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('POST', '/user/{name:[a-z]+}', 'handler1');
+        };
+
+        $method = 'POST';
+        $uri = '/user/rdlowrey';
+        $handler = 'handler1';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 12 ---- Handler of more specific routes is used, if it occurs first -------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('POST', '/user/{name:[a-z]+}', 'handler1');
+            $r->addRoute('POST', '/user/{name}', 'handler2');
+        };
+
+        $method = 'POST';
+        $uri = '/user/rdlowrey';
+        $handler = 'handler1';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 13 ---- Route with constant suffix ----------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('GET', '/user/{name}/edit', 'handler1');
+        };
+
+        $method = 'GET';
+        $uri = '/user/rdlowrey/edit';
+        $handler = 'handler1';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 14 ---- Handle multiple methods with the same handler ---------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute(['GET', 'POST'], '/user', 'handlerGetPost');
+            $r->addRoute(['DELETE'], '/user', 'handlerDelete');
+            $r->addRoute([], '/user', 'handlerNone');
+        };
+
+        $argDict = [];
+        $cases[] = ['GET', '/user', $callback, 'handlerGetPost', $argDict];
+        $cases[] = ['POST', '/user', $callback, 'handlerGetPost', $argDict];
+        $cases[] = ['DELETE', '/user', $callback, 'handlerDelete', $argDict];
+
+        // 17 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('POST', '/user.json', 'handler0');
+            $r->addRoute('GET', '/{entity}.json', 'handler1');
+        };
+
+        $cases[] = ['GET', '/user.json', $callback, 'handler1', ['entity' => 'user']];
+
+        // 18 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '', 'handler0');
+        };
+
+        $cases[] = ['GET', '', $callback, 'handler0', []];
+
+        // 19 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('HEAD', '/a/{foo}', 'handler0');
+            $r->addRoute('GET', '/b/{foo}', 'handler1');
+        };
+
+        $cases[] = ['HEAD', '/b/bar', $callback, 'handler1', ['foo' => 'bar']];
+
+        // 20 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('HEAD', '/a', 'handler0');
+            $r->addRoute('GET', '/b', 'handler1');
+        };
+
+        $cases[] = ['HEAD', '/b', $callback, 'handler1', []];
+
+        // 21 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/foo', 'handler0');
+            $r->addRoute('HEAD', '/{bar}', 'handler1');
+        };
+
+        $cases[] = ['HEAD', '/foo', $callback, 'handler1', ['bar' => 'foo']];
+
+        // 22 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('*', '/user', 'handler0');
+            $r->addRoute('*', '/{user}', 'handler1');
+            $r->addRoute('GET', '/user', 'handler2');
+        };
+
+        $cases[] = ['GET', '/user', $callback, 'handler2', []];
+
+        // 23 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('*', '/user', 'handler0');
+            $r->addRoute('GET', '/user', 'handler1');
+        };
+
+        $cases[] = ['POST', '/user', $callback, 'handler0', []];
+
+        // 24 ----
+
+        $cases[] = ['HEAD', '/user', $callback, 'handler1', []];
+
+        // 25 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/{bar}', 'handler0');
+            $r->addRoute('*', '/foo', 'handler1');
+        };
+
+        $cases[] = ['GET', '/foo', $callback, 'handler0', ['bar' => 'foo']];
+
+        // 26 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user', 'handler0');
+            $r->addRoute('*', '/{foo:.*}', 'handler1');
+        };
+
+        $cases[] = ['POST', '/bar', $callback, 'handler1', ['foo' => 'bar']];
+
+        // x -------------------------------------------------------------------------------------->
+
+        return $cases;
+    }
+
+    public function provideNotFoundDispatchCases()
+    {
+        $cases = [];
+
+        // 0 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/resource/123/456', 'handler0');
+        };
+
+        $method = 'GET';
+        $uri = '/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 1 -------------------------------------------------------------------------------------->
+
+        // reuse callback from #0
+        $method = 'POST';
+        $uri = '/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 2 -------------------------------------------------------------------------------------->
+
+        // reuse callback from #1
+        $method = 'PUT';
+        $uri = '/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 3 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/handler0', 'handler0');
+            $r->addRoute('GET', '/handler1', 'handler1');
+            $r->addRoute('GET', '/handler2', 'handler2');
+        };
+
+        $method = 'GET';
+        $uri = '/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 4 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler0');
+            $r->addRoute('GET', '/user/{id:[0-9]+}', 'handler1');
+            $r->addRoute('GET', '/user/{name}', 'handler2');
+        };
+
+        $method = 'GET';
+        $uri = '/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 5 -------------------------------------------------------------------------------------->
+
+        // reuse callback from #4
+        $method = 'GET';
+        $uri = '/user/rdlowrey/12345/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 6 -------------------------------------------------------------------------------------->
+
+        // reuse callback from #5
+        $method = 'HEAD';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // x -------------------------------------------------------------------------------------->
+
+        return $cases;
+    }
+
+    public function provideMethodNotAllowedDispatchCases()
+    {
+        $cases = [];
+
+        // 0 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/resource/123/456', 'handler0');
+        };
+
+        $method = 'POST';
+        $uri = '/resource/123/456';
+        $allowedMethods = ['GET'];
+
+        $cases[] = [$method, $uri, $callback, $allowedMethods];
+
+        // 1 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/resource/123/456', 'handler0');
+            $r->addRoute('POST', '/resource/123/456', 'handler1');
+            $r->addRoute('PUT', '/resource/123/456', 'handler2');
+            $r->addRoute('*', '/', 'handler3');
+        };
+
+        $method = 'DELETE';
+        $uri = '/resource/123/456';
+        $allowedMethods = ['GET', 'POST', 'PUT'];
+
+        $cases[] = [$method, $uri, $callback, $allowedMethods];
+
+        // 2 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler0');
+            $r->addRoute('POST', '/user/{name}/{id:[0-9]+}', 'handler1');
+            $r->addRoute('PUT', '/user/{name}/{id:[0-9]+}', 'handler2');
+            $r->addRoute('PATCH', '/user/{name}/{id:[0-9]+}', 'handler3');
+        };
+
+        $method = 'DELETE';
+        $uri = '/user/rdlowrey/42';
+        $allowedMethods = ['GET', 'POST', 'PUT', 'PATCH'];
+
+        $cases[] = [$method, $uri, $callback, $allowedMethods];
+
+        // 3 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('POST', '/user/{name}', 'handler1');
+            $r->addRoute('PUT', '/user/{name:[a-z]+}', 'handler2');
+            $r->addRoute('PATCH', '/user/{name:[a-z]+}', 'handler3');
+        };
+
+        $method = 'GET';
+        $uri = '/user/rdlowrey';
+        $allowedMethods = ['POST', 'PUT', 'PATCH'];
+
+        $cases[] = [$method, $uri, $callback, $allowedMethods];
+
+        // 4 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute(['GET', 'POST'], '/user', 'handlerGetPost');
+            $r->addRoute(['DELETE'], '/user', 'handlerDelete');
+            $r->addRoute([], '/user', 'handlerNone');
+        };
+
+        $cases[] = ['PUT', '/user', $callback, ['GET', 'POST', 'DELETE']];
+
+        // 5
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('POST', '/user.json', 'handler0');
+            $r->addRoute('GET', '/{entity}.json', 'handler1');
+        };
+
+        $cases[] = ['PUT', '/user.json', $callback, ['POST', 'GET']];
+
+        // x -------------------------------------------------------------------------------------->
+
+        return $cases;
+    }
+}

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -5,7 +5,7 @@ use FastRoute\DataGenerator\GroupCountBased;
 use FastRoute\RouteCollector;
 use PHPUnit\Framework\TestCase;
 use Slim\Dispatcher;
-use Slim\DispatcherResults;
+use Slim\RoutingResults;
 
 /**
  * Class DispatcherTest
@@ -41,7 +41,7 @@ class DispatcherTest extends TestCase
         }, $this->generateDispatcherOptions());
 
         /**
-         * @var DispatcherResults $results
+         * @var RoutingResults $results
          */
         $results = $dispatcher->dispatch('GET', '/foo');
 
@@ -56,7 +56,7 @@ class DispatcherTest extends TestCase
         $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
 
         /**
-         * @var DispatcherResults $results
+         * @var RoutingResults $results
          */
         $results = $dispatcher->dispatch($method, $uri);
 
@@ -75,7 +75,7 @@ class DispatcherTest extends TestCase
         $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
 
         /**
-         * @var DispatcherResults $results
+         * @var RoutingResults $results
          */
         $results = $dispatcher->dispatch($method, $uri);
 
@@ -90,7 +90,7 @@ class DispatcherTest extends TestCase
         $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
 
         /**
-         * @var DispatcherResults $results
+         * @var RoutingResults $results
          */
         $results = $dispatcher->dispatch($method, $uri);
 
@@ -105,7 +105,7 @@ class DispatcherTest extends TestCase
         }, $this->generateDispatcherOptions());
 
         /**
-         * @var DispatcherResults $results
+         * @var RoutingResults $results
          */
         $results = $dispatcher->dispatch('GET', '/Foo%20Bar');
         $this->assertEquals($results->getRouteArguments()['name'], 'Foo Bar');

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -95,7 +95,7 @@ class DispatcherTest extends TestCase
         $results = $dispatcher->dispatch($method, $uri);
 
         $this->assertSame($dispatcher::METHOD_NOT_ALLOWED, $results->getRouteStatus());
-        $this->assertSame($availableMethods, $results->getAllowedMethods(false));
+        $this->assertSame($availableMethods, $results->getAllowedMethods());
     }
 
     public function testRouteArgumentsAreUrlDecoded()
@@ -457,6 +457,14 @@ class DispatcherTest extends TestCase
         };
 
         $cases[] = ['POST', '/bar', $callback, 'handler1', ['foo' => 'bar']];
+
+        // 27 --- International characters
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/новости/{name}', 'handler0');
+        };
+
+        $cases[] = ['GET', '/новости/rdlowrey', $callback, 'handler0', ['name' => 'rdlowrey']];
 
         // x -------------------------------------------------------------------------------------->
 

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -13,7 +13,7 @@ use FastRoute\Dispatcher;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Slim\DispatcherResults;
+use Slim\RoutingResults;
 use Slim\Http\Body;
 use Slim\Http\Headers;
 use Slim\Http\Request;
@@ -48,9 +48,9 @@ class RoutingMiddlewareTest extends TestCase
             $this->assertNotNull($route);
             $this->assertEquals('foo', $route->getArgument('name'));
 
-            // dispatcherResults is available
-            $dispatcherResults = $req->getAttribute('dispatcherResults');
-            $this->assertInstanceOf(DispatcherResults::class, $dispatcherResults);
+            // routingResults is available
+            $routingResults = $req->getAttribute('routingResults');
+            $this->assertInstanceOf(RoutingResults::class, $routingResults);
             return $res;
         };
         Closure::bind($next, $this); // bind test class so we can test request object
@@ -76,10 +76,10 @@ class RoutingMiddlewareTest extends TestCase
             $route = $req->getAttribute('route');
             $this->assertNull($route);
 
-            // dispatcherResults is available
-            $dispatcherResults = $req->getAttribute('dispatcherResults');
-            $this->assertInstanceOf(DispatcherResults::class, $dispatcherResults);
-            $this->assertEquals(Dispatcher::METHOD_NOT_ALLOWED, $dispatcherResults->getRouteStatus());
+            // routingResults is available
+            $routingResults = $req->getAttribute('routingResults');
+            $this->assertInstanceOf(RoutingResults::class, $routingResults);
+            $this->assertEquals(Dispatcher::METHOD_NOT_ALLOWED, $routingResults->getRouteStatus());
 
             return $res;
         };

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -13,6 +13,7 @@ use FastRoute\Dispatcher;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Slim\DispatcherResults;
 use Slim\Http\Body;
 use Slim\Http\Headers;
 use Slim\Http\Request;
@@ -47,9 +48,9 @@ class RoutingMiddlewareTest extends TestCase
             $this->assertNotNull($route);
             $this->assertEquals('foo', $route->getArgument('name'));
 
-            // routeInfo is available
-            $routeInfo = $req->getAttribute('routeInfo');
-            $this->assertInternalType('array', $routeInfo);
+            // dispatcherResults is available
+            $dispatcherResults = $req->getAttribute('dispatcherResults');
+            $this->assertInstanceOf(DispatcherResults::class, $dispatcherResults);
             return $res;
         };
         Closure::bind($next, $this); // bind test class so we can test request object
@@ -75,9 +76,10 @@ class RoutingMiddlewareTest extends TestCase
             $route = $req->getAttribute('route');
             $this->assertNull($route);
 
-            // routeInfo is available
-            $routeInfo = $req->getAttribute('routeInfo');
-            $this->assertInternalType('array', $routeInfo);
+            // dispatcherResults is available
+            $dispatcherResults = $req->getAttribute('dispatcherResults');
+            $this->assertInstanceOf(DispatcherResults::class, $dispatcherResults);
+            $this->assertEquals(Dispatcher::METHOD_NOT_ALLOWED, $dispatcherResults->getRouteStatus());
 
             return $res;
         };

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -9,6 +9,8 @@
 namespace Slim\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Slim\Dispatcher;
+use Slim\DispatcherResults;
 use Slim\Router;
 
 class RouterTest extends TestCase
@@ -205,7 +207,7 @@ class RouterTest extends TestCase
         $class = new \ReflectionClass($this->router);
         $method = $class->getMethod('createDispatcher');
         $method->setAccessible(true);
-        $this->assertInstanceOf('\FastRoute\Dispatcher', $method->invoke($this->router));
+        $this->assertInstanceOf('\Slim\Dispatcher', $method->invoke($this->router));
     }
 
     public function testSetDispatcher()
@@ -213,11 +215,11 @@ class RouterTest extends TestCase
         $this->router->setDispatcher(\FastRoute\simpleDispatcher(function ($r) {
             $r->addRoute('GET', '/', function () {
             });
-        }));
+        }, ['dispatcher' => '\\Slim\\Dispatcher']));
         $class = new \ReflectionClass($this->router);
         $prop = $class->getProperty('dispatcher');
         $prop->setAccessible(true);
-        $this->assertInstanceOf('\FastRoute\Dispatcher', $prop->getValue($this->router));
+        $this->assertInstanceOf('\Slim\Dispatcher', $prop->getValue($this->router));
     }
 
     /**
@@ -362,7 +364,7 @@ class RouterTest extends TestCase
         $method->setAccessible(true);
 
         $dispatcher = $method->invoke($this->router);
-        $this->assertInstanceOf('\FastRoute\Dispatcher', $dispatcher);
+        $this->assertInstanceOf('\Slim\Dispatcher', $dispatcher);
         $this->assertFileExists($cacheFile, 'cache file was not created');
 
         // instantiate a new router & load the cached routes file & see if
@@ -375,8 +377,12 @@ class RouterTest extends TestCase
         $method->setAccessible(true);
 
         $dispatcher2 = $method->invoke($this->router);
+
+        /**
+         * @var DispatcherResults $result
+         */
         $result = $dispatcher2->dispatch('GET', '/hello/josh/lockhart');
-        $this->assertSame(\FastRoute\Dispatcher::FOUND, $result[0]);
+        $this->assertSame(Dispatcher::FOUND, $result->getRouteStatus());
 
         unlink($cacheFile);
     }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -207,7 +207,7 @@ class RouterTest extends TestCase
         $class = new \ReflectionClass($this->router);
         $method = $class->getMethod('createDispatcher');
         $method->setAccessible(true);
-        $this->assertInstanceOf('\Slim\Dispatcher', $method->invoke($this->router));
+        $this->assertInstanceOf(Dispatcher::class, $method->invoke($this->router));
     }
 
     public function testSetDispatcher()
@@ -215,11 +215,11 @@ class RouterTest extends TestCase
         $this->router->setDispatcher(\FastRoute\simpleDispatcher(function ($r) {
             $r->addRoute('GET', '/', function () {
             });
-        }, ['dispatcher' => '\\Slim\\Dispatcher']));
+        }, ['dispatcher' => Dispatcher::class]));
         $class = new \ReflectionClass($this->router);
         $prop = $class->getProperty('dispatcher');
         $prop->setAccessible(true);
-        $this->assertInstanceOf('\Slim\Dispatcher', $prop->getValue($this->router));
+        $this->assertInstanceOf(Dispatcher::class, $prop->getValue($this->router));
     }
 
     /**
@@ -364,7 +364,7 @@ class RouterTest extends TestCase
         $method->setAccessible(true);
 
         $dispatcher = $method->invoke($this->router);
-        $this->assertInstanceOf('\Slim\Dispatcher', $dispatcher);
+        $this->assertInstanceOf(Dispatcher::class, $dispatcher);
         $this->assertFileExists($cacheFile, 'cache file was not created');
 
         // instantiate a new router & load the cached routes file & see if
@@ -421,7 +421,7 @@ class RouterTest extends TestCase
         $queryParams = ['a' => 'b', 'c' => 'd'];
 
         //create a router that mocks the pathFor with expected args
-        $router = $this->getMockBuilder('\Slim\Router')->setMethods(['pathFor'])->getMock();
+        $router = $this->getMockBuilder(Router::class)->setMethods(['pathFor'])->getMock();
         $router->expects($this->once())->method('pathFor')->with($name, $data, $queryParams);
         $router->urlFor($name, $data, $queryParams);
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -10,7 +10,7 @@ namespace Slim\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Slim\Dispatcher;
-use Slim\DispatcherResults;
+use Slim\RoutingResults;
 use Slim\Router;
 
 class RouterTest extends TestCase
@@ -379,7 +379,7 @@ class RouterTest extends TestCase
         $dispatcher2 = $method->invoke($this->router);
 
         /**
-         * @var DispatcherResults $result
+         * @var RoutingResults $result
          */
         $result = $dispatcher2->dispatch('GET', '/hello/josh/lockhart');
         $this->assertSame(Dispatcher::FOUND, $result->getRouteStatus());


### PR DESCRIPTION
As per #2399 

As discussed on Slack, there are a few issues with the way `FastRoute\Dispatcher` returns information after a route has been dispatched.

**Issues**
- `FastRoute\Dispatcher::dispatch()` returns an array with an inconsistent structure
- It only appends allowed methods to the return value when no allowed methods have been found on the dispatched route.

**Changes**
- `routeInfo` now deprecated and replaced with `routingResults`
- `RoutingResults` is an immutable object instantiated by the Slim Dispatcher which now offers a way to get all a route's allowed methods which was not accessible before via `FastRoute\GroupCountBased\Dispatcher`

**Usage**
```php
use Slim\App;

$app = new App();
$app->get('/foo', function (Request $request, Response $response) {
    $routingResults = $request->getAttribute('routingResults');
    $uri = $routingResults->getUri();
    $method = $routingResults->getMethod();
    $routeArguments = $routingResults->getRouteArguments();
    $allowedMethods = $routingResults->getAllowedMethods();
});
```

**Status**
- [X] Implement new Dispatcher & Routing Results
- [X] Implement FastRoute test suite for Dispatcher
- [x] Code Review & Discussion