### PR TITLE
As we rely on PHP 7, drop call_user_func{,array} usage

### DIFF
--- a/Slim/DeferredCallable.php
+++ b/Slim/DeferredCallable.php
@@ -37,15 +37,14 @@ class DeferredCallable
         $this->callableResolver = $resolver;
     }
 
-    public function __invoke()
+    public function __invoke(...$args)
     {
         /** @var callable $callable */
         $callable = $this->callable;
         if ($this->callableResolver) {
             $callable = $this->callableResolver->resolve($callable);
         }
-        $args = func_get_args();
 
-        return call_user_func_array($callable, $args);
+        return $callable(...$args);
     }
 }

--- a/Slim/Handlers/Strategies/RequestResponse.php
+++ b/Slim/Handlers/Strategies/RequestResponse.php
@@ -41,6 +41,6 @@ class RequestResponse implements InvocationStrategyInterface
             $request = $request->withAttribute($k, $v);
         }
 
-        return call_user_func($callable, $request, $response, $routeArguments);
+        return $callable($request, $response, $routeArguments);
     }
 }

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -38,8 +38,6 @@ class RequestResponseArgs implements InvocationStrategyInterface
         ResponseInterface $response,
         array $routeArguments
     ): ResponseInterface {
-        array_unshift($routeArguments, $request, $response);
-
-        return call_user_func_array($callable, $routeArguments);
+        return $callable($request, $response, ...array_values($routeArguments));
     }
 }

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -113,15 +113,8 @@ class ErrorMiddleware
 
         $exceptionType = get_class($exception);
         $handler = $this->getErrorHandler($exceptionType);
-        $params = [
-            $request,
-            $exception,
-            $this->displayErrorDetails,
-            $this->logErrors,
-            $this->logErrorDetails,
-        ];
 
-        return call_user_func_array($handler, $params);
+        return $handler($request, $exception, $this->displayErrorDetails, $this->logErrors, $this->logErrorDetails);
     }
 
     /**

--- a/Slim/MiddlewareAwareTrait.php
+++ b/Slim/MiddlewareAwareTrait.php
@@ -70,7 +70,7 @@ trait MiddlewareAwareTrait
             $callable,
             $next
         ) {
-            $result = call_user_func($callable, $request, $response, $next);
+            $result = $callable($request, $response, $next);
             if ($result instanceof ResponseInterface === false) {
                 throw new UnexpectedValueException(
                     'Middleware must return instance of \Psr\Http\Message\ResponseInterface'


### PR DESCRIPTION
Use the `$callable()` syntax instead.
See https://trowski.com/2015/06/20/php-callable-paradox/