### PR TITLE
Put HeaderStackTestAsset into Slim\Tests\Asset namespace

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -26,7 +26,7 @@ use Slim\Http\RequestBody;
 use Slim\Http\Response;
 use Slim\Http\Uri;
 use Slim\Router;
-use Slim\HeaderStackTestAsset;
+use Slim\Tests\Assets\HeaderStack;
 use Slim\Tests\Mocks\MockAction;
 
 /**
@@ -43,12 +43,12 @@ class AppTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        HeaderStackTestAsset::reset();
+        HeaderStack::reset();
     }
 
     public function tearDown()
     {
-        HeaderStackTestAsset::reset();
+        HeaderStack::reset();
     }
 
     public static function setupBeforeClass()
@@ -1797,7 +1797,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             ['header' => 'HTTP/1.1 200 OK', 'replace' => true, 'status_code' => 200],
         ];
 
-        $this->assertSame($expectedStack, HeaderStackTestAsset::stack());
+        $this->assertSame($expectedStack, HeaderStack::stack());
     }
 
     public function testResponseDoesNotReplacePreviouslySetSetCookieHeaders()
@@ -1834,7 +1834,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
             ['header' => 'HTTP/1.1 200 OK', 'replace' => true, 'status_code' => 200],
         ];
 
-        $this->assertSame($expectedStack, HeaderStackTestAsset::stack());
+        $this->assertSame($expectedStack, HeaderStack::stack());
     }
 
     public function testExceptionErrorHandlerDoesNotDisplayErrorDetails()

--- a/tests/Assets/HeaderStack.php
+++ b/tests/Assets/HeaderStack.php
@@ -3,12 +3,8 @@
  * This is a direct copy of zend-diactoros/test/TestAsset/Functions.php and is used to override
  * header() and headers_sent() so we can test that they do the right thing.
  *
- * We put these into the Slim namespace, so that Slim\App will use these versions of header() and
- * headers_sent() when we test its output.
  */
-namespace Slim;
-
-use Slim\Tests\Assets\HeaderStack;
+namespace Slim\Tests\Assets;
 
 /**
  * Zend Framework (http://framework.zend.com/)
@@ -31,29 +27,58 @@ use Slim\Tests\Assets\HeaderStack;
  */
 
 /**
- * Have headers been sent?
- *
- * @return false
+ * Store output artifacts
  */
-function headers_sent()
+class HeaderStack
 {
-    return false;
-}
+    /**
+     * @var string[][]
+     */
+    private static $data = [];
 
-/**
- * Emit a header, without creating actual output artifacts
- *
- * @param string   $string
- * @param bool     $replace
- * @param int|null $statusCode
- */
-function header($string, $replace = true, $statusCode = null)
-{
-    HeaderStack::push(
-        [
-            'header'      => $string,
-            'replace'     => $replace,
-            'status_code' => $statusCode,
-        ]
-    );
+    /**
+     * Reset state
+     */
+    public static function reset()
+    {
+        self::$data = [];
+    }
+
+    /**
+     * Push a header on the stack
+     *
+     * @param string[] $header
+     */
+    public static function push(array $header)
+    {
+        self::$data[] = $header;
+    }
+
+    /**
+     * Return the current header stack
+     *
+     * @return string[][]
+     */
+    public static function stack()
+    {
+        return self::$data;
+    }
+
+    /**
+     * Verify if there's a header line on the stack
+     *
+     * @param string $header
+     *
+     * @return bool
+     */
+    public static function has($header)
+    {
+        foreach (self::$data as $item) {
+            if ($item['header'] === $header) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
This allows us to minimise what we put into the Slim namespace to just
the header() and headers_sent() functions.

We also rename HeaderStackTestAsset to HeaderStack as the namespace is
descriptive.