### PR TITLE
Remove PHPUnit 5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - php: nightly
 
 before_script:
-  - composer update $COMPOSER_ARGS
+  - composer update
 
 script:
   - if [[ "$ANALYSIS" != 'true' ]]; then vendor/bin/phpunit ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ dist: trusty
 matrix:
   include:
     - php: 7.0
-    - php: 7.0
-      env: COMPOSER_ARGS='--prefer-lowest'
     - php: 7.1
       env: ANALYSIS='true'
     - php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require-dev": {
         "pimple/pimple": "^3.2",
         "squizlabs/php_codesniffer": "^2.9",
-        "phpunit/phpunit": "^5.7|^6.2",
+        "phpunit/phpunit": "^6.2",
         "php-coveralls/php-coveralls": "^1.0"
     },
     "provide": {


### PR DESCRIPTION
Remove unnecessary dependency on PHPUnit 5.x (for php5.6) and remove travis test with `--prefer-lowest`