### PR TITLE
Rewrite Router->urlFor() to generate complete Urls

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -486,9 +486,9 @@ class Router implements RouterInterface
      */
     public function fullUrlFor($name, array $data = [], array $queryParams = [])
     {
-        // Check if container['request'] is initialized.
-        if (!$this->container->has('request')) {
-            throw new RuntimeException('Request object is not initialized yet.');
+        // Check if container is set.
+        if (empty($this->container)) {
+            throw new RuntimeException('Container not set.');
         }
 
         $path = $this->pathFor($name, $data, $queryParams);

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -446,7 +446,7 @@ class Router implements RouterInterface
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws RuntimeException If named route does not exist or Request not initialized
      */
-    public function urlFor($name, array $data = [], array $queryParams = [])
+    public function fullUrlFor($name, array $data = [], array $queryParams = [])
     {
         // Check if container['request'] is initialized.
         if (!$this->container->has('request')) {

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -444,7 +444,6 @@ class Router implements RouterInterface
      * @return string
      *
      * @throws \Psr\Container\ContainerExceptionInterface
-     * @throws \Psr\Container\NotFoundExceptionInterface
      * @throws RuntimeException If named route does not exist or Request not initialized
      */
     public function urlFor($name, array $data = [], array $queryParams = [])
@@ -461,6 +460,7 @@ class Router implements RouterInterface
         if (is_string($uri)) {
             $uri = Uri::createFromString($uri);
         }
+
         $scheme = $uri->getScheme();
         $authority = $uri->getAuthority();
         $host = ($scheme ? $scheme . ':' : '') . ($authority ? '//' . $authority : '');

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -425,13 +425,7 @@ class Router implements RouterInterface
      */
     public function pathFor($name, array $data = [], array $queryParams = [])
     {
-        $url = $this->relativePathFor($name, $data, $queryParams);
-
-        if ($this->basePath) {
-            $url = $this->basePath . $url;
-        }
-
-        return $url;
+        return $this->urlFor($name, $data, $queryParams);
     }
 
     /**
@@ -450,7 +444,13 @@ class Router implements RouterInterface
      */
     public function urlFor($name, array $data = [], array $queryParams = [])
     {
-        return $this->pathFor($name, $data, $queryParams);
+        $url = $this->relativePathFor($name, $data, $queryParams);
+
+        if ($this->basePath) {
+            $url = $this->basePath . $url;
+        }
+
+        return $url;
     }
 
     /**

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -433,6 +433,8 @@ class Router implements RouterInterface
     /**
      * Build the path for a named route including the base path
      *
+     * This method will be deprecated in Slim 4. Use urlFor() from now on.
+     *
      * @param string $name        Route name
      * @param array  $data        Named argument replacement data
      * @param array  $queryParams Optional query string parameters

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -11,12 +11,12 @@ namespace Slim;
 use FastRoute\Dispatcher;
 use Psr\Container\ContainerInterface;
 use InvalidArgumentException;
+use Psr\Http\Message\UriInterface;
 use RuntimeException;
 use Psr\Http\Message\ServerRequestInterface;
 use FastRoute\RouteCollector;
 use FastRoute\RouteParser;
 use FastRoute\RouteParser\Std as StdParser;
-use Slim\Http\Uri;
 use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouterInterface;
 use Slim\Interfaces\RouteInterface;
@@ -475,31 +475,21 @@ class Router implements RouterInterface
     /**
      * Get fully qualified URL for named route
      *
-     * @param string $name Route name
+     * @param UriInterface $uri
+     * @param string $routeName
      * @param array $data Named argument replacement data
      * @param array $queryParams Optional query string parameters
      *
      * @return string
      *
-     * @throws \Psr\Container\ContainerExceptionInterface
-     * @throws RuntimeException If named route does not exist or Request not initialized
      */
-    public function fullUrlFor($name, array $data = [], array $queryParams = [])
+    public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string
     {
-        // Check if container is set.
-        if (empty($this->container)) {
-            throw new RuntimeException('Container not set.');
-        }
-
-        $path = $this->pathFor($name, $data, $queryParams);
-
-        /** @var Uri $uri */
-        $uri = $this->container->get('request')->getUri();
-
+        $path = $this->urlFor($routeName, $data, $queryParams);
         $scheme = $uri->getScheme();
         $authority = $uri->getAuthority();
-        $host = ($scheme ? $scheme . ':' : '') . ($authority ? '//' . $authority : '');
+        $protocol = ($scheme ? $scheme . ':' : '') . ($authority ? '//' . $authority : '');
 
-        return $host . $path;
+        return $protocol . $path;
     }
 }

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -450,8 +450,6 @@ class Router implements RouterInterface
     /**
      * Build the path for a named route.
      *
-     * This method is deprecated. Use pathFor() from now on.
-     *
      * @param string $name        Route name
      * @param array  $data        Named argument replacement data
      * @param array  $queryParams Optional query string parameters

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -483,7 +483,7 @@ class Router implements RouterInterface
      * @return string
      *
      */
-    public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string
+    public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = [])
     {
         $path = $this->urlFor($routeName, $data, $queryParams);
         $scheme = $uri->getScheme();

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -483,7 +483,7 @@ class Router implements RouterInterface
      * @return string
      *
      */
-    public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = [])
+    public function fullUrlFor(UriInterface $uri, $routeName, array $data = [], array $queryParams = [])
     {
         $path = $this->urlFor($routeName, $data, $queryParams);
         $scheme = $uri->getScheme();

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -435,6 +435,26 @@ class Router implements RouterInterface
     }
 
     /**
+     * Build the path for a named route.
+     *
+     * This method is deprecated. Use pathFor() from now on.
+     *
+     * @param string $name        Route name
+     * @param array  $data        Named argument replacement data
+     * @param array  $queryParams Optional query string parameters
+     *
+     * @return string
+     *
+     * @throws RuntimeException         If named route does not exist
+     * @throws InvalidArgumentException If required data not provided
+     */
+    public function urlFor($name, array $data = [], array $queryParams = [])
+    {
+        trigger_error('urlFor() is deprecated. Use pathFor() instead.', E_USER_DEPRECATED);
+        return $this->pathFor($name, $data, $queryParams);
+    }
+
+    /**
      * Get fully qualified URL for named route
      *
      * @param string $name Route name

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use FastRoute\RouteCollector;
 use FastRoute\RouteParser;
 use FastRoute\RouteParser\Std as StdParser;
+use Slim\Http\Uri;
 use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouterInterface;
 use Slim\Interfaces\RouteInterface;
@@ -434,22 +435,36 @@ class Router implements RouterInterface
     }
 
     /**
-     * Build the path for a named route.
+     * Get fully qualified URL for named route
      *
-     * This method is deprecated. Use pathFor() from now on.
-     *
-     * @param string $name        Route name
-     * @param array  $data        Named argument replacement data
-     * @param array  $queryParams Optional query string parameters
+     * @param string $name Route name
+     * @param array $data Named argument replacement data
+     * @param array $queryParams Optional query string parameters
      *
      * @return string
      *
-     * @throws RuntimeException         If named route does not exist
-     * @throws InvalidArgumentException If required data not provided
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     * @throws RuntimeException If named route does not exist or Request not initialized
      */
     public function urlFor($name, array $data = [], array $queryParams = [])
     {
-        trigger_error('urlFor() is deprecated. Use pathFor() instead.', E_USER_DEPRECATED);
-        return $this->pathFor($name, $data, $queryParams);
+        // Check if container['request'] is initialized.
+        if (!$this->container->has('request')) {
+            throw new RuntimeException('Request object is not initialized yet.');
+        }
+
+        $path = $this->pathFor($name, $data, $queryParams);
+
+        /** @var Uri $uri */
+        $uri = $this->container->get('request')->getUri();
+        if (is_string($uri)) {
+            $uri = Uri::createFromString($uri);
+        }
+        $scheme = $uri->getScheme();
+        $authority = $uri->getAuthority();
+        $host = ($scheme ? $scheme . ':' : '') . ($authority ? '//' . $authority : '');
+
+        return $host . $path;
     }
 }

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -450,7 +450,6 @@ class Router implements RouterInterface
      */
     public function urlFor($name, array $data = [], array $queryParams = [])
     {
-        trigger_error('urlFor() is deprecated. Use pathFor() instead.', E_USER_DEPRECATED);
         return $this->pathFor($name, $data, $queryParams);
     }
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -448,7 +448,7 @@ class Router implements RouterInterface
     }
 
     /**
-     * Build the path for a named route.
+     * Build the path for a named route including the base path
      *
      * @param string $name        Route name
      * @param array  $data        Named argument replacement data

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -495,9 +495,6 @@ class Router implements RouterInterface
 
         /** @var Uri $uri */
         $uri = $this->container->get('request')->getUri();
