### PR TITLE
Bug fix: Reset Route arguments for each call

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -69,6 +69,13 @@ class Route extends Routable implements RouteInterface
     protected $arguments = [];
 
     /**
+     * Route arguments parameters
+     *
+     * @var null|array
+     */
+    protected $savedArguments;
+
+    /**
      * The callable payload
      *
      * @var callable
@@ -286,7 +293,15 @@ class Route extends Routable implements RouteInterface
      */
     public function prepare(ServerRequestInterface $request, array $arguments)
     {
-        // Add the arguments
+        // Save the arguments added on routes
+        if (!isset($this->savedArguments)) {
+            $this->savedArguments = $this->getArguments();
+        }
+
+        // Reset the arguments
+        $this->setArguments($this->savedArguments);
+
+        // Add the route arguments
         foreach ($arguments as $k => $v) {
             $this->setArgument($k, $v);
         }

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -73,7 +73,7 @@ class Route extends Routable implements RouteInterface
      *
      * @var null|array
      */
-    protected $savedArguments;
+    protected $savedArguments = [];
 
     /**
      * The callable payload
@@ -233,11 +233,15 @@ class Route extends Routable implements RouteInterface
      *
      * @param string $name
      * @param string $value
+     * @param bool $temp
      *
      * @return self
      */
-    public function setArgument($name, $value)
+    public function setArgument($name, $value, $temp = false)
     {
+        if (!$temp) {
+            $this->savedArguments[$name] = $value;
+        }
         $this->arguments[$name] = $value;
         return $this;
     }
@@ -246,11 +250,15 @@ class Route extends Routable implements RouteInterface
      * Replace route arguments
      *
      * @param array $arguments
+     * @param bool $temp
      *
      * @return self
      */
-    public function setArguments(array $arguments)
+    public function setArguments(array $arguments, $temp = false)
     {
+        if (!$temp) {
+            $this->savedArguments = $arguments;
+        }
         $this->arguments = $arguments;
         return $this;
     }
@@ -293,17 +301,12 @@ class Route extends Routable implements RouteInterface
      */
     public function prepare(ServerRequestInterface $request, array $arguments)
     {
-        // Save the arguments added on routes
-        if (!isset($this->savedArguments)) {
-            $this->savedArguments = $this->getArguments();
-        }
-
-        // Reset the arguments
+        // Remove temp arguments
         $this->setArguments($this->savedArguments);
 
         // Add the route arguments
         foreach ($arguments as $k => $v) {
-            $this->setArgument($k, $v);
+            $this->setArgument($k, $v, true);
         }
     }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -2317,6 +2317,102 @@ end;
         $this->assertStringStartsWith('output buffer test', $output);
     }
 
