### PR TITLE
WiP: Non buffered body

### DIFF
--- a/Slim/Http/NonBufferedBody.php
+++ b/Slim/Http/NonBufferedBody.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2017 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+namespace Slim\Http;
+
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Represents a non-readable stream that whenever it is written pushes
+ * the data back to the browser immediately.
+ */
+class NonBufferedBody implements StreamInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function close()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function detach()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSize()
+    {
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tell()
+    {
+        return 0;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eof()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSeekable()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function seek($offset, $whence = SEEK_SET)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isWritable()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function write($string)
+    {
+        $buffered = '';
+        while (0 < \ob_get_level()) {
+            $buffered = \ob_get_clean() . $buffered;
+        }
+
+        echo $buffered . $string;
+
+        \flush();
+
+        return \strlen($string) + \strlen($buffered);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isReadable()
+    {
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function read($length)
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContents()
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMetadata($key = null)
+    {
+        return null;
+    }
+}

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -272,6 +272,10 @@ class Response extends Message implements ResponseInterface
      */
     public function withHeader($name, $value)
     {
+        if ($this->body instanceof NonBufferedBody) {
+            header("$name: $value");
+        }
+
         $clone = clone $this;
         $clone->headers->set($name, $value);
 

--- a/tests/Http/NonBufferedBodyTest.php
+++ b/tests/Http/NonBufferedBodyTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2017 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+namespace Slim\Tests\Http;
+
+use Slim\Http\NonBufferedBody;
+
+class NonBufferedBodyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testTheStreamContract()
+    {
+        $body = new NonBufferedBody();
+
+        self::assertSame('', (string) $body, 'Casting to string returns no data, since the class does not store any');
+        self::assertNull($body->detach(), 'Returns null since there is no such underlying stream');
+        self::assertNull($body->getSize(), 'Current size is undefined');
+        self::assertSame(0, $body->tell(), 'Pointer is considered to be at position 0 to conform');
+        self::assertTrue($body->eof(), 'Always considered to be at EOF');
+        self::assertFalse($body->isSeekable(), 'Cannot seek');
+        self::assertTrue($body->isWritable(), 'Body is writable');
+        self::assertFalse($body->isReadable(), 'Body is not readable');
+        self::assertSame('', $body->read(10), 'Data cannot be retrieved once written');
+        self::assertSame('', $body->getContents(), 'Data cannot be retrieved once written');
+        self::assertNull($body->getMetadata(), 'Metadata mechanism is not implemented');
+    }
+}


### PR DESCRIPTION
This PR implements the proposal made in #2481 as a new subtype of `StreamInterface`.

## Code

The implementation of most methods is trivial because the interface was designed for classes wrapping an internal stream, and in this case there simply isn't one.

`write($string)` essentially destroys all active Output Buffering levels (but saving their contents), then prepends this to `$string` and flushes everything to the webserver. Successive calls to `NonBufferedBody::write()` won't destroy anything else (unless the programmer runs `ob_start()` and `echo` in-between calls for any reason) and flush `$string` right away.

Any previously buffered data is displayed in a FIFO order. In other words, data echoed at the output buffer level 1 will be printed before data echoed at level 2.

Additionally, I had to modify `Response::withHeader($name, $value)` to send the headers eagerly when the body is of type `NonBufferedBody`, otherwise the framework won't attempt to send the headers until the end stages of `App::run()`. This change is quite delicate but I believe it cannot break any previous code because `NonBufferedBody` simply did not exist before.

## Working example

```php
<?php

use Slim\Http;

require_once __DIR__ . '/../vendor/autoload.php';

$app = new \Slim\App;

$app->get('/', function (Http\Request $request, Http\Response $response) {
    $response = $response
        ->withHeader('Content-Type', 'text/plain');

    foreach (range('A', 'F') as $char) {
        sleep(1);
        $response->getBody()->write("$char\n");
    }
});

$app->add(function (Http\Request $request, Http\Response $response, callable $next) {
    $nonBufferedResponse = $response
        ->withBody(new Http\NonBufferedBody)
        ->withHeader('X-Accel-Buffering', 'no');

    return $next($request, $nonBufferedResponse);
});

$app->run();
```

## Gotchas

### HTTP headers must be sent before the content

When pushing data to the webserver while still running PHP code, one must send the headers first. Calling `Response::withHeader($name, $value)` **after** any call to `NonBufferedBody::write($string)` will trigger an `Cannot modify header information - headers already sent` PHP error. Obviously, after sending the first chunks of data you cannot push more headers in the middle of the body.

### NonBufferedBody must be set on the response before setting any HTTP header

Since `Response` now looks at the type of the `$body` attribute to determine whether to send HTTP headers eagerly or not, it is imperative to replace the underlying `StreamInterface` of the response with  `Response::withBody(new NonBufferedBody)` **before doing any call to** `Response::withHeader($name, $value)`.

I believe that this issue is best avoided with a "non-buffered middleware" that can be attached to the routes that need to behave this way, like in the example.

### Some middlewares may break

As [noted by @llvdl](https://github.com/slimphp/Slim/issues/2481#issuecomment-414155203) in the original issue, outgoing middlewares won't be able to modify the body of unbuffered responses nor add any HTTP headers. Only appending new data to the body will be possible in this scenario, which is generally not terribly useful.

### Webservers buffer output by default

Even after calling PHP's `flush()` function webservers usually buffer the output on their own.

#### Nginx + php-fpm

Nginx has the `fastcgi_buffering off;` directive to explicitly disable output buffering. Additionally, you can send a special `X-Accel-Buffering` header set to `no` to do it dynamically from PHP (see example).

#### Apache

??? TBD

## TODO

- [ ] Tests
- [ ] Documentation
- [ ] Better class naming?