### PR TITLE
fixes wrong number of parameters passed to handler in ErrorMiddleware::handleException function

### DIFF
--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Slim\Handlers;
 
+use http\Env\Response;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -80,6 +81,11 @@ class ErrorHandler implements ErrorHandlerInterface
     protected $request;
 
     /**
+     * @var ResponseInterface
+     */
+    protected $response;
+
+    /**
      * @var Throwable
      */
     protected $exception;
@@ -95,23 +101,10 @@ class ErrorHandler implements ErrorHandlerInterface
     protected $statusCode;
 
     /**
-     * @var ResponseFactoryInterface
-     */
-    protected $responseFactory;
-
-    /**
-     * ErrorHandler constructor.
-     * @param ResponseFactoryInterface $responseFactory
-     */
-    public function __construct(ResponseFactoryInterface $responseFactory)
-    {
-        $this->responseFactory = $responseFactory;
-    }
-
-    /**
      * Invoke error handler
      *
      * @param ServerRequestInterface $request   The most recent Request object
+     * @param ResponseInterface      $response  The most recent Response object
      * @param Throwable              $exception The caught Exception object
      * @param bool $displayErrorDetails Whether or not to display the error details
      * @param bool $logErrors Whether or not to log errors
@@ -121,6 +114,7 @@ class ErrorHandler implements ErrorHandlerInterface
      */
     public function __invoke(
         ServerRequestInterface $request,
+        ResponseInterface $response,
         Throwable $exception,
         bool $displayErrorDetails,
         bool $logErrors,
@@ -130,6 +124,7 @@ class ErrorHandler implements ErrorHandlerInterface
         $this->logErrors = $logErrors;
         $this->logErrorDetails = $logErrorDetails;
         $this->request = $request;
+        $this->response = $response;
         $this->exception = $exception;
         $this->method = $request->getMethod();
         $this->statusCode = $this->determineStatusCode();
@@ -253,7 +248,7 @@ class ErrorHandler implements ErrorHandlerInterface
      */
     protected function respond(): ResponseInterface
     {
-        $response = $this->responseFactory->createResponse($this->statusCode);
+        $response = $this->response->withStatus($this->statusCode);
         $response = $response->withHeader('Content-type', $this->contentType);
 
         if ($this->exception instanceof HttpMethodNotAllowedException) {

--- a/Slim/Interfaces/ErrorHandlerInterface.php
+++ b/Slim/Interfaces/ErrorHandlerInterface.php
@@ -25,6 +25,7 @@ interface ErrorHandlerInterface
 {
     /**
      * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
      * @param Throwable $exception
      * @param bool $displayErrorDetails
      * @param bool $logErrors
@@ -33,6 +34,7 @@ interface ErrorHandlerInterface
      */
     public function __invoke(
         ServerRequestInterface $request,
+        ResponseInterface $response,
         Throwable $exception,
         bool $displayErrorDetails,
         bool $logErrors,

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -201,6 +201,6 @@ class ErrorMiddleware
             return $this->callableResolver->resolve($this->defaultErrorHandler);
         }
 
-        return new ErrorHandler($this->responseFactory);
+        return new ErrorHandler();
     }
 }

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -113,8 +113,10 @@ class ErrorMiddleware
 
         $exceptionType = get_class($exception);
         $handler = $this->getErrorHandler($exceptionType);
+        $response = $this->responseFactory->createResponse($exception->getCode());
         $params = [
             $request,
+            $response,
             $exception,
             $this->displayErrorDetails,
             $this->logErrors,
@@ -150,7 +152,9 @@ class ErrorMiddleware
      * 1. Instance of \Psr\Http\Message\ServerRequestInterface
      * 2. Instance of \Psr\Http\Message\ResponseInterface
      * 3. Instance of \Exception
-     * 4. Boolean displayErrorDetails (optional)
+     * 4. Boolean displayErrorDetails
+     * 5. Boolean logErrors
+     * 6. Boolean logErrorDetails
      *
      * The callable MUST return an instance of
      * \Psr\Http\Message\ResponseInterface.
@@ -172,7 +176,9 @@ class ErrorMiddleware
      * 1. Instance of \Psr\Http\Message\ServerRequestInterface
      * 2. Instance of \Psr\Http\Message\ResponseInterface
      * 3. Instance of \Exception
-     * 4. Boolean displayErrorDetails (optional)
+     * 4. Boolean displayErrorDetails
+     * 5. Boolean logErrors
+     * 6. Boolean logErrorDetails
      *
      * The callable MUST return an instance of
      * \Psr\Http\Message\ResponseInterface.

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -97,10 +97,6 @@ class ErrorHandlerTest extends TestCase
             ->getMock();
         $class = new ReflectionClass(ErrorHandler::class);
 
-        $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($handler, $this->getResponseFactory());
-
         $reflectionProperty = $class->getProperty('exception');
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($handler, new HttpNotFoundException($request));
@@ -135,10 +131,6 @@ class ErrorHandlerTest extends TestCase
 
         $class = new ReflectionClass(ErrorHandler::class);
 
-        $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($handler, $this->getResponseFactory());
-
         $reflectionProperty = $class->getProperty('knownContentTypes');
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue($handler, $newTypes);
@@ -166,10 +158,6 @@ class ErrorHandlerTest extends TestCase
         $method = $class->getMethod('determineContentType');
         $method->setAccessible(true);
 
-        $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
-        $reflectionProperty->setValue($class, $this->getResponseFactory());
-
         // use a mock object here as ErrorHandler cannot be directly instantiated
         $handler = $this
             ->getMockBuilder(ErrorHandler::class)
@@ -185,12 +173,13 @@ class ErrorHandlerTest extends TestCase
     public function testOptions()
     {
         $request = $this->createServerRequest('/', 'OPTIONS');
-        $handler = new ErrorHandler($this->getResponseFactory());
+        $handler = new ErrorHandler();
         $exception = new HttpMethodNotAllowedException($request);
         $exception->setAllowedMethods(['POST', 'PUT']);
+        $response = $this->getResponseFactory()->createResponse();
 
         /** @var ResponseInterface $res */
-        $res = $handler->__invoke($request, $exception, true, true, true);
+        $res = $handler->__invoke($request, $response, $exception, true, true, true);
 
         $this->assertSame(200, $res->getStatusCode());
         $this->assertTrue($res->hasHeader('Allow'));
@@ -203,8 +192,9 @@ class ErrorHandlerTest extends TestCase
             ->createServerRequest('/', 'GET')
             ->withHeader('Accept', 'application/json');
 
+        $response = $this->getResponseFactory()->createResponse();
+
         $handler = $this->getMockBuilder(ErrorHandler::class)
-            ->setConstructorArgs(['responseFactory' => $this->getResponseFactory()])
             ->setMethods(['writeToErrorLog', 'logError'])
             ->getMock();
 
@@ -213,6 +203,6 @@ class ErrorHandlerTest extends TestCase
         $handler->expects($this->once())
                 ->method('writeToErrorLog');
 
-        $handler->__invoke($request, $exception, true, true, true);
+        $handler->__invoke($request, $response, $exception, true, true, true);
     }
 }

--- a/tests/Middleware/ErrorMiddlewareTest.php
+++ b/tests/Middleware/ErrorMiddlewareTest.php
@@ -10,6 +10,7 @@ namespace Slim\Tests\Middleware;
 
 use Closure;
 use Error;
+use Throwable;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\App;
@@ -116,7 +117,7 @@ class ErrorMiddlewareTest extends TestCase
         };
         $app->add($mw2);
 
-        $handler = function (ServerRequestInterface $request, $exception) {
+        $handler = function (ServerRequestInterface $request, ResponseInterface $response, Throwable $exception) {
             $response = $this->createResponse();
             $response->getBody()->write($exception->getMessage());
             return $response;


### PR DESCRIPTION
This PR adds the `$response` object to the parameters passed to the attached handler and updates related phpdocs

closes https://github.com/slimphp/Slim/issues/2564