### PR TITLE
Fix dispatching of non handle() methods for PSR15 request handlers

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -54,7 +54,8 @@ final class CallableResolver implements CallableResolverInterface
 
         if (!is_callable($toResolve) && is_string($toResolve)) {
             $class = $toResolve;
-            $method = '__invoke';
+            $instance = null;
+            $method = null;
 
             // check for slim callable as "class:method"
             $callablePattern = '!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!';
@@ -64,18 +65,21 @@ final class CallableResolver implements CallableResolverInterface
             }
 
             if ($this->container instanceof ContainerInterface && $this->container->has($class)) {
-                $resolved = [$this->container->get($class), $method];
+                $instance = $this->container->get($class);
             } else {
                 if (!class_exists($class)) {
                     throw new RuntimeException(sprintf('Callable %s does not exist', $class));
                 }
-                $resolved = [new $class($this->container), $method];
+                $instance = new $class($this->container);
             }
 
             // For a class that implements RequestHandlerInterface, we will call handle()
-            if ($resolved[0] instanceof RequestHandlerInterface) {
-                $resolved[1] = 'handle';
+            // if no method has been specified explicitly
+            if ($instance instanceof RequestHandlerInterface && $method === null) {
+                $method = 'handle';
             }
+
+            $resolved = [$instance, $method ?? '__invoke'];
         }
 
         if ($resolved instanceof RequestHandlerInterface) {

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -36,7 +36,7 @@ final class CallableResolver implements CallableResolverInterface
     }
 
     /**
-     * Resolve toResolve into a closure that that the router can dispatch.
+     * Resolve toResolve into a callable that the router can dispatch.
      *
      * If toResolve is of the format 'class:method', then try to extract 'class'
      * from the container otherwise instantiate it and then dispatch 'method'.

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -20,7 +20,7 @@ namespace Slim\Interfaces;
 interface CallableResolverInterface
 {
     /**
-     * Invoke the resolved callable.
+     * Resolve $toResolve into a callable
      *
      * @param mixed $toResolve
      *

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -146,6 +146,16 @@ class CallableResolverTest extends TestCase
         $this->assertEquals("1", RequestHandlerTest::$CalledCount);
     }
 
+    public function testResolutionToAPsrRequestHandlerClassWithCustomMethod()
+    {
+        $request = $this->createServerRequest('/', 'GET');
+        $resolver = new CallableResolver(); // No container injected
+        $callable = $resolver->resolve(RequestHandlerTest::class . ':custom');
+        $this->assertInternalType('array', $callable);
+        $this->assertInstanceOf(RequestHandlerTest::class, $callable[0]);
+        $this->assertEquals('custom', $callable[1]);
+    }
+
     /**
      * @expectedException \RuntimeException
      */

--- a/tests/Mocks/RequestHandlerTest.php
+++ b/tests/Mocks/RequestHandlerTest.php
@@ -42,4 +42,9 @@ class RequestHandlerTest implements RequestHandlerInterface
 
         return $response;
     }
+
+    public function custom(ServerRequestInterface $request) : ResponseInterface
+    {
+        return $responseFactory->createResponse();
+    }
 }


### PR DESCRIPTION
If a method has been explicitly defined, the callable resolver
should honor that for all classes (even for classes that
implement RequestHandlerInterface) and only default to 'handle'
(for PSR-15 RequestHandlers) if no method has been specified.

An example:
When FooBar implements RequestHandlerInterface and
'FooBar:customMethod' is specified to be dispatched, the
CallableResolver must not resolve to the handle() method
even though FooBar implements the RequestHandlerInterface.
It should only do that, if no method name is given: 'FooBar'