### PR TITLE
Bug Fix: Pick port defaults depending if the host was in HTTP_HOST or SERVER

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -177,7 +177,7 @@ class Uri implements UriInterface
         if ($env->has('HTTP_HOST')) {
             $host = $env->get('HTTP_HOST');
             // set a port default
-            $port = 80;
+            $port = null;
         } else {
             $host = $env->get('SERVER_NAME');
             // set a port default

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -173,15 +173,17 @@ class Uri implements UriInterface
         $username = $env->get('PHP_AUTH_USER', '');
         $password = $env->get('PHP_AUTH_PW', '');
 
-        // Authority: Host
+        // Authority: Host and Port
         if ($env->has('HTTP_HOST')) {
             $host = $env->get('HTTP_HOST');
+            // set a port default
+            $port = 80;
         } else {
             $host = $env->get('SERVER_NAME');
+            // set a port default
+            $port = (int)$env->get('SERVER_PORT', 80);
         }
 
-        // Authority: Port
-        $port = (int)$env->get('SERVER_PORT', 80);
         if (preg_match('/^(\[[a-fA-F0-9:.]+\])(:\d+)?\z/', $host, $matches)) {
             $host = $matches[1];
 

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -546,6 +546,27 @@ class UriTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $uri->getFragment());
     }
 
+    public function testCreateFromEnvironmentSetsDefaultPortWhenHostHeaderDoesntHaveAPort()
+    {
+        $environment = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'QUERY_STRING' => 'abc=123',
+            'HTTP_HOST' => 'example.com',
+            'HTTPS' => 'on',
+        ]);
+
+        $uri = Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('example.com', $uri->getHost());
+        $this->assertEquals(null, $uri->getPort());
+        $this->assertEquals('/foo/bar', $uri->getPath());
+        $this->assertEquals('abc=123', $uri->getQuery());
+        $this->assertEquals('', $uri->getFragment());
+
+        $this->assertEquals('https://example.com/foo/bar?abc=123', (string)$uri);
+    }
+
     public function testCreateEnvironmentWithIPv6HostNoPort()
     {
         $environment = Environment::mock([
@@ -556,14 +577,13 @@ class UriTest extends \PHPUnit_Framework_TestCase
             'QUERY_STRING' => 'abc=123',
             'HTTP_HOST' => '[2001:db8::1]',
             'REMOTE_ADDR' => '2001:db8::1',
-            'SERVER_PORT' => 8080,
         ]);
 
         $uri = Uri::createFromEnvironment($environment);
 
         $this->assertEquals('josh:sekrit', $uri->getUserInfo());
         $this->assertEquals('[2001:db8::1]', $uri->getHost());
-        $this->assertEquals('8080', $uri->getPort());
+        $this->assertNull($uri->getPort());
         $this->assertEquals('/foo/bar', $uri->getPath());
         $this->assertEquals('abc=123', $uri->getQuery());
         $this->assertEquals('', $uri->getFragment());
@@ -579,8 +599,34 @@ class UriTest extends \PHPUnit_Framework_TestCase
             'QUERY_STRING' => 'abc=123',
             'HTTP_HOST' => '[2001:db8::1]:8080',
             'REMOTE_ADDR' => '2001:db8::1',
-            'SERVER_PORT' => 8080,
         ]);
+
+        $uri = Uri::createFromEnvironment($environment);
+
+        $this->assertEquals('josh:sekrit', $uri->getUserInfo());
+        $this->assertEquals('[2001:db8::1]', $uri->getHost());
+        $this->assertEquals('8080', $uri->getPort());
+        $this->assertEquals('/foo/bar', $uri->getPath());
+        $this->assertEquals('abc=123', $uri->getQuery());
+        $this->assertEquals('', $uri->getFragment());
+    }
+
+    /**
+     * @group one
+     */
+    public function testCreateEnvironmentWithNoHostHeader()
+    {
+        $environment = Environment::mock([
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/foo/bar',
+            'PHP_AUTH_USER' => 'josh',
+            'PHP_AUTH_PW' => 'sekrit',
+            'QUERY_STRING' => 'abc=123',
+            'REMOTE_ADDR' => '2001:db8::1',
+            'SERVER_NAME' => '[2001:db8::1]',
+            'SERVER_PORT' => '8080',
+        ]);
+        $environment->remove('HTTP_HOST');
 
         $uri = Uri::createFromEnvironment($environment);
 


### PR DESCRIPTION
This change relates to #2486 where a local server on port 8080 receiving a request from ngrok that is on port 80 ends up with a URI containing the ngrok host but the local server port number. This change fixes it for me BUT it causes a test to fail (`UriTest::testCreateEnvironmentWithIPv6HostNoPort`) because the test expects the response to be port 8080, but I'm not sure I agree that's the right behaviour. I can fix the test if we can agree that NULL is the expected response to `getPort()` called on a request without a port number?