### PR TITLE
[Slim 4] Add PHP 7.0 type definitions

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim;
 
 use Psr\Container\ContainerInterface;
@@ -50,12 +53,12 @@ class App
     private $container;
 
     /**
-     * @var \Slim\Interfaces\CallableResolverInterface
+     * @var CallableResolverInterface
      */
     protected $callableResolver;
 
     /**
-     * @var \Slim\Interfaces\RouterInterface
+     * @var RouterInterface
      */
     protected $router;
 
@@ -130,7 +133,7 @@ class App
      * @param string $key
      * @return bool
      */
-    public function hasSetting($key)
+    public function hasSetting(string $key): bool
     {
         return isset($this->settings[$key]);
     }
@@ -140,7 +143,7 @@ class App
      *
      * @return array
      */
-    public function getSettings()
+    public function getSettings(): array
     {
         return $this->settings;
     }
@@ -152,7 +155,7 @@ class App
      * @param mixed $defaultValue
      * @return mixed
      */
-    public function getSetting($key, $defaultValue = null)
+    public function getSetting(string $key, $defaultValue = null)
     {
         return $this->hasSetting($key) ? $this->settings[$key] : $defaultValue;
     }
@@ -173,7 +176,7 @@ class App
      * @param string $key
      * @param mixed $value
      */
-    public function addSetting($key, $value)
+    public function addSetting(string $key, $value)
     {
         $this->settings[$key] = $value;
     }
@@ -195,9 +198,9 @@ class App
     /**
      * Get callable resolver
      *
-     * @return CallableResolver|null
+     * @return CallableResolverInterface
      */
