### PR TITLE
4.x Fix Travis Build Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - php: 7.0
     - php: 7.1
       env: ANALYSIS='true'
+    - php: 7.2
     - php: nightly
   allow_failures:
     - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,9 @@ dist: trusty
 
 matrix:
   include:
-    - php: 5.6
     - php: 7.0
     - php: 7.1
       env: ANALYSIS='true'
-    - php: hhvm
-    - php: 5.6
-      env: COMPOSER_ARGS='--prefer-lowest'
     - php: nightly
   allow_failures:
     - php: nightly


### PR DESCRIPTION
Remove HHVM and PHP 5.6 from Travis build configuration