### PR TITLE
Slim\Http\Uri expects host to be a string, not null

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "slim/http": ">=0.2",
+        "slim/http": "0.4",
         "psr/http-message": "^1.0",
         "nikic/fast-route": "^1.0",
         "psr/container": "^1.0",

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1392,6 +1392,7 @@ class AppTest extends TestCase
 
         $app = new App();
         $_SERVER = [
+            'HTTP_HOST' => 'example.com',
             'SCRIPT_NAME' => '/index.php',
             'REQUEST_URI' => '/foo',
             'REQUEST_METHOD' => 'GET',


### PR DESCRIPTION
This is always the case in the real world, but an App test failed to set HTTP_HOST, so this fixes that.