-    public function getCallableResolver()
+    public function getCallableResolver(): CallableResolverInterface
     {
         if (! $this->callableResolver instanceof CallableResolverInterface) {
             $this->callableResolver = new CallableResolver($this->container);
@@ -221,7 +224,7 @@ class App
      *
      * @return RouterInterface
      */
-    public function getRouter()
+    public function getRouter(): RouterInterface
     {
         if (! $this->router instanceof RouterInterface) {
             $router = new Router();
@@ -248,9 +251,9 @@ class App
      * @param  string $pattern  The route URI pattern
      * @param  callable|string  $callable The route callback routine
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return RouteInterface
      */
-    public function get($pattern, $callable)
+    public function get(string $pattern, $callable): RouteInterface
     {
         return $this->map(['GET'], $pattern, $callable);
     }
@@ -261,9 +264,9 @@ class App
      * @param  string $pattern  The route URI pattern
      * @param  callable|string  $callable The route callback routine
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return RouteInterface
      */
-    public function post($pattern, $callable)
+    public function post(string $pattern, $callable): RouteInterface
     {
         return $this->map(['POST'], $pattern, $callable);
     }
@@ -274,9 +277,9 @@ class App
      * @param  string $pattern  The route URI pattern
      * @param  callable|string  $callable The route callback routine
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return RouteInterface
      */
-    public function put($pattern, $callable)
+    public function put(string $pattern, $callable): RouteInterface
     {
         return $this->map(['PUT'], $pattern, $callable);
     }
@@ -287,9 +290,9 @@ class App
      * @param  string $pattern  The route URI pattern
      * @param  callable|string  $callable The route callback routine
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return RouteInterface
      */
-    public function patch($pattern, $callable)
+    public function patch(string $pattern, $callable): RouteInterface
     {
         return $this->map(['PATCH'], $pattern, $callable);
     }
@@ -300,9 +303,9 @@ class App
      * @param  string $pattern  The route URI pattern
      * @param  callable|string  $callable The route callback routine
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return RouteInterface
      */
-    public function delete($pattern, $callable)
+    public function delete(string $pattern, $callable): RouteInterface
     {
         return $this->map(['DELETE'], $pattern, $callable);
     }
@@ -313,9 +316,9 @@ class App
      * @param  string $pattern  The route URI pattern
      * @param  callable|string  $callable The route callback routine
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return RouteInterface
      */
-    public function options($pattern, $callable)
+    public function options(string $pattern, $callable): RouteInterface
     {
         return $this->map(['OPTIONS'], $pattern, $callable);
     }
@@ -326,9 +329,9 @@ class App
      * @param  string $pattern  The route URI pattern
      * @param  callable|string  $callable The route callback routine
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return RouteInterface
      */
-    public function any($pattern, $callable)
+    public function any(string $pattern, $callable): RouteInterface
     {
         return $this->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], $pattern, $callable);
     }
@@ -342,7 +345,7 @@ class App
      *
      * @return RouteInterface
      */
-    public function map(array $methods, $pattern, $callable)
+    public function map(array $methods, string $pattern, $callable): RouteInterface
     {
         // Bind route callable to container, if present
         if ($this->container instanceof ContainerInterface && $callable instanceof \Closure) {
@@ -364,7 +367,7 @@ class App
      *
      * @return RouteInterface
      */
-    public function redirect($from, $to, $status = 302)
+    public function redirect(string $from, $to, int $status = 302): RouteInterface
     {
         $handler = function ($request, ResponseInterface $response) use ($to, $status) {
             return $response->withHeader('Location', (string)$to)->withStatus($status);
@@ -385,7 +388,7 @@ class App
      *
      * @return RouteGroupInterface
      */
-    public function group($pattern, $callable)
+    public function group(string $pattern, $callable): RouteGroupInterface
     {
         /** @var RouteGroup $group */
         $router = $this->getRouter();
@@ -412,7 +415,7 @@ class App
      * @param RequestInterface|null $request
      * @return ResponseInterface
      */
-    public function run(RequestInterface $request = null)
+    public function run(RequestInterface $request = null): ResponseInterface
     {
         // create request
         if ($request === null) {
@@ -438,7 +441,7 @@ class App
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    public function respond(ResponseInterface $response)
+    public function respond(ResponseInterface $response): ResponseInterface
     {
         // Send response
         if (!headers_sent()) {
@@ -515,7 +518,7 @@ class App
      * @throws HttpNotFoundException
      * @throws HttpMethodNotAllowedException
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         /**
          * @var RoutingResults $routingResults
@@ -541,7 +544,7 @@ class App
      *
      * @throws \RuntimeException
      */
-    protected function finalize(ResponseInterface $response)
+    protected function finalize(ResponseInterface $response): ResponseInterface
     {
         if ($this->isEmptyResponse($response)) {
             return $response->withoutHeader('Content-Type')->withoutHeader('Content-Length');
@@ -559,7 +562,7 @@ class App
      * @param ResponseInterface $response
      * @return bool
      */
-    protected function isEmptyResponse(ResponseInterface $response)
+    protected function isEmptyResponse(ResponseInterface $response): bool
     {
         if (method_exists($response, 'isEmpty')) {
             return $response->isEmpty();

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -6,10 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim;
 
-use RuntimeException;
 use Psr\Container\ContainerInterface;
+use RuntimeException;
 use Slim\Interfaces\CallableResolverInterface;
 
 /**
@@ -44,7 +47,7 @@ final class CallableResolver implements CallableResolverInterface
      * @throws RuntimeException if the callable does not exist
      * @throws RuntimeException if the callable is not resolvable
      */
-    public function resolve($toResolve)
+    public function resolve($toResolve): callable
     {
         $resolved = $toResolve;
 

--- a/Slim/DeferredCallable.php
+++ b/Slim/DeferredCallable.php
@@ -7,6 +7,8 @@
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
+declare(strict_types=1);
+
 namespace Slim;
 
 use Slim\Interfaces\CallableResolverInterface;

--- a/Slim/Dispatcher.php
+++ b/Slim/Dispatcher.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim;
 
 use FastRoute\Dispatcher\GroupCountBased;
@@ -32,7 +35,7 @@ class Dispatcher extends GroupCountBased
      * @param string $uri
      * @return RoutingResults
      */
-    public function dispatch($httpMethod, $uri)
+    public function dispatch($httpMethod, $uri): RoutingResults
     {
         $this->httpMethod = $httpMethod;
         $this->uri = $uri;
@@ -78,12 +81,12 @@ class Dispatcher extends GroupCountBased
     }
 
     /**
-     * @param $status
-     * @param null $handler
+     * @param int $status
+     * @param string|null $handler
      * @param array $arguments
      * @return RoutingResults
      */
-    protected function routingResults($status, $handler = null, $arguments = [])
+    protected function routingResults(int $status, string $handler = null, array $arguments = []): RoutingResults
     {
         return new RoutingResults($this, $this->httpMethod, $this->uri, $status, $handler, $arguments);
     }
@@ -92,7 +95,7 @@ class Dispatcher extends GroupCountBased
      * @param array $result
      * @return RoutingResults
      */
-    protected function routingResultsFromVariableRouteResults($result)
+    protected function routingResultsFromVariableRouteResults(array $result): RoutingResults
     {
         if ($result[0] === self::FOUND) {
             return $this->routingResults(self::FOUND, $result[1], $result[2]);
@@ -105,7 +108,7 @@ class Dispatcher extends GroupCountBased
      * @param string $uri
      * @return array
      */
-    public function getAllowedMethods($httpMethod, $uri)
+    public function getAllowedMethods(string $httpMethod, string $uri): array
     {
         if (isset($this->allowedMethods[$uri])) {
             return $this->allowedMethods[$uri];

--- a/Slim/Error/AbstractErrorRenderer.php
+++ b/Slim/Error/AbstractErrorRenderer.php
@@ -6,11 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Error;
 
 use Slim\Http\Body;
 use Slim\Interfaces\ErrorRendererInterface;
-use Exception;
 use Throwable;
 
 /**
@@ -22,11 +24,11 @@ use Throwable;
 abstract class AbstractErrorRenderer implements ErrorRendererInterface
 {
     /**
-     * @param Exception|Throwable $exception
+     * @param Throwable $exception
      * @param bool $displayErrorDetails
      * @return Body
      */
-    public function renderWithBody($exception, $displayErrorDetails)
+    public function renderWithBody(Throwable $exception, bool $displayErrorDetails): Body
     {
         $output = $this->render($exception, $displayErrorDetails);
         $body = new Body(fopen('php://temp', 'r+'));

--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -6,10 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Error\Renderers;
 
 use Slim\Error\AbstractErrorRenderer;
-use Exception;
+use Throwable;
 
 /**
  * Default Slim application HTML Error Renderer
@@ -17,11 +20,11 @@ use Exception;
 class HtmlErrorRenderer extends AbstractErrorRenderer
 {
     /**
-     * @param \Exception|\Throwable $exception
+     * @param Throwable $exception
      * @param bool $displayErrorDetails
      * @return string
      */
-    public function render($exception, $displayErrorDetails)
+    public function render(Throwable $exception, bool $displayErrorDetails): string
     {
         $title = 'Slim Application Error';
 
@@ -41,7 +44,7 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
      * @param string $html
      * @return string
      */
-    public function renderHtmlBody($title = '', $html = '')
+    public function renderHtmlBody(string $title = '', string $html = ''): string
     {
         return sprintf(
             "<html>" .
@@ -67,10 +70,10 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
     }
 
     /**
-     * @param Exception $exception
+     * @param Throwable $exception
      * @return string
      */
-    private function renderExceptionFragment($exception)
+    private function renderExceptionFragment(Throwable $exception): string
     {
         $html = sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
 

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -6,9 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Error\Renderers;
 
 use Slim\Error\AbstractErrorRenderer;
+use Throwable;
 
 /**
  * Default Slim application JSON Error Renderer
@@ -16,11 +20,11 @@ use Slim\Error\AbstractErrorRenderer;
 class JsonErrorRenderer extends AbstractErrorRenderer
 {
     /**
-     * @param \Exception|\Throwable $exception
+     * @param Throwable $exception
      * @param bool $displayErrorDetails
      * @return string
      */
-    public function render($exception, $displayErrorDetails)
+    public function render(Throwable $exception, bool $displayErrorDetails): string
     {
         $error = ['message' => $exception->getMessage()];
 
@@ -35,10 +39,10 @@ class JsonErrorRenderer extends AbstractErrorRenderer
     }
 
     /**
-     * @param \Exception|\Throwable $exception
+     * @param Throwable $exception
      * @return array
      */
-    private function formatExceptionFragment($exception)
+    private function formatExceptionFragment(Throwable $exception): array
     {
         return [
             'type' => get_class($exception),

--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -6,9 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Error\Renderers;
 
 use Slim\Error\AbstractErrorRenderer;
+use Throwable;
 
 /**
  * Default Slim application Plain Text Error Renderer
@@ -16,11 +20,11 @@ use Slim\Error\AbstractErrorRenderer;
 class PlainTextErrorRenderer extends AbstractErrorRenderer
 {
     /**
-     * @param \Exception|\Throwable $exception
+     * @param Throwable $exception
      * @param bool $displayErrorDetails
      * @return string
      */
-    public function render($exception, $displayErrorDetails)
+    public function render(Throwable $exception, bool $displayErrorDetails): string
     {
         $text = "Slim Application Error:\n";
         $text .= $this->formatExceptionFragment($exception);
@@ -34,10 +38,10 @@ class PlainTextErrorRenderer extends AbstractErrorRenderer
     }
 
     /**
-     * @param \Exception|\Throwable $exception
+     * @param Throwable $exception
      * @return string
      */
-    private function formatExceptionFragment($exception)
+    private function formatExceptionFragment(Throwable $exception): string
     {
         $text = sprintf("Type: %s\n", get_class($exception));
 

--- a/Slim/Error/Renderers/XmlErrorRenderer.php
+++ b/Slim/Error/Renderers/XmlErrorRenderer.php
@@ -6,9 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Error\Renderers;
 
 use Slim\Error\AbstractErrorRenderer;
+use Throwable;
 
 /**
  * Default Slim application XML Error Renderer
@@ -16,11 +20,11 @@ use Slim\Error\AbstractErrorRenderer;
 class XmlErrorRenderer extends AbstractErrorRenderer
 {
     /**
-     * @param \Exception|\Throwable $exception
+     * @param Throwable $exception
      * @param bool $displayErrorDetails
      * @return string
      */
-    public function render($exception, $displayErrorDetails)
+    public function render(Throwable $exception, bool $displayErrorDetails): string
     {
         $xml = "<error>\n  <message>{$exception->getMessage()}</message>\n";
 
@@ -47,7 +51,7 @@ class XmlErrorRenderer extends AbstractErrorRenderer
      * @param  string $content
      * @return string
      */
-    private function createCdataSection($content)
+    private function createCdataSection(string $content): string
     {
         return sprintf('<![CDATA[%s]]>', str_replace(']]>', ']]]]><![CDATA[>', $content));
     }

--- a/Slim/Exception/HttpBadRequestException.php
+++ b/Slim/Exception/HttpBadRequestException.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Exception;
 
 class HttpBadRequestException extends HttpSpecializedException

--- a/Slim/Exception/HttpException.php
+++ b/Slim/Exception/HttpException.php
@@ -6,10 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Exception;
 
-use Psr\Http\Message\ServerRequestInterface;
 use Exception;
+use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
 class HttpException extends Exception
@@ -20,7 +23,7 @@ class HttpException extends Exception
     protected $request;
 
     /**
-     * @var string|null
+     * @var string
      */
     protected $title = '';
 
@@ -32,12 +35,16 @@ class HttpException extends Exception
     /**
      * HttpException constructor.
      * @param ServerRequestInterface $request
-     * @param string|null $message
+     * @param string $message
      * @param int $code
-     * @param Exception|Throwable|null $previous
+     * @param Throwable|null $previous
      */
-    public function __construct(ServerRequestInterface $request, $message = null, $code = 0, $previous = null)
-    {
+    public function __construct(
+        ServerRequestInterface $request,
+        string $message = '',
+        int $code = 0,
+        Throwable $previous = null
+    ) {
         parent::__construct($message, $code, $previous);
         $this->request = $request;
     }
@@ -45,7 +52,7 @@ class HttpException extends Exception
     /**
      * @param string $title
      */
-    public function setTitle($title)
+    public function setTitle(string $title)
     {
         $this->title = $title;
     }
@@ -53,15 +60,15 @@ class HttpException extends Exception
     /**
      * @param string $description
      */
-    public function setDescription($description)
+    public function setDescription(string $description)
     {
         $this->description = $description;
     }
 
     /**
-     * @return null|ServerRequestInterface
+     * @return ServerRequestInterface
      */
-    public function getRequest()
+    public function getRequest(): ServerRequestInterface
     {
         return $this->request;
     }
@@ -69,7 +76,7 @@ class HttpException extends Exception
     /**
      * @return string
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -77,7 +84,7 @@ class HttpException extends Exception
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }

--- a/Slim/Exception/HttpForbiddenException.php
+++ b/Slim/Exception/HttpForbiddenException.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Exception;
 
 class HttpForbiddenException extends HttpSpecializedException

--- a/Slim/Exception/HttpInternalServerErrorException.php
+++ b/Slim/Exception/HttpInternalServerErrorException.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Exception;
 
 class HttpInternalServerErrorException extends HttpSpecializedException

--- a/Slim/Exception/HttpMethodNotAllowedException.php
+++ b/Slim/Exception/HttpMethodNotAllowedException.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Exception;
 
 class HttpMethodNotAllowedException extends HttpSpecializedException
@@ -23,7 +26,7 @@ class HttpMethodNotAllowedException extends HttpSpecializedException
     /**
      * @return array
      */
-    public function getAllowedMethods()
+    public function getAllowedMethods(): array
     {
         return $this->allowedMethods;
     }

--- a/Slim/Exception/HttpNotFoundException.php
+++ b/Slim/Exception/HttpNotFoundException.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Exception;
 
 class HttpNotFoundException extends HttpSpecializedException

--- a/Slim/Exception/HttpNotImplementedException.php
+++ b/Slim/Exception/HttpNotImplementedException.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Exception;
 
 class HttpNotImplementedException extends HttpSpecializedException

--- a/Slim/Exception/HttpSpecializedException.php
+++ b/Slim/Exception/HttpSpecializedException.php
@@ -23,10 +23,10 @@ abstract class HttpSpecializedException extends HttpException
     /**
      * HttpSpecializedException constructor.
      * @param ServerRequestInterface $request
-     * @param string $message
+     * @param string|null $message
      * @param Throwable|null $previous
      */
-    public function __construct(ServerRequestInterface $request, string $message = '', Throwable $previous = null)
+    public function __construct(ServerRequestInterface $request, string $message = null, Throwable $previous = null)
     {
         if ($message !== null) {
             $this->message = $message;

--- a/Slim/Exception/HttpSpecializedException.php
+++ b/Slim/Exception/HttpSpecializedException.php
@@ -6,10 +6,12 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Exception;
 
 use Psr\Http\Message\ServerRequestInterface;
-use Exception;
 use Throwable;
 
 /**
@@ -21,10 +23,10 @@ abstract class HttpSpecializedException extends HttpException
     /**
      * HttpSpecializedException constructor.
      * @param ServerRequestInterface $request
-     * @param string|null $message
-     * @param Exception|Throwable|null $previous
+     * @param string $message
+     * @param Throwable|null $previous
      */
-    public function __construct(ServerRequestInterface $request, $message = null, $previous = null)
+    public function __construct(ServerRequestInterface $request, string $message = '', Throwable $previous = null)
     {
         if ($message !== null) {
             $this->message = $message;

--- a/Slim/Exception/HttpUnauthorizedException.php
+++ b/Slim/Exception/HttpUnauthorizedException.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Exception;
 
 class HttpUnauthorizedException extends HttpSpecializedException

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -6,21 +6,23 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Handlers;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Slim\Error\Renderers\PlainTextErrorRenderer;
+use RuntimeException;
 use Slim\Error\Renderers\HtmlErrorRenderer;
-use Slim\Error\Renderers\XmlErrorRenderer;
 use Slim\Error\Renderers\JsonErrorRenderer;
+use Slim\Error\Renderers\PlainTextErrorRenderer;
+use Slim\Error\Renderers\XmlErrorRenderer;
 use Slim\Exception\HttpException;
 use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Http\Response;
 use Slim\Interfaces\ErrorHandlerInterface;
 use Slim\Interfaces\ErrorRendererInterface;
-use Exception;
-use RuntimeException;
 use Throwable;
 
 /**
@@ -75,7 +77,7 @@ class ErrorHandler implements ErrorHandlerInterface
     protected $request;
 
     /**
-     * @var Exception
+     * @var Throwable
      */
     protected $exception;
 
@@ -93,7 +95,7 @@ class ErrorHandler implements ErrorHandlerInterface
      * Invoke error handler
      *
      * @param ServerRequestInterface $request   The most recent Request object
-     * @param Exception|Throwable    $exception The caught Exception object
+     * @param Throwable              $exception The caught Exception object
      * @param bool $displayErrorDetails Whether or not to display the error details
      * @param bool $logErrors Whether or not to log errors
      * @param bool $logErrorDetails Whether or not to log error details
@@ -102,11 +104,11 @@ class ErrorHandler implements ErrorHandlerInterface
      */
     public function __invoke(
         ServerRequestInterface $request,
-        $exception,
-        $displayErrorDetails,
-        $logErrors,
-        $logErrorDetails
-    ) {
+        Throwable $exception,
+        bool $displayErrorDetails,
+        bool $logErrors,
+        bool $logErrorDetails
+    ): ResponseInterface {
         $this->displayErrorDetails = $displayErrorDetails;
         $this->logErrors = $logErrors;
         $this->logErrorDetails = $logErrorDetails;
@@ -134,7 +136,7 @@ class ErrorHandler implements ErrorHandlerInterface
      * @param ServerRequestInterface $request
      * @return string
      */
-    protected function determineContentType(ServerRequestInterface $request)
+    protected function determineContentType(ServerRequestInterface $request): string
     {
         $acceptHeader = $request->getHeaderLine('Accept');
         $selectedContentTypes = array_intersect(explode(',', $acceptHeader), $this->knownContentTypes);
@@ -172,7 +174,7 @@ class ErrorHandler implements ErrorHandlerInterface
      *
      * @throws RuntimeException
      */
-    protected function determineRenderer()
+    protected function determineRenderer(): ErrorRendererInterface
     {
         $renderer = $this->renderer;
 
@@ -217,7 +219,7 @@ class ErrorHandler implements ErrorHandlerInterface
     /**
      * @return int
      */
-    protected function determineStatusCode()
+    protected function determineStatusCode(): int
     {
         if ($this->method === 'OPTIONS') {
             return 200;
@@ -233,7 +235,7 @@ class ErrorHandler implements ErrorHandlerInterface
     /**
      * @return ResponseInterface
      */
-    protected function respond()
+    protected function respond(): ResponseInterface
     {
         $response = new Response();
         $body = $this->renderer->renderWithBody($this->exception, $this->displayErrorDetails);
@@ -266,7 +268,7 @@ class ErrorHandler implements ErrorHandlerInterface
      *
      * @param string $error
      */
-    protected function logError($error)
+    protected function logError(string $error)
     {
         error_log($error);
     }

--- a/Slim/Handlers/Strategies/RequestResponse.php
+++ b/Slim/Handlers/Strategies/RequestResponse.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Handlers\Strategies;
 
 use Psr\Http\Message\ResponseInterface;
@@ -21,19 +24,19 @@ class RequestResponse implements InvocationStrategyInterface
      * Invoke a route callable with request, response, and all route parameters
      * as an array of arguments.
      *
-     * @param array|callable         $callable
+     * @param callable               $callable
      * @param ServerRequestInterface $request
      * @param ResponseInterface      $response
      * @param array                  $routeArguments
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,
         ResponseInterface $response,
         array $routeArguments
-    ) {
+    ): ResponseInterface {
         foreach ($routeArguments as $k => $v) {
             $request = $request->withAttribute($k, $v);
         }

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Handlers\Strategies;
 
 use Psr\Http\Message\ResponseInterface;
@@ -22,19 +25,19 @@ class RequestResponseArgs implements InvocationStrategyInterface
      * Invoke a route callable with request, response and all route parameters
      * as individual arguments.
      *
-     * @param array|callable         $callable
+     * @param callable               $callable
      * @param ServerRequestInterface $request
      * @param ResponseInterface      $response
      * @param array                  $routeArguments
      *
-     * @return mixed
+     * @return ResponseInterface
      */
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,
         ResponseInterface $response,
         array $routeArguments
-    ) {
+    ): ResponseInterface {
         array_unshift($routeArguments, $request, $response);
 
         return call_user_func_array($callable, $routeArguments);

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Interfaces;
 
 /**
@@ -23,5 +26,5 @@ interface CallableResolverInterface
      *
      * @return callable
      */
-    public function resolve($toResolve);
+    public function resolve($toResolve): callable;
 }

--- a/Slim/Interfaces/ErrorHandlerInterface.php
+++ b/Slim/Interfaces/ErrorHandlerInterface.php
@@ -6,11 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Interfaces;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Exception;
 use Throwable;
 
 /**
@@ -23,7 +25,7 @@ interface ErrorHandlerInterface
 {
     /**
      * @param ServerRequestInterface $request
-     * @param Exception|Throwable $exception
+     * @param Throwable $exception
      * @param bool $displayErrorDetails
      * @param bool $logErrors
      * @param bool $logErrorDetails
@@ -31,9 +33,9 @@ interface ErrorHandlerInterface
      */
     public function __invoke(
         ServerRequestInterface $request,
-        $exception,
-        $displayErrorDetails,
-        $logErrors,
-        $logErrorDetails
-    );
+        Throwable $exception,
+        bool $displayErrorDetails,
+        bool $logErrors,
+        bool $logErrorDetails
+    ): ResponseInterface;
 }

--- a/Slim/Interfaces/ErrorRendererInterface.php
+++ b/Slim/Interfaces/ErrorRendererInterface.php
@@ -6,7 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Interfaces;
+
+use Slim\Http\Body;
+use Throwable;
 
 /**
  * ErrorRendererInterface
@@ -17,16 +23,16 @@ namespace Slim\Interfaces;
 interface ErrorRendererInterface
 {
     /**
-     * @param \Exception|\Throwable $exception
+     * @param Throwable $exception
      * @param bool $displayErrorDetails
      * @return string
      */
-    public function render($exception, $displayErrorDetails);
+    public function render(Throwable $exception, bool $displayErrorDetails): string;
 
     /**
-     * @param \Exception|\Throwable $exception
+     * @param Throwable $exception
      * @param bool $displayErrorDetails
-     * @return \Slim\Http\Body
+     * @return Body
      */
-    public function renderWithBody($exception, $displayErrorDetails);
+    public function renderWithBody(Throwable $exception, bool $displayErrorDetails): Body;
 }

--- a/Slim/Interfaces/InvocationStrategyInterface.php
+++ b/Slim/Interfaces/InvocationStrategyInterface.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Interfaces;
 
 use Psr\Http\Message\ResponseInterface;
@@ -24,12 +27,12 @@ interface InvocationStrategyInterface
      * @param ResponseInterface      $response The response object.
      * @param array                  $routeArguments The route's placholder arguments
      *
-     * @return ResponseInterface|string The response from the callable.
+     * @return ResponseInterface The response from the callable.
      */
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,
         ResponseInterface $response,
         array $routeArguments
-    );
+    ): ResponseInterface;
 }

--- a/Slim/Interfaces/RouteGroupInterface.php
+++ b/Slim/Interfaces/RouteGroupInterface.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Interfaces;
 
 use Slim\App;
@@ -23,7 +26,7 @@ interface RouteGroupInterface
      *
      * @return string
      */
-    public function getPattern();
+    public function getPattern(): string;
 
     /**
      * Prepend middleware to the group middleware collection

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -6,11 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Interfaces;
 
-use InvalidArgumentException;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Route Interface
@@ -29,14 +31,14 @@ interface RouteInterface
      *
      * @return string|null
      */
-    public function getArgument($name, $default = null);
+    public function getArgument(string $name, $default = null);
 
     /**
      * Get route arguments
      *
      * @return string[]
      */
-    public function getArguments();
+    public function getArguments(): array;
 
     /**
      * Get route name
@@ -50,7 +52,7 @@ interface RouteInterface
      *
      * @return string
      */
-    public function getPattern();
+    public function getPattern(): string;
 
     /**
      * Set a route argument
@@ -60,7 +62,7 @@ interface RouteInterface
      *
      * @return self
      */
-    public function setArgument($name, $value);
+    public function setArgument(string $name, string $value): self;
 
     /**
      * Replace route arguments
@@ -69,7 +71,7 @@ interface RouteInterface
      *
      * @return self
      */
-    public function setArguments(array $arguments);
+    public function setArguments(array $arguments): self;
 
     /**
      * Set route name
@@ -77,9 +79,8 @@ interface RouteInterface
      * @param string $name
      *
      * @return static
-     * @throws InvalidArgumentException if the route name is not a string
      */
-    public function setName($name);
+    public function setName(string $name): self;
 
     /**
      * Add middleware
@@ -111,7 +112,7 @@ interface RouteInterface
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    public function run(ServerRequestInterface $request, ResponseInterface $response);
+    public function run(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface;
 
     /**
      * Dispatch route callable against current Request and Response objects
@@ -125,5 +126,5 @@ interface RouteInterface
      *
      * @return ResponseInterface
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response);
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface;
 }

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -6,11 +6,14 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Interfaces;
 
-use RuntimeException;
 use InvalidArgumentException;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 use Slim\RoutingResults;
 
 /**
@@ -34,7 +37,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function map($methods, $pattern, $handler);
+    public function map(array $methods, string $pattern, $handler): RouteInterface;
 
     /**
      * Dispatch router for HTTP request
@@ -45,7 +48,7 @@ interface RouterInterface
      *
      * @link   https://github.com/nikic/FastRoute/blob/master/src/Dispatcher.php
      */
-    public function dispatch(ServerRequestInterface $request);
+    public function dispatch(ServerRequestInterface $request): RoutingResults;
 
     /**
      * Add a route group to the array
@@ -55,7 +58,7 @@ interface RouterInterface
      *
      * @return RouteGroupInterface
      */
-    public function pushGroup($pattern, $callable);
+    public function pushGroup(string $pattern, $callable): RouteGroupInterface;
 
     /**
      * Removes the last route group from the array
@@ -69,18 +72,18 @@ interface RouterInterface
      *
      * @param string $name        Route name
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return RouteInterface
      *
      * @throws RuntimeException   If named route does not exist
      */
-    public function getNamedRoute($name);
+    public function getNamedRoute(string $name): RouteInterface;
 
     /**
-     * @param $identifier
+     * @param string $identifier
      *
-     * @return \Slim\Interfaces\RouteInterface
+     * @return RouteInterface
      */
-    public function lookupRoute($identifier);
+    public function lookupRoute(string $identifier): RouteInterface;
 
     /**
      * Build the path for a named route excluding the base path
@@ -94,7 +97,7 @@ interface RouterInterface
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
-    public function relativePathFor($name, array $data = [], array $queryParams = []);
+    public function relativePathFor(string $name, array $data = [], array $queryParams = []): string;
 
     /**
      * Build the path for a named route including the base path
@@ -108,7 +111,7 @@ interface RouterInterface
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
-    public function pathFor($name, array $data = [], array $queryParams = []);
+    public function pathFor(string $name, array $data = [], array $queryParams = []): string;
 
     /**
      * Set default route invocation strategy

--- a/Slim/Middleware/ContentLengthMiddleware.php
+++ b/Slim/Middleware/ContentLengthMiddleware.php
@@ -6,11 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Middleware;
 
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Slim\Http\Body;
+use Psr\Http\Message\ServerRequestInterface;
 
 class ContentLengthMiddleware
 {
@@ -22,8 +24,12 @@ class ContentLengthMiddleware
      * @param  callable               $next      Middleware callable
      * @return ResponseInterface                 PSR7 response
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
-    {
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ): ResponseInterface {
+        /** @var ResponseInterface $response */
         $response = $next($request, $response);
 
         // Add Content-Length header if not already added

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Middleware;
 
 use Psr\Http\Message\ResponseInterface;
@@ -14,7 +17,6 @@ use Slim\Exception\HttpException;
 use Slim\Handlers\ErrorHandler;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\ErrorHandlerInterface;
-use Exception;
 use Throwable;
 
 class ErrorMiddleware
@@ -58,9 +60,9 @@ class ErrorMiddleware
      */
     public function __construct(
         CallableResolverInterface $callableResolver,
-        $displayErrorDetails,
-        $logErrors,
-        $logErrorDetails
+        bool $displayErrorDetails,
+        bool $logErrors,
+        bool $logErrorDetails
     ) {
         $this->callableResolver = $callableResolver;
         $this->displayErrorDetails = $displayErrorDetails;
@@ -77,12 +79,13 @@ class ErrorMiddleware
      *
      * @return ResponseInterface
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
-    {
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ): ResponseInterface {
         try {
             return $next($request, $response);
-        } catch (Exception $e) {
-            return $this->handleException($request, $e);
         } catch (Throwable $e) {
             return $this->handleException($request, $e);
         }
@@ -90,10 +93,10 @@ class ErrorMiddleware
 
     /**
      * @param ServerRequestInterface $request
-     * @param Exception|Throwable $exception
+     * @param Throwable $exception
      * @return mixed
      */
-    public function handleException(ServerRequestInterface $request, $exception)
+    public function handleException(ServerRequestInterface $request, Throwable $exception)
     {
         if ($exception instanceof HttpException) {
             $request = $exception->getRequest();
@@ -119,7 +122,7 @@ class ErrorMiddleware
      * @param string $type Exception/Throwable name. ie: RuntimeException::class
      * @return callable|ErrorHandler
      */
-    public function getErrorHandler($type)
+    public function getErrorHandler(string $type)
     {
         if (isset($this->handlers[$type])) {
             return $this->callableResolver->resolve($this->handlers[$type]);
@@ -146,7 +149,7 @@ class ErrorMiddleware
      * @param string $type Exception/Throwable name. ie: RuntimeException::class
      * @param callable|ErrorHandlerInterface $handler
      */
-    public function setErrorHandler($type, $handler)
+    public function setErrorHandler(string $type, $handler)
     {
         $this->handlers[$type] = $handler;
     }

--- a/Slim/Middleware/MethodOverrideMiddleware.php
+++ b/Slim/Middleware/MethodOverrideMiddleware.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Middleware;
 
 use Psr\Http\Message\ResponseInterface;
@@ -24,8 +27,11 @@ class MethodOverrideMiddleware
      * @param  callable               $next      Middleware callable
      * @return ResponseInterface                 PSR7 response
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
-    {
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ): ResponseInterface {
         $methodHeader = $request->getHeaderLine('X-Http-Method-Override');
 
         if ($methodHeader) {

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -6,11 +6,15 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Middleware;
 
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Slim\Http\Body;
+use Throwable;
 
 class OutputBufferingMiddleware
 {
@@ -27,9 +31,9 @@ class OutputBufferingMiddleware
      *
      * @param string $style Either "append" or "prepend"
      */
-    public function __construct($style = 'append')
+    public function __construct(string $style = 'append')
     {
-        if (!is_string($style) || !in_array($style, [static::APPEND, static::PREPEND])) {
+        if (!in_array($style, [static::APPEND, static::PREPEND])) {
             throw new \InvalidArgumentException('Invalid style. Must be one of: append, prepend');
         }
 
@@ -43,16 +47,17 @@ class OutputBufferingMiddleware
      * @param  ResponseInterface      $response  PSR7 response
      * @param  callable               $next      Middleware callable
      * @return ResponseInterface                 PSR7 response
+     * @throws Throwable
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
-    {
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ): ResponseInterface {
         try {
             ob_start();
             $newResponse = $next($request, $response);
             $output = ob_get_clean();
-        } catch (\Exception $e) {
-            ob_end_clean();
-            throw $e;
         } catch (\Throwable $e) {
             ob_end_clean();
             throw $e;

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim\Middleware;
 
 use FastRoute\Dispatcher;
@@ -47,8 +50,11 @@ class RoutingMiddleware
      * @throws HttpMethodNotAllowedException
      * @throws RuntimeException
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $next)
-    {
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ): ResponseInterface {
         $request = $this->performRouting($request);
         return $next($request, $response);
     }
@@ -61,8 +67,9 @@ class RoutingMiddleware
      *
      * @throws HttpNotFoundException
      * @throws HttpMethodNotAllowedException
+     * @throws RuntimeException
      */
-    public function performRouting(ServerRequestInterface $request)
+    public function performRouting(ServerRequestInterface $request): ServerRequestInterface
     {
         $routingResults = $this->router->dispatch($request);
         $routeStatus = $routingResults->getRouteStatus();

--- a/Slim/MiddlewareAwareTrait.php
+++ b/Slim/MiddlewareAwareTrait.php
@@ -6,11 +6,14 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim;
 
-use RuntimeException;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 use UnexpectedValueException;
 
 /**
@@ -50,7 +53,7 @@ trait MiddlewareAwareTrait
      * @throws RuntimeException         If middleware is added while the stack is dequeuing
      * @throws UnexpectedValueException If the middleware doesn't return a Psr\Http\Message\ResponseInterface
      */
-    protected function addMiddleware(callable $callable)
+    protected function addMiddleware(callable $callable): self
     {
         if ($this->middlewareLock) {
             throw new RuntimeException('Middleware can’t be added once the stack is dequeuing');
@@ -106,7 +109,7 @@ trait MiddlewareAwareTrait
      *
      * @return ResponseInterface
      */
-    public function callMiddlewareStack(ServerRequestInterface $request, ResponseInterface $response)
+    public function callMiddlewareStack(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         if (is_null($this->tip)) {
             $this->seedMiddlewareStack();

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim;
 
 use Slim\Interfaces\CallableResolverInterface;
@@ -21,7 +24,7 @@ abstract class Routable
     /**
      * Route callable
      *
-     * @var callable
+     * @var callable|string
      */
     protected $callable;
 
@@ -49,7 +52,7 @@ abstract class Routable
      *
      * @return callable[]
      */
-    public function getMiddleware()
+    public function getMiddleware(): array
     {
         return $this->middleware;
     }
@@ -59,7 +62,7 @@ abstract class Routable
      *
      * @return string
      */
-    public function getPattern()
+    public function getPattern(): string
     {
         return $this->pattern;
     }
@@ -102,7 +105,7 @@ abstract class Routable
      *
      * @param string $newPattern
      */
-    public function setPattern($newPattern)
+    public function setPattern(string $newPattern)
     {
         $this->pattern = $newPattern;
     }

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -6,13 +6,13 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim;
 
-use Exception;
-use Throwable;
-use InvalidArgumentException;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Slim\Handlers\Strategies\RequestResponse;
 use Slim\Interfaces\InvocationStrategyInterface;
 use Slim\Interfaces\RouteInterface;
@@ -74,11 +74,11 @@ class Route extends Routable implements RouteInterface
      *
      * @param string|string[]   $methods The route HTTP methods
      * @param string            $pattern The route pattern
-     * @param callable          $callable The route callable
+     * @param callable|string   $callable The route callable
      * @param RouteGroup[]      $groups The parent route groups
      * @param int               $identifier The route identifier
      */
-    public function __construct($methods, $pattern, $callable, $groups = [], $identifier = 0)
+    public function __construct($methods, string $pattern, $callable, array $groups = [], int $identifier = 0)
     {
         $this->methods  = is_string($methods) ? [$methods] : $methods;
         $this->pattern  = $pattern;
@@ -103,7 +103,7 @@ class Route extends Routable implements RouteInterface
      *
      * @return InvocationStrategyInterface
      */
-    public function getInvocationStrategy()
+    public function getInvocationStrategy(): InvocationStrategyInterface
     {
         return $this->routeInvocationStrategy;
     }
@@ -134,7 +134,7 @@ class Route extends Routable implements RouteInterface
     /**
      * Get route callable
      *
-     * @return callable
+     * @return callable|string
      */
     public function getCallable()
     {
@@ -144,7 +144,7 @@ class Route extends Routable implements RouteInterface
     /**
      * This method enables you to override the Route's callable
      *
-     * @param string|\Closure $callable
+     * @param callable|string $callable
      */
     public function setCallable($callable)
     {
@@ -156,7 +156,7 @@ class Route extends Routable implements RouteInterface
      *
      * @return string[]
      */
-    public function getMethods()
+    public function getMethods(): array
     {
         return $this->methods;
     }
@@ -166,7 +166,7 @@ class Route extends Routable implements RouteInterface
      *
      * @return RouteGroup[]
      */
-    public function getGroups()
+    public function getGroups(): array
     {
         return $this->groups;
     }
@@ -186,7 +186,7 @@ class Route extends Routable implements RouteInterface
      *
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
@@ -197,14 +197,9 @@ class Route extends Routable implements RouteInterface
      * @param string $name
      *
      * @return self
-     *
-     * @throws InvalidArgumentException if the route name is not a string
      */
-    public function setName($name)
+    public function setName(string $name): RouteInterface
     {
-        if (!is_string($name)) {
-            throw new InvalidArgumentException('Route name must be a string');
-        }
         $this->name = $name;
         return $this;
     }
@@ -217,7 +212,7 @@ class Route extends Routable implements RouteInterface
      *
      * @return self
      */
-    public function setArgument($name, $value)
+    public function setArgument(string $name, string $value): RouteInterface
     {
         $this->arguments[$name] = $value;
         return $this;
@@ -230,7 +225,7 @@ class Route extends Routable implements RouteInterface
      *
      * @return self
      */
-    public function setArguments(array $arguments)
+    public function setArguments(array $arguments): RouteInterface
     {
         $this->arguments = $arguments;
         return $this;
@@ -241,7 +236,7 @@ class Route extends Routable implements RouteInterface
      *
      * @return array
      */
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->arguments;
     }
@@ -254,7 +249,7 @@ class Route extends Routable implements RouteInterface
      *
      * @return mixed
      */
-    public function getArgument($name, $default = null)
+    public function getArgument(string $name, $default = null)
     {
         if (array_key_exists($name, $this->arguments)) {
             return $this->arguments[$name];
@@ -292,7 +287,7 @@ class Route extends Routable implements RouteInterface
      *
      * @return ResponseInterface
      */
-    public function run(ServerRequestInterface $request, ResponseInterface $response)
+    public function run(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         // Finalise route now that we are about to run it
         $this->finalize();
@@ -313,7 +308,7 @@ class Route extends Routable implements RouteInterface
      * @return \Psr\Http\Message\ResponseInterface
      * @throws \Exception  if the route callable throws an exception
      */
-    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         // Resolve route callable
         $callable = $this->callable;

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim;
 
 use Slim\Interfaces\RouteGroupInterface;
@@ -23,7 +26,7 @@ class RouteGroup extends Routable implements RouteGroupInterface
      * @param string   $pattern  The pattern prefix for the group
      * @param callable $callable The group callable
      */
-    public function __construct($pattern, $callable)
+    public function __construct(string $pattern, $callable)
     {
         $this->pattern = $pattern;
         $this->callable = $callable;

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim;
 
 use InvalidArgumentException;
@@ -17,8 +20,8 @@ use FastRoute\RouteParser\Std as StdParser;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\InvocationStrategyInterface;
 use Slim\Interfaces\RouteGroupInterface;
-use Slim\Interfaces\RouterInterface;
 use Slim\Interfaces\RouteInterface;
+use Slim\Interfaces\RouterInterface;
 
 /**
  * Router
@@ -124,15 +127,9 @@ class Router implements RouterInterface
      * @param string $basePath
      *
      * @return self
-     *
-     * @throws InvalidArgumentException
      */
-    public function setBasePath($basePath)
+    public function setBasePath(string $basePath): self
     {
-        if (!is_string($basePath)) {
-            throw new InvalidArgumentException('Router basePath must be a string');
-        }
-
         $this->basePath = $basePath;
 
         return $this;
@@ -182,15 +179,9 @@ class Router implements RouterInterface
      * @param  callable $handler The route callable
      *
      * @return RouteInterface
-     *
-     * @throws InvalidArgumentException if the route pattern isn't a string
      */
-    public function map($methods, $pattern, $handler)
+    public function map(array $methods, string $pattern, $handler): RouteInterface
     {
-        if (!is_string($pattern)) {
-            throw new InvalidArgumentException('Route pattern must be a string');
-        }
-
         // Prepend parent group pattern(s)
         if ($this->routeGroups) {
             $pattern = $this->processGroups() . $pattern;
@@ -214,7 +205,7 @@ class Router implements RouterInterface
      *
      * @return RoutingResults
      */
-    public function dispatch(ServerRequestInterface $request)
+    public function dispatch(ServerRequestInterface $request): RoutingResults
     {
         $uri = '/' . ltrim(rawurldecode($request->getUri()->getPath()), '/');
         return $this->createDispatcher()->dispatch($request->getMethod(), $uri);
@@ -227,9 +218,9 @@ class Router implements RouterInterface
      * @param  string   $pattern The route pattern
      * @param  callable $callable The route callable
      *
-     * @return Route
+     * @return RouteInterface
      */
-    protected function createRoute($methods, $pattern, $callable)
+    protected function createRoute(array $methods, string $pattern, $callable): RouteInterface
     {
         $route = new Route($methods, $pattern, $callable, $this->routeGroups, $this->routeCounter);
         if ($this->callableResolver) {
@@ -245,7 +236,7 @@ class Router implements RouterInterface
     /**
      * @return Dispatcher
      */
-    protected function createDispatcher()
+    protected function createDispatcher(): Dispatcher
     {
         if ($this->dispatcher) {
             return $this->dispatcher;
@@ -286,7 +277,7 @@ class Router implements RouterInterface
      *
      * @return Route[]
      */
-    public function getRoutes()
+    public function getRoutes(): array
     {
         return $this->routes;
     }
@@ -296,11 +287,11 @@ class Router implements RouterInterface
      *
      * @param string $name        Route name
      *
-     * @return Route
+     * @return RouteInterface
      *
      * @throws RuntimeException   If named route does not exist
      */
-    public function getNamedRoute($name)
+    public function getNamedRoute(string $name): RouteInterface
     {
         foreach ($this->routes as $route) {
             if ($name == $route->getName()) {
@@ -317,7 +308,7 @@ class Router implements RouterInterface
      *
      * @throws RuntimeException   If named route does not exist
      */
-    public function removeNamedRoute($name)
+    public function removeNamedRoute(string $name)
     {
         $route = $this->getNamedRoute($name);
 
@@ -330,7 +321,7 @@ class Router implements RouterInterface
      *
      * @return string A group pattern to prefix routes with
      */
-    protected function processGroups()
+    protected function processGroups(): string
     {
         $pattern = "";
         foreach ($this->routeGroups as $group) {
@@ -347,7 +338,7 @@ class Router implements RouterInterface
      *
      * @return RouteGroupInterface
      */
-    public function pushGroup($pattern, $callable)
+    public function pushGroup(string $pattern, $callable): RouteGroupInterface
     {
         $group = new RouteGroup($pattern, $callable);
         $this->routeGroups[] = $group;
@@ -365,10 +356,10 @@ class Router implements RouterInterface
     }
 
     /**
-     * @param $identifier
-     * @return \Slim\Interfaces\RouteInterface
+     * @param string $identifier
+     * @return RouteInterface
      */
-    public function lookupRoute($identifier)
+    public function lookupRoute(string $identifier): RouteInterface
     {
         if (!isset($this->routes[$identifier])) {
             throw new RuntimeException('Route not found, looks like your route cache is stale.');
@@ -388,7 +379,7 @@ class Router implements RouterInterface
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
-    public function relativePathFor($name, array $data = [], array $queryParams = [])
+    public function relativePathFor(string $name, array $data = [], array $queryParams = []): string
     {
         $route = $this->getNamedRoute($name);
         $pattern = $route->getPattern();
@@ -452,7 +443,7 @@ class Router implements RouterInterface
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
-    public function pathFor($name, array $data = [], array $queryParams = [])
+    public function pathFor(string $name, array $data = [], array $queryParams = []): string
     {
         $url = $this->relativePathFor($name, $data, $queryParams);
 
@@ -477,7 +468,7 @@ class Router implements RouterInterface
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
-    public function urlFor($name, array $data = [], array $queryParams = [])
+    public function urlFor(string $name, array $data = [], array $queryParams = []): string
     {
         trigger_error('urlFor() is deprecated. Use pathFor() instead.', E_USER_DEPRECATED);
         return $this->pathFor($name, $data, $queryParams);

--- a/Slim/RoutingResults.php
+++ b/Slim/RoutingResults.php
@@ -6,6 +6,9 @@
  * @copyright Copyright (c) 2011-2018 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
+declare(strict_types=1);
+
 namespace Slim;
 
 class RoutingResults
@@ -37,7 +40,7 @@ class RoutingResults
     protected $routeStatus;
 
     /**
-     * @var callable|null
+     * @var null|string
      */
     protected $routeHandler;
 
@@ -49,19 +52,19 @@ class RoutingResults
     /**
      * RoutingResults constructor.
      * @param Dispatcher $dispatcher
-     * @param $httpMethod
-     * @param $uri
+     * @param string $httpMethod
+     * @param string $uri
      * @param int $routeStatus
-     * @param callable|null $routeHandler
+     * @param string|null $routeHandler
      * @param array $routeArguments
      */
     public function __construct(
         Dispatcher $dispatcher,
-        $httpMethod,
-        $uri,
-        $routeStatus,
-        $routeHandler = null,
-        $routeArguments = []
+        string $httpMethod,
+        string $uri,
+        int $routeStatus,
+        string $routeHandler = null,
+        array $routeArguments = []
     ) {
         $this->dispatcher = $dispatcher;
         $this->httpMethod = $httpMethod;
@@ -72,9 +75,9 @@ class RoutingResults
     }
 
     /**
-     * @return mixed
+     * @return Dispatcher
      */
-    public function getDispatcher()
+    public function getDispatcher(): Dispatcher
     {
         return $this->dispatcher;
     }
@@ -82,7 +85,7 @@ class RoutingResults
     /**
      * @return string
      */
-    public function getHttpMethod()
+    public function getHttpMethod(): string
     {
         return $this->httpMethod;
     }
@@ -90,7 +93,7 @@ class RoutingResults
     /**
      * @return string
      */
-    public function getUri()
+    public function getUri(): string
     {
         return $this->uri;
     }
@@ -98,13 +101,13 @@ class RoutingResults
     /**
      * @return int
      */
-    public function getRouteStatus()
+    public function getRouteStatus(): int
     {
         return $this->routeStatus;
     }
 
     /**
-     * @return callable|null
+     * @return null|string
      */
     public function getRouteHandler()
     {
@@ -115,7 +118,7 @@ class RoutingResults
      * @param bool $urlDecode
      * @return array
      */
-    public function getRouteArguments($urlDecode = true)
+    public function getRouteArguments(bool $urlDecode = true): array
     {
         if (!$urlDecode) {
             return $this->routeArguments;
@@ -132,7 +135,7 @@ class RoutingResults
     /**
      * @return array
      */
-    public function getAllowedMethods()
+    public function getAllowedMethods(): array
     {
         return $this->dispatcher->getAllowedMethods($this->httpMethod, $this->uri);
     }

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -173,6 +173,7 @@ class ErrorHandlerTest extends TestCase
         $request = $this->getMockBuilder(Request::class)
             ->disableOriginalConstructor()
             ->getMock();
+        $request->expects($this->any())->method('getHeaderLine')->with('Accept')->willReturn('application/json');
 
         $handler = $this->getMockBuilder(ErrorHandler::class)
             ->setMethods(['writeToErrorLog', 'logError'])

--- a/tests/Mocks/InvocationStrategyTest.php
+++ b/tests/Mocks/InvocationStrategyTest.php
@@ -24,14 +24,14 @@ class InvocationStrategyTest implements InvocationStrategyInterface
      * @param ResponseInterface $response The response object.
      * @param array $routeArguments The route's placholder arguments
      *
-     * @return ResponseInterface|string The response from the callable.
+     * @return ResponseInterface The response from the callable.
      */
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,
         ResponseInterface $response,
         array $routeArguments
-    ) {
+    ): ResponseInterface {
         static::$LastCalledFor = $callable;
 
         return $response;

--- a/tests/Mocks/MockErrorRenderer.php
+++ b/tests/Mocks/MockErrorRenderer.php
@@ -16,11 +16,11 @@ use Slim\Error\AbstractErrorRenderer;
 class MockErrorRenderer extends AbstractErrorRenderer
 {
     /**
-     * @param \Exception|\Throwable $exception
+     * @param \Throwable $exception
      * @param bool $displayErrorDetails
      * @return string
      */
-    public function render($exception, $displayErrorDetails)
+    public function render(\Throwable $exception, bool $displayErrorDetails): string
     {
         return '';
     }

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -171,15 +171,6 @@ class RouteTest extends TestCase
         $this->assertEquals('foo', $route->getName());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testSetInvalidName()
-    {
-        $route = $this->routeFactory();
-        $route->setName(false);
-    }
-
     public function testAddMiddlewareAsStringResolvesWithoutContainer()
     {
         $route = $this->routeFactory();

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -53,20 +53,6 @@ class RouterTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Route pattern must be a string
-     */
-    public function testMapWithInvalidPatternType()
-    {
-        $methods = ['GET'];
-        $pattern = ['foo'];
-        $callable = function ($request, $response, $args) {
-        };
-
-        $this->router->map($methods, $pattern, $callable);
-    }
-
-    /**
      * Base path is ignored by relativePathFor()
      */
     public function testRelativePathFor()
@@ -192,14 +178,6 @@ class RouterTest extends TestCase
         $route->setName('foo');
 
         $this->router->pathFor('bar', ['first' => 'josh', 'last' => 'lockhart']);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testSettingInvalidBasePath()
-    {
-        $this->router->setBasePath(['invalid']);
     }
 
     public function testCreateDispatcher()


### PR DESCRIPTION
According to #2175 I started adding argument  and response type definitions where the type is clear right now. There are still some cases where we can not define some type right now but shouldn't block this one.

~This PR is build upon #2404.~