### PR TITLE
Allow registration of media type parser containing `+` character

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1031,18 +1031,15 @@ class Request extends Message implements ServerRequestInterface
         $mediaType = $this->getMediaType();
 
         // Check if this specific media type has a parser registered first
-        $mediaTypeHasParser = (isset($this->bodyParsers[$mediaType]) === true);
-
-        if (!$mediaTypeHasParser) {
+        if (!isset($this->bodyParsers[$mediaType])) {
             // If not, look for a media type with a structured syntax suffix (RFC 6839)
             $parts = explode('+', $mediaType);
             if (count($parts) >= 2) {
                 $mediaType = 'application/' . $parts[count($parts)-1];
-                $mediaTypeHasParser = (isset($this->bodyParsers[$mediaType]) === true);
             }
         }
 
-        if ($mediaTypeHasParser) {
+        if (isset($this->bodyParsers[$mediaType])) {
             $body = (string)$this->getBody();
             $parsed = $this->bodyParsers[$mediaType]($body);
 

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1030,20 +1030,19 @@ class Request extends Message implements ServerRequestInterface
 
         $mediaType = $this->getMediaType();
 
-        // Check if this specific media type is registered first
-        $mediaTypeHasParser = (isset($this->bodyParsers[$mediaType]) === false);
+        // Check if this specific media type has a parser registered first
+        $mediaTypeHasParser = (isset($this->bodyParsers[$mediaType]) === true);
 
-        if ($mediaTypeHasParser === false) {
+        if (!$mediaTypeHasParser) {
             // If not, look for a media type with a structured syntax suffix (RFC 6839)
             $parts = explode('+', $mediaType);
             if (count($parts) >= 2) {
                 $mediaType = 'application/' . $parts[count($parts)-1];
-
-                $mediaTypeHasParser = (isset($this->bodyParsers[$mediaType]) === false);
+                $mediaTypeHasParser = (isset($this->bodyParsers[$mediaType]) === true);
             }
         }
 
-        if ($mediaTypeHasParser === true) {
+        if ($mediaTypeHasParser) {
             $body = (string)$this->getBody();
             $parsed = $this->bodyParsers[$mediaType]($body);
 

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1030,13 +1030,20 @@ class Request extends Message implements ServerRequestInterface
 
         $mediaType = $this->getMediaType();
 
-        // look for a media type with a structured syntax suffix (RFC 6839)
-        $parts = explode('+', $mediaType);
-        if (count($parts) >= 2) {
-            $mediaType = 'application/' . $parts[count($parts)-1];
+        // Check if this specific media type is registered first
+        $mediaTypeHasParser = (isset($this->bodyParsers[$mediaType]) === false);
+
+        if ($mediaTypeHasParser === false) {
+            // If not, look for a media type with a structured syntax suffix (RFC 6839)
+            $parts = explode('+', $mediaType);
+            if (count($parts) >= 2) {
+                $mediaType = 'application/' . $parts[count($parts)-1];
+
+                $mediaTypeHasParser = (isset($this->bodyParsers[$mediaType]) === false);
+            }
         }
 
-        if (isset($this->bodyParsers[$mediaType]) === true) {
+        if ($mediaTypeHasParser === true) {
             $body = (string)$this->getBody();
             $parsed = $this->bodyParsers[$mediaType]($body);
 

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -953,7 +953,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
 
         $request->registerMediaTypeParser('application/vnd.api+json', function ($input) {
-            return array('data' => $input);
+            return ['data' => $input];
         });
 
         $this->assertEquals(['data' => '{"foo":"bar"}'], $request->getParsedBody());

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -940,6 +940,25 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['foo' => 'bar'], $request->getParsedBody());
     }
 
+    public function testGetParsedBodyWithJsonStructuredSuffixAndRegisteredParser()
+    {
+        $method = 'GET';
+        $uri = new Uri('https', 'example.com', 443, '/foo/bar', 'abc=123', '', '');
+        $headers = new Headers();
+        $headers->set('Content-Type', 'application/vnd.api+json;charset=utf8');
+        $cookies = [];
+        $serverParams = [];
+        $body = new RequestBody();
+        $body->write('{"foo":"bar"}');
+        $request = new Request($method, $uri, $headers, $cookies, $serverParams, $body);
+
+        $request->registerMediaTypeParser('application/vnd.api+json', function ($input) {
+            return array('data' => $input);
+        });
+
+        $this->assertEquals(['data' => '{"foo":"bar"}'], $request->getParsedBody());
+    }
+
     public function testGetParsedBodyXml()
     {
         $method = 'GET';


### PR DESCRIPTION
Fix for #2537 


