### PR TITLE
Slim 2.x Mcrypt Deprecation Notice Silencing

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -103,24 +103,24 @@ class Util
         $settings = array_merge($defaults, $settings);
 
         //Get module
-        $module = mcrypt_module_open($settings['algorithm'], '', $settings['mode'], '');
+        $module = @mcrypt_module_open($settings['algorithm'], '', $settings['mode'], '');
 
         //Validate IV
-        $ivSize = mcrypt_enc_get_iv_size($module);
+        $ivSize = @mcrypt_enc_get_iv_size($module);
         if (strlen($iv) > $ivSize) {
             $iv = substr($iv, 0, $ivSize);
         }
 
         //Validate key
-        $keySize = mcrypt_enc_get_key_size($module);
+        $keySize = @mcrypt_enc_get_key_size($module);
         if (strlen($key) > $keySize) {
             $key = substr($key, 0, $keySize);
         }
 
         //Encrypt value
-        mcrypt_generic_init($module, $key, $iv);
+        @mcrypt_generic_init($module, $key, $iv);
         $res = @mcrypt_generic($module, $data);
-        mcrypt_generic_deinit($module);
+        @mcrypt_generic_deinit($module);
 
         return $res;
     }
@@ -153,25 +153,25 @@ class Util
         $settings = array_merge($defaults, $settings);
 
         //Get module
-        $module = mcrypt_module_open($settings['algorithm'], '', $settings['mode'], '');
+        $module = @mcrypt_module_open($settings['algorithm'], '', $settings['mode'], '');
 
         //Validate IV
-        $ivSize = mcrypt_enc_get_iv_size($module);
+        $ivSize = @mcrypt_enc_get_iv_size($module);
         if (strlen($iv) > $ivSize) {
             $iv = substr($iv, 0, $ivSize);
         }
 
         //Validate key
-        $keySize = mcrypt_enc_get_key_size($module);
+        $keySize = @mcrypt_enc_get_key_size($module);
         if (strlen($key) > $keySize) {
             $key = substr($key, 0, $keySize);
         }
 
         //Decrypt value
-        mcrypt_generic_init($module, $key, $iv);
+        @mcrypt_generic_init($module, $key, $iv);
         $decryptedData = @mdecrypt_generic($module, $data);
         $res = rtrim($decryptedData, "\0");
-        mcrypt_generic_deinit($module);
+        @mcrypt_generic_deinit($module);
 
         return $res;
     }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "suggest": {
         "ext-mcrypt": "Required for HTTP cookie encryption",
-        "phpseclib/mcrypt_compat": "Polyfil for mcrypt extension"
+        "phpseclib/mcrypt_compat": "Polyfill for mcrypt extension"
     },
     "autoload": {
         "psr-0": { "Slim": "." }


### PR DESCRIPTION
This is a proposed fix for #2362 

@akrabat I'm not sure if you're okay with using `@mcrypt_` to silence the warnings since of the behavior in 7.1 (7.2 is fine).