### PR TITLE
Add support of routes, that contain national characters

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -76,6 +76,33 @@ class Route extends Routable implements RouteInterface
     protected $callable;
 
     /**
+     * Convert hexadecimal number (range 0..15) into uppercased hex digit (0..9, A..F)
+     * @param $byte number in range 0..15
+     * @return uppercased hex digit (0..9, A..F) or underscore (in case of error)
+     */
+    public static function digit2hex($byte){
+        if(($byte>=0) && ($byte<=9))
+            return chr($byte+ord('0'));
+        if(($byte>=10) && ($byte<=15))
+            return chr($byte+ord('A')-10);
+        return '_';
+    }
+
+    /**
+     * Convert symbols from higher half of ANSI table into it's percent-encoded presentation
+     * @param $str UTF-8 encoded string
+     * @return string with higher half of ANSI table percent-encoded
+     */
+    public static function patternEncode($str){
+        $arr=str_split($str);
+        foreach ($arr as &$value) {
+            if(ord($value)>127)
+                $value='%' . self::digit2hex(ord($value) >> 4) . self::digit2hex(ord($value) & 0xF);
+        }
+        return implode($arr);
+    }
+
+    /**
      * Create new route
      *
      * @param string|string[]   $methods The route HTTP methods
@@ -87,7 +114,7 @@ class Route extends Routable implements RouteInterface
     public function __construct($methods, $pattern, $callable, $groups = [], $identifier = 0)
     {
         $this->methods  = is_string($methods) ? [$methods] : $methods;
-        $this->pattern  = $pattern;
+        $this->pattern  = self::patternEncode($pattern);
         $this->callable = $callable;
         $this->groups   = $groups;
         $this->identifier = 'route' . $identifier;

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -80,11 +80,14 @@ class Route extends Routable implements RouteInterface
      * @param $byte number in range 0..15
      * @return uppercased hex digit (0..9, A..F) or underscore (in case of error)
      */
-    public static function digit2hex($byte){
-        if(($byte>=0) && ($byte<=9))
+    public static function digit2hex($byte)
+    {
+        if (($byte >= 0) && ($byte <= 9)) {
             return chr($byte+ord('0'));
-        if(($byte>=10) && ($byte<=15))
+        }
+        if (($byte >= 10) && ($byte <= 15)) {
             return chr($byte+ord('A')-10);
+        }
         return '_';
     }
 
@@ -96,8 +99,9 @@ class Route extends Routable implements RouteInterface
     public static function patternEncode($str){
         $arr=str_split($str);
         foreach ($arr as &$value) {
-            if(ord($value)>127)
+            if (ord($value) > 127) {
                 $value='%' . self::digit2hex(ord($value) >> 4) . self::digit2hex(ord($value) & 0xF);
+            }
         }
         return implode($arr);
     }


### PR DESCRIPTION
Add support of routes, that contain national (for me - Russian) characters.

Preface

Some years ago, most browsers began to support national characters in URI, for example:
http://somesite.ru/новости
("новости" is "news" in Russian). This URIs are percent-encoded https://en.wikipedia.org/wiki/Percent-encoding and they are more user-friendly.

Problem

Slim cannot use such uris in routes, because "raw" uri will appears as:
/%D0%BD%D0%BE%D0%B2%D0%BE%D1%81%D1%82%D0%B8
so the plain pattern:
$app->get('/новости', function ($request, $response, $args) {
  // some code
});
won't work.

Solutions

One of the possible solutions is to url-encode all patterns, but in such case, some special for patterns characters, like curly braces will be encoded too early and the pattern wouldn't work.
I found a balanced solution: encode only national characters and don't touch symbols from lower half of ANSI table, this will guarantee, that pattern, that didn't use national characters will work as before, but most routes with national characters (and national characters in combination with safe characters, like latin characters, numbers, underscores etc.) will work perfect too.

Advantage

Routes with national characters will work.

Disadvantage

- A source-file, that defines routes (index.php by default) MUST be UTF-8 encoded. In most cases, this is true, so it's tiny flaw.
- Some complex routes like /новости{1} won't work, but I never saw like uris on real internet sites, so I don't think, that it's a great flaw.