### PR TITLE
Bug fix: Stop Slim overwriting Host header if it's defined (#2391)

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -197,8 +197,10 @@ class Request extends Message implements ServerRequestInterface
             $this->protocolVersion = str_replace('HTTP/', '', $serverParams['SERVER_PROTOCOL']);
         }
 
-        if (!$this->headers->has('Host') || $this->uri->getHost() !== '') {
-            $this->headers->set('Host', $this->uri->getHost());
+        if (!$this->headers->has('Host') && $this->uri->getHost() !== '') {
+            $port = $this->uri->getPort() ? ":{$this->uri->getPort()}" : '';
+
+            $this->headers->set('Host', $this->uri->getHost() . $port);
         }
 
         $this->registerMediaTypeParser('application/json', function ($input) {


### PR DESCRIPTION
See #2391

The previous condition skipped checking if the Host header was already set and would overwrite it with the value from the given URI.

This fixes it to only add the Host header if it's missing and also appends the port if it's non-standard.