### PR TITLE
Remove HTTP method case-insensitivity from Router

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -187,9 +187,6 @@ class Router implements RouterInterface
             $pattern = $this->processGroups() . $pattern;
         }
 
-        // According to RFC methods are defined in uppercase (See RFC 7231)
-        $methods = array_map("strtoupper", $methods);
-
         /** @var Route $route */
         $route = $this->createRoute($methods, $pattern, $handler);
         $this->routes[$route->getIdentifier()] = $route;

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -241,6 +241,19 @@ class AppTest extends TestCase
         $this->assertAttributeContains('POST', 'methods', $route);
     }
 
+    public function testMapRouteWithLowercaseMethod()
+    {
+        $path = '/foo';
+        $callable = function ($req, $res) {
+            // Do something
+        };
+        $app = new App($this->getResponseFactory());
+        $route = $app->map(['get'], $path, $callable);
+
+        $this->assertInstanceOf('\Slim\Route', $route);
+        $this->assertAttributeContains('get', 'methods', $route);
+    }
+
     public function testRedirectRoute()
     {
         $source = '/foo';

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1451,7 +1451,7 @@ class AppTest extends TestCase
 
         /** @var Router $router */
         $router = $app->getRouter();
-        $router->map(['get'], '/foo', 'foo:bar');
+        $router->map(['GET'], '/foo', 'foo:bar');
 
         // Invoke app
         $resOut = $app($request, $response);


### PR DESCRIPTION
Now `$router->map(['get'], '/foo', 'foo:bar');` will return `Slim\Exception\HttpNotFoundException`