### PR TITLE
4.x-Rename $routeHandler to $routeIdentifier in RoutingResults

### DIFF
--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -77,7 +77,7 @@ class RoutingMiddleware
         switch ($routeStatus) {
             case Dispatcher::FOUND:
                 $routeArguments = $routingResults->getRouteArguments();
-                $route = $this->router->lookupRoute($routingResults->getRouteHandler());
+                $route = $this->router->lookupRoute($routingResults->getRouteIdentifier());
                 $route->prepare($request, $routeArguments);
                 return $request
                     ->withAttribute('route', $route)

--- a/Slim/RoutingResults.php
+++ b/Slim/RoutingResults.php
@@ -42,7 +42,7 @@ class RoutingResults
     /**
      * @var null|string
      */
-    protected $routeHandler;
+    protected $routeIdentifier;
 
     /**
      * @var array
@@ -55,7 +55,7 @@ class RoutingResults
      * @param string $httpMethod
      * @param string $uri
      * @param int $routeStatus
-     * @param string|null $routeHandler
+     * @param string|null $routeIdentifier
      * @param array $routeArguments
      */
     public function __construct(
@@ -63,14 +63,14 @@ class RoutingResults
         string $httpMethod,
         string $uri,
         int $routeStatus,
-        string $routeHandler = null,
+        string $routeIdentifier = null,
         array $routeArguments = []
     ) {
         $this->dispatcher = $dispatcher;
         $this->httpMethod = $httpMethod;
         $this->uri = $uri;
         $this->routeStatus = $routeStatus;
-        $this->routeHandler = $routeHandler;
+        $this->routeIdentifier = $routeIdentifier;
         $this->routeArguments = $routeArguments;
     }
 
@@ -109,9 +109,9 @@ class RoutingResults
     /**
      * @return null|string
      */
-    public function getRouteHandler()
+    public function getRouteIdentifier()
     {
-        return $this->routeHandler;
+        return $this->routeIdentifier;
     }
 
     /**

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -61,7 +61,7 @@ class DispatcherTest extends TestCase
         $results = $dispatcher->dispatch($method, $uri);
 
         $this->assertSame($dispatcher::FOUND, $results->getRouteStatus());
-        $this->assertSame($handler, $results->getRouteHandler());
+        $this->assertSame($handler, $results->getRouteIdentifier());
         $this->assertSame($argDict, $results->getRouteArguments());
         $this->assertSame($method, $results->getHttpMethod());
         $this->assertSame($uri, $results->getUri());


### PR DESCRIPTION
As per discussion in #2421 this PR is to rename `$routeHandler` to `$routeIdentifier` and associated getter method in `RoutingResults`.