### PR TITLE
Support using App as PSR-15 RequestHandler

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -18,6 +18,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
+use Psr\Http\Server\RequestHandlerInterface;
 use Slim\Http\Headers;
 use Slim\Http\Request;
 use Slim\Http\Response;
@@ -34,7 +35,7 @@ use Slim\Middleware\RoutingMiddleware;
  * configure, and run a Slim Framework application.
  * The \Slim\App class also accepts Slim Framework middleware.
  */
-class App
+class App implements RequestHandlerInterface
 {
     use MiddlewareAwareTrait;
 
@@ -422,6 +423,21 @@ class App
             $request = Request::createFromGlobals($_SERVER);
         }
 
+        return $this->handle($request);
+    }
+
+    /**
+     * Handle a request
+     *
+     * This method traverses the application middleware stack and then returns the
+     * resultant Response object.
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return ResponseInterface
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
         // create response
         $headers = new Headers(['Content-Type' => 'text/html; charset=UTF-8']);
         $httpVersion = $this->getSetting('httpVersion');

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "slim/http": ">=0.2",
         "psr/http-message": "^1.0",
         "nikic/fast-route": "^1.0",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0",
+        "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "pimple/pimple": "^3.2",


### PR DESCRIPTION
Implementing the RequestHandlerInterface means the Slim App is embeddable to another PSR-15 middleware stack.

Cherry-pick of @bnf's https://github.com/slimphp/Slim/pull/2379/commits/de89805c4f5b6ca0423897757920f30cf04bc4e from #2379