### PR TITLE
Allow easier extensions to the main App class

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -59,7 +59,7 @@ class App
      *
      * @var ContainerInterface
      */
-    private $container;
+    protected $container;
 
     /********************************************************************************
      * Constructor


### PR DESCRIPTION
This seems/feels like a miss-type

Either the property should be protected, or the class should be final.
If the `$container` is private, most of the public base class methods would fail, because there the container hasn't been set

This way people will be able to easily extend the Slim\App class.

If this was a deliberate design-choice than, I'm sorry, but I don't see the point.