### PR TITLE
308 is also a redirect code

### DIFF
--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -433,7 +433,8 @@ class Response extends Message implements ResponseInterface
                 StatusCode::HTTP_MOVED_PERMANENTLY,
                 StatusCode::HTTP_FOUND,
                 StatusCode::HTTP_SEE_OTHER,
-                StatusCode::HTTP_TEMPORARY_REDIRECT
+                StatusCode::HTTP_TEMPORARY_REDIRECT,
+                StatusCode::HTTP_PERMANENT_REDIRECT
             ]
         );
     }


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location,

> Status of responses including a Location header: 201, 301, 302, 303, 307, 308

I am not sure 201 is appropriate here but 308 was missing from the list.