### PR TITLE
Bug Fix: Make string comparison more strict in Slim\Http\Uri class

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -338,7 +338,7 @@ class Uri implements UriInterface
         $host = $this->getHost();
         $port = $this->getPort();
 
-        return ($userInfo ? $userInfo . '@' : '') . $host . ($port !== null ? ':' . $port : '');
+        return ($userInfo !== '' ? $userInfo . '@' : '') . $host . ($port !== null ? ':' . $port : '');
     }
 
     /**
@@ -358,7 +358,7 @@ class Uri implements UriInterface
      */
     public function getUserInfo()
     {
-        return $this->user . ($this->password ? ':' . $this->password : '');
+        return $this->user . ($this->password !== '' ? ':' . $this->password : '');
     }
 
     /**
@@ -379,8 +379,8 @@ class Uri implements UriInterface
     {
         $clone = clone $this;
         $clone->user = $this->filterUserInfo($user);
-        if ($clone->user) {
-            $clone->password = $password ? $this->filterUserInfo($password) : '';
+        if ('' !== $clone->user) {
+            $clone->password = !in_array($password, [null, ''], true) ? $this->filterUserInfo($password) : '';
         } else {
             $clone->password = '';
         }
@@ -812,11 +812,11 @@ class Uri implements UriInterface
 
         $path = $basePath . '/' . ltrim($path, '/');
 
-        return ($scheme ? $scheme . ':' : '')
-            . ($authority ? '//' . $authority : '')
+        return ($scheme !== '' ? $scheme . ':' : '')
+            . ($authority !== '' ? '//' . $authority : '')
             . $path
-            . ($query ? '?' . $query : '')
-            . ($fragment ? '#' . $fragment : '');
+            . ($query !== '' ? '?' . $query : '')
+            . ($fragment !== '' ? '#' . $fragment : '');
     }
 
     /**
@@ -834,11 +834,11 @@ class Uri implements UriInterface
         $authority = $this->getAuthority();
         $basePath = $this->getBasePath();
 
-        if ($authority && substr($basePath, 0, 1) !== '/') {
+        if ($authority !== '' && substr($basePath, 0, 1) !== '/') {
             $basePath = $basePath . '/' . $basePath;
         }
 
-        return ($scheme ? $scheme . ':' : '')
+        return ($scheme !== '' ? $scheme . ':' : '')
             . ($authority ? '//' . $authority : '')
             . rtrim($basePath, '/');
     }

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -699,4 +699,16 @@ class UriTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals('abc=123', $uri->getQuery());
     }
+
+    public function testUriDistinguishZeroFromEmptyString()
+    {
+        $expected = 'https://0:0@0:1/0?0#0';
+        $this->assertSame($expected, (string) Uri::createFromString($expected));
+    }
+
+    public function testGetBaseUrlDistinguishZeroFromEmptyString()
+    {
+        $expected = 'https://0:0@0:1/0?0#0';
+        $this->assertSame('https://0:0@0:1', (string) Uri::createFromString($expected)->getBaseUrl());
+    }
 }


### PR DESCRIPTION
This PR resolves the following bug in the `Uri` class:

```php
<?php

use Slim\Http\Uri;
$uri = Uri::createFromString('https://0:0@0:1/0?0#0'); // display https://0:0@0:1'
// expected 'https://0:0@0:1/0?0#0'

$uri = Uri::createFromString('https://0:0@0:1/0?0#0')->getBaseUrl(); // display https://0:1'
// expected 'https://0:0@0:1'
```
All string comparison are made more strict now.

Maybe other PRs may look and fix this issue in other classes as well.
Also this could be backported to Slim\Http repository as well.
