### PR TITLE
Ensure PSR-7 stream read() is called with an int argument per spec

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -461,7 +461,7 @@ class App
             if (isset($contentLength)) {
                 $amountToRead = $contentLength;
                 while ($amountToRead > 0 && !$body->eof()) {
-                    $data = $body->read(min($chunkSize, $amountToRead));
+                    $data = $body->read(min((int)$chunkSize, (int)$amountToRead));
                     echo $data;
 
                     $amountToRead -= strlen($data);


### PR DESCRIPTION
This fixes #2511.

The PSR-7 spec [requires](https://github.com/php-fig/http-message/blob/f6561bf28d520154e4b0ec72be95418abe6d9363/src/StreamInterface.php#L127-L129) that the length argument of the stream read method be an integer, but Slim retrieves the content length as a string due to its use of $response->getHeaderLine. This causes compatibility issues with PSR-7 implementations that use strict typing, namely [zendframework/zend-diactoros](https://github.com/zendframework/zend-diactoros) 2.0+.

I'm not sure how to write a unit test for this change as it's a type change that doesn't affect output/behavior except with strict PSR-7 implementations.