### PR TITLE
Add a redirect route shortcut

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -12,6 +12,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
 use Slim\Http\Headers;
 use Slim\Http\Request;
 use Slim\Http\Response;
@@ -343,6 +344,24 @@ class App
         $route = $this->getRouter()->map($methods, $pattern, $callable);
 
         return $route;
+    }
+
+    /**
+     * Add a route that sends an HTTP redirect
+     *
+     * @param string              $from
+     * @param string|UriInterface $to
+     * @param int                 $status
+     *
+     * @return RouteInterface
+     */
+    public function redirect($from, $to, $status = 302)
+    {
+        $handler = function ($request, ResponseInterface $response) use ($to, $status) {
+            return $response->withHeader('Location', (string)$to)->withStatus($status);
+        };
+
+        return $this->get($from, $handler);
     }
 
     /**

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -12,6 +12,7 @@ use PHPUnit\Framework\TestCase;
 use Pimple\Container as Pimple;
 use Pimple\Psr11\Container as Psr11Container;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 use Slim\App;
 use Slim\CallableResolver;
 use Slim\Error\Renderers\HtmlErrorRenderer;
@@ -271,6 +272,13 @@ class AppTest extends TestCase
         $routeWithDefaultStatus = $app->redirect($source, $destination);
         $response = $routeWithDefaultStatus->run($this->requestFactory($source), new Response());
         $this->assertEquals(302, $response->getStatusCode());
+
+        $uri = $this->getMockBuilder(UriInterface::class)->getMock();
+        $uri->expects($this->once())->method('__toString')->willReturn($destination);
+
+        $routeToUri = $app->redirect($source, $uri);
+        $response = $routeToUri->run($this->requestFactory($source), new Response());
+        $this->assertEquals($destination, $response->getHeaderLine('Location'));
     }
 
     /********************************************************************************

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -253,6 +253,26 @@ class AppTest extends TestCase
         $this->assertAttributeContains('POST', 'methods', $route);
     }
 
+    public function testRedirectRoute()
+    {
+        $source = '/foo';
+        $destination = '/bar';
+
+        $app = new App();
+        $route = $app->redirect($source, $destination, 301);
+
+        $this->assertInstanceOf('\Slim\Route', $route);
+        $this->assertAttributeContains('GET', 'methods', $route);
+
+        $response = $route->run($this->requestFactory($source), new Response());
+        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals($destination, $response->getHeaderLine('Location'));
+
+        $routeWithDefaultStatus = $app->redirect($source, $destination);
+        $response = $routeWithDefaultStatus->run($this->requestFactory($source), new Response());
+        $this->assertEquals(302, $response->getStatusCode());
+    }
+
     /********************************************************************************
      * Route Patterns
      *******************************************************************************/


### PR DESCRIPTION
Per a short conversation with @akrabat.

(I'm blanket overwriting whatever status code the `ResponseInterface` has because I wasn't sure the flexibility in e.g. `Slim\Http\Response::withRedirect` is necessary at this level, but maybe it's worth keeping the behavior the same for consistency?)