### PR TITLE
Make groups use the Router's callable resolver

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -390,9 +390,6 @@ class App
         /** @var RouteGroup $group */
         $router = $this->getRouter();
         $group = $router->pushGroup($pattern, $callable);
-        if ($this->callableResolver instanceof CallableResolverInterface) {
-            $group->setCallableResolver($this->callableResolver);
-        }
         $group($this);
         $router->popGroup();
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -351,6 +351,9 @@ class Router implements RouterInterface
     {
         $group = new RouteGroup($pattern, $callable);
         $this->routeGroups[] = $group;
+        if ($this->callableResolver) {
+            $group->setCallableResolver($this->callableResolver);
+        }
         return $group;
     }
 


### PR DESCRIPTION
This PR makes the RouteGroup's use the Routers callable resolver instead of using the one in the App class.

This would avoid situations where setting a new callable resolver in the App class after the router has been created, would cause to have different resolvers for routes and groups.