### PR TITLE
4.x Remove App Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 ## 4.0.0 - TBD
 
 ### Added
-
-- [#2507](https://github.com/slimphp/Slim/pull/2507) Method names are now case-sensitive in Router::map(), and so, by extension, in App::map() 
+- [#2555](https://github.com/slimphp/Slim/pull/2555) Added PSR-15 Middleware Support
 - [#2529](https://github.com/slimphp/Slim/pull/2529) Slim no longer ships with a PSR-7 implementation. You need to provide a PSR-7 ServerRequest and a PSR-17 ResponseFactory to run Slim.
+- [#2507](https://github.com/slimphp/Slim/pull/2507) Method names are now case-sensitive in Router::map(), and so, by extension, in App::map() 
 - [#2497](https://github.com/slimphp/Slim/pull/2497) PSR-15 RequestHandlers can now be used as route callables
 - [#2496](https://github.com/slimphp/Slim/pull/2496) A Slim App can now be used as PSR-15 Request Handler
 - [#2405](https://github.com/slimphp/Slim/pull/2405) RoutingMiddleware now adds the `routingResults` request attribute to hold the results of routing
@@ -20,10 +20,12 @@
 
 ### Deprecated
 
-- Nothing.
+- [#2555](https://github.com/slimphp/Slim/pull/2555) Double-Pass Middleware Support has been deprecated
 
 ### Removed
 
+- [#2589](https://github.com/slimphp/Slim/pull/2589) Remove App::$settings altogether
+- [#2587](https://github.com/slimphp/Slim/pull/2587) Remove Pimple as a dev-dependency
 - [#2398](https://github.com/slimphp/Slim/pull/2398) Slim no longer has error handling built into App. Add ErrorMiddleware() as the outermost middleware.
 - [#2375](https://github.com/slimphp/Slim/pull/2375) Slim no longer sets the `default_mimetype` to an empty string, so you need to set it yourself in php.ini or your app using `ini_set('default_mimetype', '');`.
 - [#2288](https://github.com/slimphp/Slim/pull/2288) `determineRouteBeforeAppMiddleware` setting is removed. Add RoutingMiddleware() where you need it now.
@@ -43,7 +45,7 @@
 - [#2104](https://github.com/slimphp/Slim/pull/2104) Settings are the top level array elements in `App::__construct()`
 
 ### Fixed
-
+- [#2588](https://github.com/slimphp/Slim/pull/2588) Fix file/directory permission handling of `Router::setCacheFile()`
 - [#2067](https://github.com/slimphp/Slim/pull/2067) Unit tests now pass on Windows systems
 - [#2405](https://github.com/slimphp/Slim/pull/2405) We rawurldecode() the path before passing to FastRoute, so UTF-8 characters in paths should now work.
 

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -71,14 +71,6 @@ class App implements RequestHandlerInterface
      */
     protected $responseFactory;
 
-    /**
-     * @var array
-     */
-    protected $settings = [
-        'httpVersion' => '1.1',
-        'routerCacheFile' => null,
-    ];
-
     /********************************************************************************
      * Constructor
      *******************************************************************************/
@@ -88,26 +80,19 @@ class App implements RequestHandlerInterface
      *
      * @param ResponseFactoryInterface  $responseFactory
      * @param ContainerInterface|null   $container
-     * @param array                     $settings
      * @param CallableResolverInterface $callableResolver
      * @param RouterInterface           $router
      */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
         ContainerInterface $container = null,
-        array $settings = [],
         CallableResolverInterface $callableResolver = null,
         RouterInterface $router = null
     ) {
         $this->responseFactory = $responseFactory;
         $this->container = $container;
         $this->callableResolver = $callableResolver ?? new CallableResolver($container);
-        $this->addSettings($settings);
-
         $this->router = $router ?? new Router($responseFactory, $this->callableResolver);
-        $routerCacheFile = $this->getSetting('routerCacheFile', null);
-        $this->router->setCacheFile($routerCacheFile);
-
         $this->middlewareRunner = new MiddlewareRunner();
         $this->addMiddleware(new DispatchMiddleware($this->router));
     }
@@ -140,64 +125,6 @@ class App implements RequestHandlerInterface
     {
         $this->middlewareRunner->add($middleware);
         return $this;
-    }
-
-    /********************************************************************************
-     * Settings management
-     *******************************************************************************/
-
-    /**
-     * Does app have a setting with given key?
-     *
-     * @param string $key
-     * @return bool
-     */
-    public function hasSetting(string $key): bool
-    {
-        return isset($this->settings[$key]);
-    }
-
-    /**
-     * Get app settings
-     *
-     * @return array
-     */
-    public function getSettings(): array
-    {
-        return $this->settings;
-    }
-
-    /**
-     * Get app setting with given key
-     *
-     * @param string $key
-     * @param mixed $defaultValue
-     * @return mixed
-     */
-    public function getSetting(string $key, $defaultValue = null)
-    {
-        return $this->hasSetting($key) ? $this->settings[$key] : $defaultValue;
-    }
-
-    /**
-     * Merge a key-value array with existing app settings
-     *
-     * @param array $settings
-     */
-    public function addSettings(array $settings)
-    {
-        $this->settings = array_merge($this->settings, $settings);
-    }
-
-    /**
-     * Add single app setting
-     *
-     * @param string $key
-     * @param mixed $value
-     */
-    public function addSetting(string $key, $value)
-    {
-        $this->settings[$key] = $value;
     }
 
     /********************************************************************************

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -72,63 +72,6 @@ class AppTest extends TestCase
     }
 
     /********************************************************************************
-     * Settings management methods
-     *******************************************************************************/
-
-    public function testHasSetting()
-    {
-        $responseFactory = $this->getResponseFactory();
-        $app = new App($responseFactory);
-        $this->assertTrue($app->hasSetting('httpVersion'));
-        $this->assertFalse($app->hasSetting('foo'));
-    }
-
-    public function testGetSettings()
-    {
-        $responseFactory = $this->getResponseFactory();
-        $app = new App($responseFactory);
-        $appSettings = $app->getSettings();
-        $this->assertAttributeEquals($appSettings, 'settings', $app);
-    }
-
-    public function testGetSettingExists()
-    {
-        $responseFactory = $this->getResponseFactory();
-        $app = new App($responseFactory);
-        $this->assertEquals('1.1', $app->getSetting('httpVersion'));
-    }
-
-    public function testGetSettingNotExists()
-    {
-        $responseFactory = $this->getResponseFactory();
-        $app = new App($responseFactory);
-        $this->assertNull($app->getSetting('foo'));
-    }
-
-    public function testGetSettingNotExistsWithDefault()
-    {
-        $responseFactory = $this->getResponseFactory();
-        $app = new App($responseFactory);
-        $this->assertEquals('what', $app->getSetting('foo', 'what'));
-    }
-
-    public function testAddSettings()
-    {
-        $responseFactory = $this->getResponseFactory();
-        $app = new App($responseFactory);
-        $app->addSettings(['foo' => 'bar']);
-        $this->assertAttributeContains('bar', 'settings', $app);
-    }
-
-    public function testAddSetting()
-    {
-        $responseFactory = $this->getResponseFactory();
-        $app = new App($responseFactory);
-        $app->addSetting('foo', 'bar');
-        $this->assertAttributeContains('bar', 'settings', $app);
-    }
-
-    /********************************************************************************
      * Router proxy methods
      *******************************************************************************/
 


### PR DESCRIPTION
Remove `App` settings and associated tests as per discussion @akrabat via Slack.

We have removed all of the settings from the `App`. The customization that those settings provided are now available in the instantiation of core middleware or the logic to apply those settings has changed.

The settings deprecated:
- `httpVersion` This can be set via your PSR-7 implementation's `ResponseFactory` if available
- `routerCacheFile` You have to get the router via `App::getRouter()` then `$router->setCacheFile($file)`
- `displayErrorDetails` is now moved to `ErrorMiddleware`'s constructor parameters
- `outputBuffering` is now moved to `OutputBufferingMiddleware`'s constructor parameters
- `determineRouteBeforeAppMiddleware` is now moved to order in which you add `RoutingMiddleware`
- `responseChunkSize` is moved to `ResponseEmitter`'s constructor parameters
- `addContentLengthHeader` is defined by whether or not you add `ContentLengthMiddleware` to your middleware queue

Will need to update `CHANGELOG`