### PR TITLE
Issue #2386 Fix

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -448,7 +448,22 @@ class App implements RequestHandlerInterface
             ->withProtocolVersion($httpVersion)
             ->withHeader('Content-Type', 'text/html; charset=UTF-8');
 
-        return $this->callMiddlewareStack($request, $response);
+        $response = $this->callMiddlewareStack($request, $response);
+
+        /**
+         * This is to be in compliance with RFC 2616, Section 9.
+         * If the incoming request method is HEAD, we need to ensure that the response body
+         * is empty as the request may fall back on a GET route handler due to FastRoute's
+         * routing logic which could potentially append content to the response body
+         * https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4
+         */
+        $method = strtoupper($request->getMethod());
+        if ($method === 'HEAD') {
+            $emptyBody = $this->responseFactory->createResponse()->getBody();
+            return $response->withBody($emptyBody);
+        }
+
+        return $response;
     }
 
     /**

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1441,6 +1441,24 @@ class AppTest extends TestCase
         $this->expectOutputString('Hello World');
     }
 
+    public function testHandleReturnsEmptyResponseBodyWithHeadRequestMethod()
+    {
+        $called = 0;
+        $responseFactory = $this->getResponseFactory();
+        $app = new App($responseFactory);
+        $app->get('/', function (ServerRequestInterface $request, ResponseInterface $response) use (&$called) {
+            $called += 1;
+            $response->getBody()->write('Hello World');
+            return $response;
+        });
+
+        $request = $this->createServerRequest('/', 'HEAD');
+        $response = $app->handle($request);
+
+        $this->assertEquals(1, $called);
+        $this->assertEmpty((string) $response->getBody());
+    }
+
     // TODO: Re-add testUnsupportedMethodWithoutRoute
 
     // TODO: Re-add testUnsupportedMethodWithRoute


### PR DESCRIPTION
This pull request is in relation to #2386 so we comply with [RFC 2616, Section 9](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4) and ensure that the `Response` body is empty on `HEAD` requests which potentially fall back on same path `GET` route handler due to FastRoute's routing logic. 