### PR TITLE
Allow PSR-15 RequestHandlers to be used as route callables

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Slim;
 
 use Psr\Container\ContainerInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 use Slim\Interfaces\CallableResolverInterface;
 
@@ -69,6 +70,11 @@ final class CallableResolver implements CallableResolverInterface
                     throw new RuntimeException(sprintf('Callable %s does not exist', $class));
                 }
                 $resolved = [new $class($this->container), $method];
+            }
+
+            // For a class that implements RequestHandlerInterface, we will call handle()
+            if ($resolved[0] instanceof RequestHandlerInterface) {
+                $resolved[1] = 'handle';
             }
         }
 

--- a/Slim/Handlers/Strategies/RequestHandler.php
+++ b/Slim/Handlers/Strategies/RequestHandler.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2018 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Handlers\Strategies;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Interfaces\InvocationStrategyInterface;
+
+/**
+ * Default route callback strategy with route parameters as an array of arguments.
+ */
+class RequestHandler implements InvocationStrategyInterface
+{
+    /**
+     * Invoke a route callable that implments RequestHandlerInterface
+     *
+     * @param callable               $callable
+     * @param ServerRequestInterface $request
+     *
+     * @return ResponseInterface
+     */
+    public function __invoke(
+        callable $callable,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        array $routeArguments
+    ): ResponseInterface {
+        return $callable($request);
+    }
+}

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -13,6 +13,8 @@ namespace Slim;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Handlers\Strategies\RequestHandler;
 use Slim\Handlers\Strategies\RequestResponse;
 use Slim\Interfaces\InvocationStrategyInterface;
 use Slim\Interfaces\RouteInterface;
@@ -316,14 +318,13 @@ class Route extends Routable implements RouteInterface
             $callable = $this->callableResolver->resolve($callable);
         }
 
-        /** @var InvocationStrategyInterface $handler */
         $handler = $this->routeInvocationStrategy;
-
-        $routeResponse = $handler($callable, $request, $response, $this->arguments);
-        if (! $routeResponse instanceof ResponseInterface) {
-            throw new \RuntimeException('Route handler must return instance of \Psr\Http\Message\ResponseInterface');
+        if (is_array($callable) && $callable[0] instanceof RequestHandlerInterface) {
+            // callables that implement RequestHandlerInterface use the RequestHandler strategy
+            $handler = new RequestHandler();
         }
 
-        return $routeResponse;
+        // invoke route callable via invokation strategy handler
+        return $handler($callable, $request, $response, $this->arguments);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/http-message": "^1.0",
         "nikic/fast-route": "^1.0",
         "psr/container": "^1.0",
-        "psr/http-server-middleware": "^1.0"
+        "psr/http-server-handler": "^1.0"
     },
     "require-dev": {
         "pimple/pimple": "^3.2",

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1744,6 +1744,12 @@ class AppTest extends TestCase
         $this->assertTrue($result);
     }
 
+    public function testAppIsARequestHandler()
+    {
+        $app = new App;
+        $this->assertInstanceof('Psr\Http\Server\RequestHandlerInterface', $app);
+    }
+
     protected function skipIfPhp70()
     {
         if (version_compare(PHP_VERSION, '7.0', '>=')) {

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -14,6 +14,8 @@ use Pimple\Psr11\Container;
 use Slim\CallableResolver;
 use Slim\Tests\Mocks\CallableTest;
 use Slim\Tests\Mocks\InvokableTest;
+use Slim\Tests\Mocks\RequestHandlerTest;
+use Slim\Http\Request;
 
 class CallableResolverTest extends TestCase
 {
@@ -114,6 +116,15 @@ class CallableResolverTest extends TestCase
         $callable = $resolver->resolve('Slim\Tests\Mocks\InvokableTest');
         $callable();
         $this->assertEquals(1, InvokableTest::$CalledCount);
+    }
+
+    public function testResolutionToAPsrRequestHandlerClass()
+    {
+        $request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
+        $resolver = new CallableResolver(); // No container injected
+        $callable = $resolver->resolve(RequestHandlerTest::class);
+        $callable($request);
+        $this->assertEquals(1, RequestHandlerTest::$CalledCount);
     }
 
     /**

--- a/tests/Mocks/RequestHandlerTest.php
+++ b/tests/Mocks/RequestHandlerTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2018 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Mocks;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Http\Response;
+
+/**
+ * Mock object for Slim\Tests\CallableResolverTest
+ */
+class RequestHandlerTest implements RequestHandlerInterface
+{
+    public static $CalledCount = 0;
+    public static $strategy = '';
+
+    public function handle(ServerRequestInterface $request) : ResponseInterface
+    {
+        static::$CalledCount++;
+
+        // store the strategy that was used to call this handler - it's in the back trace
+        $trace = debug_backtrace();
+        if (isset($trace[1])) {
+            static::$strategy = $trace[1]['class'];
+        }
+
+        $response = new Response();
+        $response = $response->withHeader('Content-Type', 'text/plain');
+        $response->write(static::$CalledCount);
+
+        return $response;
+    }
+}


### PR DESCRIPTION
This requires modifying `CallableResolver` to change the method to `handle` if the callable object is a RequestHandlerInterface. 

Also, we introduce a `RequestHandler` invocation strategy that is automatically applied by the `Route` is a RequestHandlerInterface callable is invoked.

Fixes #2488.
Fixes #2052.