-        if (is_string($uri)) {
-            $uri = Uri::createFromString($uri);
-        }
 
         $scheme = $uri->getScheme();
         $authority = $uri->getAuthority();

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -457,7 +457,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $router->setBasePath('/app'); // test URL with sub directory
 
         $uri = Uri::createFromString('http://example.com:8000/only/authority/important?a=b#c');
-        $result = $router->fullUrlFor($uri,'testRoute', ['token' => 'randomToken']);
+        $result = $router->fullUrlFor($uri, 'testRoute', ['token' => 'randomToken']);
         $expected = 'http://example.com:8000/app/token/randomToken';
 
         $this->assertEquals($expected, $result);

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -415,7 +415,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
      *
      * @throws ContainerExceptionInterface
      */
-    public function testUrlFor()
+    public function testFullUrlFor()
     {
         $app = new \Slim\App();
         $container = $app->getContainer();
@@ -438,7 +438,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         /** @var Router $router */
         $router = $container->get('router');
         $router->setBasePath('/app'); // test URL with sub directory
-        $result = $router->urlFor('testRoute', ['token' => 'randomToken']);
+        $result = $router->fullUrlFor('testRoute', ['token' => 'randomToken']);
 
         $expected = 'http://example.com:8000/app/token/randomToken';
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -10,6 +10,7 @@
 namespace Slim\Tests;
 
 use Psr\Container\ContainerExceptionInterface;
+use Slim\Http\Uri;
 use Slim\Router;
 
 class RouterTest extends \PHPUnit_Framework_TestCase
@@ -455,7 +456,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             ->setName('testRoute');
         $router->setBasePath('/app'); // test URL with sub directory
 
-        $uri = \Slim\Http\Uri::createFromString('http://example.com:8000/only/authority/important?a=b#c');
+        $uri = Uri::createFromString('http://example.com:8000/only/authority/important?a=b#c');
         $result = $router->fullUrlFor($uri,'testRoute', ['token' => 'randomToken']);
         $expected = 'http://example.com:8000/app/token/randomToken';
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -476,19 +476,4 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $result);
     }
