### PR TITLE
Update docbock for Request::getParam() second param's type

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1134,7 +1134,7 @@ class Request extends Message implements ServerRequestInterface
      * Note: This method is not part of the PSR-7 standard.
      *
      * @param  string $key The parameter key.
-     * @param  string $default The default value.
+     * @param  mixed $default The default value.
      *
      * @return mixed The parameter value.
      */


### PR DESCRIPTION
`getParam` method `$default` argument type is marked as string, but actually any type of parameters can be passed for `$default` argument and everything will work. That's why I changed it's type to `mixed`