+    public function testInvokeSequentialProccessToAPathWithOptionalArgsAndWithoutOptionalArgs()
+    {
+        $app = new App();
+        $app->get('/foo[/{bar}]', function ($req, $res, $args) {
+            return $res->write(count($args));
+        });
+
+        // Prepare request and response objects
+        $env = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'REQUEST_METHOD' => 'GET',
+        ]);
+        $uri = Uri::createFromEnvironment($env);
+        $headers = Headers::createFromEnvironment($env);
+        $cookies = [];
+        $serverParams = $env->all();
+        $body = new RequestBody();
+        $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+        $res = new Response();
+
+        // Invoke process with optional arg
+        $resOut = $app->process($req, $res);
+
+        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
+        $this->assertEquals('1', (string)$resOut->getBody());
+
+        // Prepare request and response objects
+        $env = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo',
+            'REQUEST_METHOD' => 'GET',
+        ]);
+        $uri = Uri::createFromEnvironment($env);
+        $headers = Headers::createFromEnvironment($env);
+        $cookies = [];
+        $serverParams = $env->all();
+        $body = new RequestBody();
+        $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+        $res = new Response();
+
+        // Invoke process with optional arg
+        $resOut2 = $app->process($req, $res);
+
+        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut2);
+        $this->assertEquals('0', (string)$resOut2->getBody());
+    }
+
+    public function testInvokeSequentialProccessToAPathWithOptionalArgsAndWithoutOptionalArgsAndKeepSetedArgs()
+    {
+        $app = new App();
+        $app->get('/foo[/{bar}]', function ($req, $res, $args) {
+            return $res->write(count($args));
+        })->setArgument('baz', 'quux');
+
+        // Prepare request and response objects
+        $env = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'REQUEST_METHOD' => 'GET',
+        ]);
+        $uri = Uri::createFromEnvironment($env);
+        $headers = Headers::createFromEnvironment($env);
+        $cookies = [];
+        $serverParams = $env->all();
+        $body = new RequestBody();
+        $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+        $res = new Response();
+
+        // Invoke process with optional arg
+        $resOut = $app->process($req, $res);
+
+        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
+        $this->assertEquals('2', (string)$resOut->getBody());
+
+        // Prepare request and response objects
+        $env = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo',
+            'REQUEST_METHOD' => 'GET',
+        ]);
+        $uri = Uri::createFromEnvironment($env);
+        $headers = Headers::createFromEnvironment($env);
+        $cookies = [];
+        $serverParams = $env->all();
+        $body = new RequestBody();
+        $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+        $res = new Response();
+
+        // Invoke process with optional arg
+        $resOut2 = $app->process($req, $res);
+
+        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut2);
+        $this->assertEquals('1', (string)$resOut2->getBody());
+    }
+
     protected function skipIfPhp70()
     {
         if (version_compare(PHP_VERSION, '7.0', '>=')) {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -2358,7 +2358,7 @@ end;
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
-        // Invoke process with optional arg
+        // Invoke process without optional arg
         $resOut2 = $app->process($req, $res);
 
         $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut2);
@@ -2386,7 +2386,7 @@ end;
         $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
         $res = new Response();
 
-        // Invoke process with optional arg
+        // Invoke process without optional arg
         $resOut = $app->process($req, $res);
 
         $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
@@ -2411,6 +2411,57 @@ end;
 
         $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut2);
         $this->assertEquals('1', (string)$resOut2->getBody());
+    }
+
+    public function testInvokeSequentialProccessAfterAddingAnotherRouteArgument()
+    {
+        $app = new App();
+        $route = $app->get('/foo[/{bar}]', function ($req, $res, $args) {
+            return $res->write(count($args));
+        })->setArgument('baz', 'quux');
+
+        // Prepare request and response objects
+        $env = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'REQUEST_METHOD' => 'GET',
+        ]);
+        $uri = Uri::createFromEnvironment($env);
+        $headers = Headers::createFromEnvironment($env);
+        $cookies = [];
+        $serverParams = $env->all();
+        $body = new RequestBody();
+        $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+        $res = new Response();
+
+        // Invoke process with optional arg
+        $resOut = $app->process($req, $res);
+
+        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut);
+        $this->assertEquals('2', (string)$resOut->getBody());
+
+        // Prepare request and response objects
+        $env = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'REQUEST_METHOD' => 'GET',
+        ]);
+        $uri = Uri::createFromEnvironment($env);
+        $headers = Headers::createFromEnvironment($env);
+        $cookies = [];
+        $serverParams = $env->all();
+        $body = new RequestBody();
+        $req = new Request('GET', $uri, $headers, $cookies, $serverParams, $body);
+        $res = new Response();
+
+        // add another argument
+        $route->setArgument('one', '1');
+
+        // Invoke process with optional arg
+        $resOut2 = $app->process($req, $res);
+
+        $this->assertInstanceOf('\Psr\Http\Message\ResponseInterface', $resOut2);
+        $this->assertEquals('3', (string)$resOut2->getBody());
     }
 
     protected function skipIfPhp70()


### PR DESCRIPTION
Route arguments weren't reset for each call of `App::process` and if the route had optional arguments on the url this could cause unexpected behaviors.

This Fix #2430 