-
-    /**
-     * Test fullUrlFor() without an container should throw a RuntimeException
-     */
-    public function testFullUrlForWithoutContainer()
-    {
-        $this->setExpectedException(
-            '\RuntimeException',
-            sprintf('Container not set.')
-        );
-
-        $router = new Router();
-        // Intentionally don't set container (Router::setContainer())
-        $router->fullUrlFor('something');
-    }
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -434,11 +434,13 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         );
         $container['request'] = $request;
 
-        // Generate complete URL
+        // Generate complete URL with custom base path
         /** @var Router $router */
         $router = $container->get('router');
+        $router->setBasePath('/app'); // test URL with sub directory
         $result = $router->urlFor('testRoute', ['token' => 'randomToken']);
-        $expected = 'http://example.com:8000/token/randomToken';
+
+        $expected = 'http://example.com:8000/app/token/randomToken';
 
         $this->assertEquals($expected, $result);
     }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -424,8 +424,14 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $app->get('/token/{token}', null)->setName('testRoute');
 
         // Inject request
-        $uri = \Slim\Http\Uri::createFromString('http://example.com:8000/only/authority/important?a=b#c');
-        $request = new \Slim\Http\Request('GET', $uri, new \Slim\Http\Headers(), [], \Slim\Http\Environment::mock()->all(), new \Slim\Http\RequestBody());
+        $request = new \Slim\Http\Request(
+            'GET',
+            \Slim\Http\Uri::createFromString('http://example.com:8000/only/authority/important?a=b#c'),
+            new \Slim\Http\Headers(),
+            [],
+            \Slim\Http\Environment::mock()->all(),
+            new \Slim\Http\RequestBody()
+        );
         $container['request'] = $request;
 
         // Generate complete URL

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -442,36 +442,21 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Creates a slim app, adds test route, injects a fake request
-     * and generates a complete URL for the test route
-     *
-     * @throws ContainerExceptionInterface
+     * Test fullUrlFor() with custom base path
      */
     public function testFullUrlFor()
     {
-        $app = new \Slim\App();
-        $container = $app->getContainer();
+        $methods = ['GET'];
+        $pattern = '/token/{token}';
 
-        // Add test route
-        $app->get('/token/{token}', null)->setName('testRoute');
-
-        // Inject request
-        $request = new \Slim\Http\Request(
-            'GET',
-            \Slim\Http\Uri::createFromString('http://example.com:8000/only/authority/important?a=b#c'),
-            new \Slim\Http\Headers(),
-            [],
-            \Slim\Http\Environment::mock()->all(),
-            new \Slim\Http\RequestBody()
-        );
-        $container['request'] = $request;
-
-        // Generate complete URL with custom base path
-        /** @var Router $router */
-        $router = $container->get('router');
+        $router = new Router(); // new Router to prevent side effects from Router::setBasePath()
+        $router
+            ->map($methods, $pattern, null)
+            ->setName('testRoute');
         $router->setBasePath('/app'); // test URL with sub directory
-        $result = $router->fullUrlFor('testRoute', ['token' => 'randomToken']);
 
+        $uri = \Slim\Http\Uri::createFromString('http://example.com:8000/only/authority/important?a=b#c');
+        $result = $router->fullUrlFor($uri,'testRoute', ['token' => 'randomToken']);
         $expected = 'http://example.com:8000/app/token/randomToken';
 
         $this->assertEquals($expected, $result);

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -476,4 +476,19 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * Test fullUrlFor() without an container should throw a RuntimeException
+     */
+    public function testFullUrlForWithoutContainer()
+    {
+        $this->setExpectedException(
+            '\RuntimeException',
+            sprintf('Container not set.')
+        );
+
+        $router = new Router();
+        // Intentionally don't set container (Router::setContainer())
+        $router->fullUrlFor('something');
+    }
 }


### PR DESCRIPTION
Hello!

Like @splitbrain mentioned in https://github.com/slimphp/Twig-View/issues/101 there is actually no way to generate a complete url while slim runs in a sub directory.

This pull request refactors https://github.com/slimphp/Twig-View/pull/102 TwigExtension->urlFor() to Router->urlFor()

Is there any chance you can merge this?
Let me know if this pull request need improvement.

