### PR TITLE
Add a redirect() route shortcut, 3.x edition

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -249,6 +249,24 @@ class App
     }
 
     /**
+     * Add a route that sends an HTTP redirect
+     *
+     * @param string              $from
+     * @param string|UriInterface $to
+     * @param int                 $status
+     *
+     * @return RouteInterface
+     */
+    public function redirect($from, $to, $status = 302)
+    {
+        $handler = function ($request, ResponseInterface $response) use ($to, $status) {
+            return $response->withHeader('Location', (string)$to)->withStatus($status);
+        };
+
+        return $this->get($from, $handler);
+    }
+
+    /**
      * Route Groups
      *
      * This method accepts a route pattern and a callback. All route

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -10,6 +10,7 @@
 namespace Slim\Tests;
 
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 use Slim\App;
 use Slim\Container;
 use Slim\Exception\MethodNotAllowedException;
@@ -187,6 +188,13 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $routeWithDefaultStatus = $app->redirect($source, $destination);
         $response = $routeWithDefaultStatus->run($request, new Response());
         $this->assertEquals(302, $response->getStatusCode());
+
+        $uri = $this->getMockBuilder(UriInterface::class)->getMock();
+        $uri->expects($this->once())->method('__toString')->willReturn($destination);
+
+        $routeToUri = $app->redirect($source, $uri);
+        $response = $routeToUri->run($request, new Response());
+        $this->assertEquals($destination, $response->getHeaderLine('Location'));
     }
 
     /********************************************************************************

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -166,6 +166,29 @@ class AppTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeContains('POST', 'methods', $route);
     }
 
+    public function testRedirectRoute()
+    {
+        $source = '/foo';
+        $destination = '/bar';
+
+        $app = new App();
+        $request = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $route = $app->redirect($source, $destination, 301);
+
+        $this->assertInstanceOf('\Slim\Route', $route);
+        $this->assertAttributeContains('GET', 'methods', $route);
+        
+        $response = $route->run($request, new Response());
+        $this->assertEquals(301, $response->getStatusCode());
+        $this->assertEquals($destination, $response->getHeaderLine('Location'));
+
+        $routeWithDefaultStatus = $app->redirect($source, $destination);
+        $response = $routeWithDefaultStatus->run($request, new Response());
+        $this->assertEquals(302, $response->getStatusCode());
+    }
+
     /********************************************************************************
      * Route Patterns
      *******************************************************************************/


### PR DESCRIPTION
Applies #2425 to the `3.x` branch, I think.