### PR TITLE
4.x HttpSpecializedException Constructor Fix

### DIFF
--- a/Slim/Exception/HttpSpecializedException.php
+++ b/Slim/Exception/HttpSpecializedException.php
@@ -26,6 +26,10 @@ abstract class HttpSpecializedException extends HttpException
      */
     public function __construct(ServerRequestInterface $request, $message = null, $previous = null)
     {
-        parent::__construct($request, $message, $this->code, $previous);
+        if ($message !== null) {
+            $this->message = $message;
+        }
+
+        parent::__construct($request, $this->message, $this->code, $previous);
     }
 }


### PR DESCRIPTION
We didn't catch this during the code review for the `4.x-ErrorMiddleware` PR #2398.

The local variable setting logic for the `$message` variable was omitted in the `HttpSpecializedException` constructor logic.

```php
public function __construct(ServerRequestInterface $request, $message = null, $previous = null) 
{
    parent::__construct($request, $message, $this->code, $previous);
}
```

When you extend `HttpSpecializedException` and set the `$message` variable locally it gets nulled because of the missing parent constructor logic.
```php
class HttpMethodNotAllowedException extends HttpSpecializedException
{
    $message = 'My locally set message.';
}
```