### PR TITLE
Allow chaining in Route::setOutputBuffering

### DIFF
--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -200,6 +200,8 @@ class Route extends Routable implements RouteInterface
      *
      * @param boolean|string $mode
      *
+     * @return self
+     *
      * @throws InvalidArgumentException If an unknown buffering mode is specified
      */
     public function setOutputBuffering($mode)
@@ -208,6 +210,7 @@ class Route extends Routable implements RouteInterface
             throw new InvalidArgumentException('Unknown output buffering mode');
         }
         $this->outputBuffering = $mode;
+        return $this;
     }
 
     /**

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -189,6 +189,8 @@ class RouteTest extends \PHPUnit_Framework_TestCase
 
         $route->setOutputBuffering('prepend');
         $this->assertSame('prepend', $route->getOutputBuffering());
+
+        $this->assertEquals($route, $route->setOutputBuffering(false));
     }
 
     public function testSetInvalidOutputBuffering()


### PR DESCRIPTION
After this, it will be possible to chaing `setOutputBuffering` method just like with `setName`, `setArgument` and `setArguments` methods

```php
$app->get('/foobar', App\Foobar::class)
  ->setOutputBuffering(false)
  ->setName('foobar');
```