### PR TITLE
Update route group $callable parameter type

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -273,8 +273,8 @@ class App
      * declarations in the callback will be prepended by the group(s)
      * that it is in.
      *
-     * @param string   $pattern
-     * @param callable $callable
+     * @param string           $pattern
+     * @param callable|Closure $callable
      *
      * @return RouteGroupInterface
      */


### PR DESCRIPTION
Added @param callable|Closure $callable. This is important for advanced IDEs not to show warning error colouring when closure is used.