### PR TITLE
4.x Refactor AppTest To Use Prophecy

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -166,7 +166,7 @@ class AppTest extends TestCase
 
         $methodName = strtolower($method);
         $app = new App($responseFactoryProphecy->reveal());
-        $app->$methodName('/', function ($request, ResponseInterface $response) {
+        $app->$methodName('/', function (ServerRequestInterface $request, ResponseInterface $response) {
             return $response;
         });
         $response = $app->handle($requestProphecy->reveal());
@@ -186,7 +186,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->any('/', function ($request, ResponseInterface $response) {
+        $app->any('/', function (ServerRequestInterface $request, ResponseInterface $response) {
             return $response;
         });
 
@@ -242,7 +242,7 @@ class AppTest extends TestCase
         });
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->map([$method], '/', function ($request, ResponseInterface $response) {
+        $app->map([$method], '/', function (ServerRequestInterface $request, ResponseInterface $response) {
             return $response;
         });
         $response = $app->handle($requestProphecy->reveal());
@@ -570,7 +570,7 @@ class AppTest extends TestCase
 
         $app->add($middlewareProphecy->reveal());
         $app->add($middlewareProphecy2->reveal());
-        $app->get('/', function ($request, $response) {
+        $app->get('/', function (ServerRequestInterface $request, $response) {
             return $response;
         });
 
@@ -613,7 +613,7 @@ class AppTest extends TestCase
 
         $app = new App($responseFactoryProphecy->reveal(), $containerProphecy->reveal());
         $app->add('middleware');
-        $app->get('/', function ($request, ResponseInterface $response) {
+        $app->get('/', function (ServerRequestInterface $request, ResponseInterface $response) {
             return $response;
         });
 
@@ -684,7 +684,7 @@ class AppTest extends TestCase
         });
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/', function ($request, ResponseInterface $response) use (&$output) {
+        $app->get('/', function (ServerRequestInterface $request, ResponseInterface $response) use (&$output) {
             $output .= 'Center';
             return $response;
         })
@@ -766,7 +766,7 @@ class AppTest extends TestCase
 
         $app = new App($responseFactoryProphecy->reveal());
         $app->group('/foo', function (App $app) use (&$output) {
-            $app->get('/bar', function ($request, ResponseInterface $response) use (&$output) {
+            $app->get('/bar', function (ServerRequestInterface $request, ResponseInterface $response) use (&$output) {
                 $output .= 'Center';
                 return $response;
             });
@@ -871,7 +871,10 @@ class AppTest extends TestCase
         $app = new App($responseFactoryProphecy->reveal());
         $app->group('/foo', function (App $app) use ($middlewareProphecy2, $middlewareProphecy3, &$output) {
             $app->group('/bar', function (App $app) use ($middlewareProphecy3, &$output) {
-                $app->get('/baz', function ($request, ResponseInterface $response) use (&$output) {
+                $app->get('/baz', function (
+                    ServerRequestInterface $request,
+                    ResponseInterface $response
+                ) use (&$output) {
                     $output .= 'Center';
                     return $response;
                 })->add($middlewareProphecy3->reveal());
@@ -950,7 +953,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/', function ($request, $response) {
+        $app->get('/', function (ServerRequestInterface $request, $response) {
             return $response;
         });
 
@@ -990,7 +993,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/', function ($request, ResponseInterface $response, $args) {
+        $app->get('/', function (ServerRequestInterface $request, ResponseInterface $response, $args) {
             $response->getBody()->write("Hello {$args['name']}");
             return $response;
         })->setArgument('name', 'World');
@@ -1031,7 +1034,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/', function ($request, ResponseInterface $response, $args) {
+        $app->get('/', function (ServerRequestInterface $request, ResponseInterface $response, $args) {
             $response->getBody()->write("{$args['greeting']} {$args['name']}");
             return $response;
         })->setArguments(['greeting' => 'Hello', 'name' => 'World']);
@@ -1072,7 +1075,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/Hello/{name}', function ($request, ResponseInterface $response, $args) {
+        $app->get('/Hello/{name}', function (ServerRequestInterface $request, ResponseInterface $response, $args) {
             $response->getBody()->write("Hello {$args['name']}");
             return $response;
         });
@@ -1114,7 +1117,7 @@ class AppTest extends TestCase
 
         $app = new App($responseFactoryProphecy->reveal());
         $app->getRouter()->setDefaultInvocationStrategy(new RequestResponseArgs());
-        $app->get('/Hello/{name}', function ($request, ResponseInterface $response, $name) {
+        $app->get('/Hello/{name}', function (ServerRequestInterface $request, ResponseInterface $response, $name) {
             $response->getBody()->write("Hello {$name}");
             return $response;
         });
@@ -1155,7 +1158,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/Hello/{name}', function ($request, ResponseInterface $response, $args) {
+        $app->get('/Hello/{name}', function (ServerRequestInterface $request, ResponseInterface $response, $args) {
             $response->getBody()->write("Hello {$args['name']}");
             return $response;
         })->setArgument('name', 'World!');
@@ -1382,7 +1385,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/Hello/{name}', function ($request, ResponseInterface $response, $args) {
+        $app->get('/Hello/{name}', function (ServerRequestInterface $request, ResponseInterface $response, $args) {
             $response->getBody()->write($request->getAttribute('greeting') . ' ' . $args['name']);
             return $response;
         });
@@ -1424,7 +1427,7 @@ class AppTest extends TestCase
 
         $app = new App($responseFactoryProphecy->reveal());
         $app->getRouter()->setDefaultInvocationStrategy(new RequestResponseArgs());
-        $app->get('/Hello/{name}', function ($request, ResponseInterface $response, $name) {
+        $app->get('/Hello/{name}', function (ServerRequestInterface $request, ResponseInterface $response, $name) {
             $response->getBody()->write($request->getAttribute('greeting') . ' ' . $name);
             return $response;
         });
@@ -1477,7 +1480,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/', function ($request, ResponseInterface $response) {
+        $app->get('/', function (ServerRequestInterface $request, ResponseInterface $response) {
             $response->getBody()->write('Hello World');
             return $response;
         });
@@ -1533,7 +1536,7 @@ class AppTest extends TestCase
 
         $called = 0;
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/', function ($request, ResponseInterface $response) use (&$called) {
+        $app->get('/', function (ServerRequestInterface $request, ResponseInterface $response) use (&$called) {
             $called++;
             $response->getBody()->write('Hello World');
             return $response;
@@ -1642,7 +1645,7 @@ class AppTest extends TestCase
         $app
             ->add($middlewareProphecy->reveal())
             ->add($middlewareProphecy2->reveal());
-        $app->get('/', function ($request, ResponseInterface $response) {
+        $app->get('/', function (ServerRequestInterface $request, ResponseInterface $response) {
             return $response;
         });
 
@@ -1744,7 +1747,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/Hello[/{name}]', function ($request, ResponseInterface $response, $args) {
+        $app->get('/Hello[/{name}]', function (ServerRequestInterface $request, ResponseInterface $response, $args) {
             $response->getBody()->write((string) count($args));
             return $response;
         });
@@ -1800,7 +1803,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->get('/Hello[/{name}]', function ($request, ResponseInterface $response, $args) {
+        $app->get('/Hello[/{name}]', function (ServerRequestInterface $request, ResponseInterface $response, $args) {
             $response->getBody()->write((string) count($args));
             return $response;
         })->setArgument('extra', 'value');
@@ -1856,7 +1859,11 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $route = $app->get('/Hello[/{name}]', function ($request, ResponseInterface $response, $args) {
+        $route = $app->get('/Hello[/{name}]', function (
+            ServerRequestInterface $request,
+            ResponseInterface $response,
+            $args
+        ) {
             $response->getBody()->write((string) count($args));
             return $response;
         })->setArgument('extra', 'value');

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1320,7 +1320,7 @@ class AppTest extends TestCase
 
         $response = $app->handle($requestProphecy->reveal());
 
-        $expectedPayload = json_encode(['name'=> 'foo', 'arguments' => []]);
+        $expectedPayload = json_encode(['name' => 'foo', 'arguments' => []]);
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals($expectedPayload, (string) $response->getBody());
     }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1320,7 +1320,7 @@ class AppTest extends TestCase
 
         $response = $app->handle($requestProphecy->reveal());
 
-        $expectedPayload = json_encode(['name'=>'foo', 'arguments' => []]);
+        $expectedPayload = json_encode(['name'=> 'foo', 'arguments' => []]);
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals($expectedPayload, (string) $response->getBody());
     }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -8,7 +8,6 @@
  */
 namespace Slim\Tests;
 
-use Closure;
 use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -372,42 +372,114 @@ class AppTest extends TestCase
     public function routeGroupsDataProvider()
     {
         return [
-            [['', ''], ''], // testEmptyGroupWithEmptyRoute
-            [['', '/'], '/'], // testEmptyGroupWithSingleSlashRoute
-            [['', '/foo'], '/foo'], // testEmptyGroupWithSegmentRouteThatDoesNotEndInASlash
-            [['', '/foo/'], '/foo/'], // testEmptyGroupWithSegmentRouteThatEndsInASlash
-            [['/', ''], '/'], // testGroupSingleSlashWithEmptyRoute
-            [['/', '/'], '//'], // testGroupSingleSlashWithSingleSlashRoute
-            [['/', '/foo'], '//foo'], // testGroupSingleSlashWithSegmentRouteThatDoesNotEndInASlash
-            [['/', '/foo/'], '//foo/'], // testGroupSingleSlashWithSegmentRouteThatEndsInASlash
-            [['/foo', ''], '/foo'], // testGroupSegmentWithEmptyRoute
-            [['/foo', '/'], '/foo/'], // testGroupSegmentWithSingleSlashRoute
-            [['/foo', '/bar'], '/foo/bar'], // testGroupSegmentWithSegmentRouteThatDoesNotEndInASlash
-            [['/foo', '/bar/'], '/foo/bar/'], // testGroupSegmentWithSegmentRouteThatEndsInASlash
-            [['', '/foo', ''], '/foo'], // testEmptyGroupWithNestedGroupSegmentWithAnEmptyRoute
-            [['', '/foo', '/'], '/foo/'], // testEmptyGroupWithNestedGroupSegmentWithSingleSlashRoute
-            [['/', '', 'foo'], '/foo'], // testGroupSingleSlashWithEmptyNestedGroupAndSegmentRouteWithoutLeadingSlash
-            [['/', '', '/foo'], '//foo'], // testGroupSingleSlashWithEmptyNestedGroupAndSegmentRoute
-            [['/', '/', 'foo'], '//foo'], // testGroupSingleSlashWithSingleSlashGroupAndSegmentRouteWithoutLeadingSlash
-            [['/', '/', '/foo'], '///foo'], // testGroupSingleSlashWithSingleSlashNestedGroupAndSegmentRoute
-            [['/', '/foo', ''], '//foo'], // testGroupSingleSlashWithNestedGroupSegmentWithAnEmptyRoute
-            [['/', '/foo', '/'], '//foo/'], // testGroupSingleSlashWithNestedGroupSegmentWithSingleSlashRoute
-            [['/', '/foo', '/bar'], '//foo/bar'], // testGroupSingleSlashWithNestedGroupSegmentWithSegmentRoute
-            [['/', '/foo', '/bar/'], '//foo/bar/'], // testGroupSingleSlashWithNestedGroupSegmentWithSegmentRouteThatHasATrailingSlash
-            [['', '', 'foo'], 'foo'], // testEmptyGroupWithEmptyNestedGroupAndSegmentRouteWithoutLeadingSlash
-            [['', '', '/foo'], '/foo'], // testEmptyGroupWithEmptyNestedGroupAndSegmentRoute
-            [['', '/', 'foo'], '/foo'], // testEmptyGroupWithSingleSlashGroupAndSegmentRouteWithoutLeadingSlash
-            [['', '/', '/foo'], '//foo'], // testEmptyGroupWithSingleSlashNestedGroupAndSegmentRoute
-            [['', '/foo', '/bar'], '/foo/bar'], // testEmptyGroupWithNestedGroupSegmentWithSegmentRoute
-            [['', '/foo', '/bar/'], '/foo/bar/'], // testEmptyGroupWithNestedGroupSegmentWithSegmentRouteThatHasATrailingSlash
-            [['/foo', '', 'bar'], '/foobar'], // testGroupSegmentWithEmptyNestedGroupAndSegmentRouteWithoutLeadingSlash
-            [['/foo', '', '/bar'], '/foo/bar'], // testGroupSegmentWithEmptyNestedGroupAndSegmentRoute
-            [['/foo', '/', 'bar'], '/foo/bar'], // testGroupSegmentWithSingleSlashNestedGroupAndSegmentRoute
-            [['/foo', '/', '/bar'], '/foo//bar'], // testGroupSegmentWithSingleSlashNestedGroupAndSegmentRoute
-            [['/foo', '/bar', ''], '/foo/bar'], // testTwoGroupSegmentsWithSingleSlashRoute
-            [['/foo', '/bar', '/'], '/foo/bar/'], // testTwoGroupSegmentsWithSingleSlashRoute
-            [['/foo', '/bar', '/baz'], '/foo/bar/baz'], // testTwoGroupSegmentsWithSegmentRoute
-            [['/foo', '/bar', '/baz/'], '/foo/bar/baz/'], // testTwoGroupSegmentsWithSegmentRouteThatHasATrailingSlash
+            'empty group with empty route' => [
+                ['', ''], ''
+            ],
+            'empty group with single slash route' => [
+                ['', '/'], '/'
+            ],
+            'empty group with segment route that does not end in aSlash' => [
+                ['', '/foo'], '/foo'
+            ],
+            'empty group with segment route that ends in aSlash' => [
+                ['', '/foo/'], '/foo/'
+            ],
+            'group single slash with empty route' => [
+                ['/', ''], '/'
+            ],
+            'group single slash with single slash route' => [
+                ['/', '/'], '//'
+            ],
+            'group single slash with segment route that does not end in aSlash' => [
+                ['/', '/foo'], '//foo'
+            ],
+            'group single slash with segment route that ends in aSlash' => [
+                ['/', '/foo/'], '//foo/'
+            ],
+            'group segment with empty route' => [
+                ['/foo', ''], '/foo'
+            ],
+            'group segment with single slash route' => [
+                ['/foo', '/'], '/foo/'
+            ],
+            'group segment with segment route that does not end in aSlash' => [
+                ['/foo', '/bar'], '/foo/bar'
+            ],
+            'group segment with segment route that ends in aSlash' => [
+                ['/foo', '/bar/'], '/foo/bar/'
+            ],
+            'empty group with nested group segment with an empty route' => [
+                ['', '/foo', ''], '/foo'
+            ],
+            'empty group with nested group segment with single slash route' => [
+                ['', '/foo', '/'], '/foo/'
+            ],
+            'group single slash with empty nested group and segment route without leading slash' => [
+                ['/', '', 'foo'], '/foo'
+            ],
+            'group single slash with empty nested group and segment route' => [
+                ['/', '', '/foo'], '//foo'
+            ],
+            'group single slash with single slash group and segment route without leading slash' => [
+                ['/', '/', 'foo'], '//foo'
+            ],
+            'group single slash with single slash nested group and segment route' => [
+                ['/', '/', '/foo'], '///foo'
+            ],
+            'group single slash with nested group segment with an empty route' => [
+                ['/', '/foo', ''], '//foo'
+            ],
+            'group single slash with nested group segment with single slash route' => [
+                ['/', '/foo', '/'], '//foo/'
+            ],
+            'group single slash with nested group segment with segment route' => [
+                ['/', '/foo', '/bar'], '//foo/bar'
+            ],
+            'group single slash with nested group segment with segment route that has aTrailing slash' => [
+                ['/', '/foo', '/bar/'], '//foo/bar/'
+            ],
+            'empty group with empty nested group and segment route without leading slash' => [
+                ['', '', 'foo'], 'foo'
+            ],
+            'empty group with empty nested group and segment route' => [
+                ['', '', '/foo'], '/foo'
+            ],
+            'empty group with single slash group and segment route without leading slash' => [
+                ['', '/', 'foo'], '/foo'
+            ],
+            'empty group with single slash nested group and segment route' => [
+                ['', '/', '/foo'], '//foo'
+            ],
+            'empty group with nested group segment with segment route' => [
+                ['', '/foo', '/bar'], '/foo/bar'
+            ],
+            'empty group with nested group segment with segment route that has aTrailing slash' => [
+                ['', '/foo', '/bar/'], '/foo/bar/'
+            ],
+            'group segment with empty nested group and segment route without leading slash' => [
+                ['/foo', '', 'bar'], '/foobar'
+            ],
+            'group segment with empty nested group and segment route' => [
+                ['/foo', '', '/bar'], '/foo/bar'
+            ],
+            'group segment with single slash nested group and segment route' => [
+                ['/foo', '/', 'bar'], '/foo/bar'
+            ],
+            'group segment with single slash nested group and segment route' => [
+                ['/foo', '/', '/bar'], '/foo//bar'
+            ],
+            'two group segments with single slash route' => [
+                ['/foo', '/bar', ''], '/foo/bar'
+            ],
+            'two group segments with single slash route' => [
+                ['/foo', '/bar', '/'], '/foo/bar/'
+            ],
+            'two group segments with segment route' => [
+                ['/foo', '/bar', '/baz'], '/foo/bar/baz'
+            ],
+            'two group segments with segment route that has aTrailing slash' => [
+                ['/foo', '/bar', '/baz/'], '/foo/bar/baz/'
+            ],
         ];
     }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -190,8 +190,8 @@ class AppTest extends TestCase
             return $response;
         });
 
-        $methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
-        foreach ($methods as $method) {
+        foreach ($this->upperCaseRequestMethodsProvider() as $methods) {
+            $method = $methods[0];
             $uriProphecy = $this->prophesize(UriInterface::class);
             $uriProphecy->getPath()->willReturn('/');
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -249,7 +249,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $responseFactoryProphecy->createResponse(Argument::any())->will(function ($args) use ($responseProphecy, $to) {
             $responseProphecy->getStatusCode()->willReturn(isset($args[0]) ? $args[0] : 200);
-            $responseProphecy->getHeaderLine(Argument::exact('Location'))->willReturn($to);
+            $responseProphecy->getHeaderLine('Location')->willReturn($to);
             $responseProphecy->withHeader(
                 Argument::type('string'),
                 Argument::type('string')
@@ -311,7 +311,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1176,7 +1176,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1204,13 +1204,8 @@ class AppTest extends TestCase
         $middlewareProphecy->process(Argument::cetera())->willReturn($responseProphecy->reveal());
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
-        $containerProphecy
-            ->has(Argument::exact('middleware'))
-            ->willReturn(true);
-
-        $containerProphecy
-            ->get(Argument::exact('middleware'))
-            ->willReturn($middlewareProphecy);
+        $containerProphecy->has('middleware')->willReturn(true);
+        $containerProphecy->get('middleware')->willReturn($middlewareProphecy);
 
         $app = new App($responseFactoryProphecy->reveal(), $containerProphecy->reveal());
         $app->add('middleware');
@@ -1298,7 +1293,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1381,7 +1376,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1485,7 +1480,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1529,7 +1524,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('POST');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1561,7 +1556,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1603,7 +1598,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1645,7 +1640,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1687,7 +1682,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1730,7 +1725,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1772,7 +1767,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1798,7 +1793,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1826,8 +1821,8 @@ class AppTest extends TestCase
         };
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
-        $containerProphecy->has(Argument::exact('handler'))->willReturn(true);
-        $containerProphecy->get(Argument::exact('handler'))->willReturn($handler);
+        $containerProphecy->has('handler')->willReturn(true);
+        $containerProphecy->get('handler')->willReturn($handler);
 
         $app = new App($responseFactoryProphecy->reveal(), $containerProphecy->reveal());
         $app->get('/', 'handler:foo');
@@ -1838,7 +1833,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1864,8 +1859,8 @@ class AppTest extends TestCase
         };
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
-        $containerProphecy->has(Argument::exact('handler'))->willReturn(true);
-        $containerProphecy->get(Argument::exact('handler'))->willReturn($handler);
+        $containerProphecy->has('handler')->willReturn(true);
+        $containerProphecy->get('handler')->willReturn($handler);
 
         $app = new App($responseFactoryProphecy->reveal(), $containerProphecy->reveal());
         $app->get('/', 'handler:method_does_not_exist');
@@ -1900,8 +1895,8 @@ class AppTest extends TestCase
         $mockAction = new MockAction();
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
-        $containerProphecy->has(Argument::exact('handler'))->willReturn(true);
-        $containerProphecy->get(Argument::exact('handler'))->willReturn($mockAction);
+        $containerProphecy->has('handler')->willReturn(true);
+        $containerProphecy->get('handler')->willReturn($mockAction);
 
         $app = new App($responseFactoryProphecy->reveal(), $containerProphecy->reveal());
         $app->get('/', 'handler:foo');
@@ -1912,7 +1907,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1959,7 +1954,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2001,7 +1996,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2044,7 +2039,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2068,7 +2063,7 @@ class AppTest extends TestCase
         $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
             $streamBody .= $args[0];
         });
-        $streamProphecy->read(Argument::exact(11))->will(function () use (&$hasBeenRead, &$streamBody) {
+        $streamProphecy->read(11)->will(function () use (&$hasBeenRead, &$streamBody) {
             $hasBeenRead = true;
             return $streamBody;
         });
@@ -2101,7 +2096,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2150,7 +2145,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('HEAD');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2313,7 +2308,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2362,7 +2357,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2378,7 +2373,7 @@ class AppTest extends TestCase
         $requestProphecy2 = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy2->getMethod()->willReturn('GET');
         $requestProphecy2->getUri()->willReturn($uriProphecy2->reveal());
-        $requestProphecy2->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy2->getAttribute('routingResults')->willReturn(null);
         $requestProphecy2->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2419,7 +2414,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2435,7 +2430,7 @@ class AppTest extends TestCase
         $requestProphecy2 = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy2->getMethod()->willReturn('GET');
         $requestProphecy2->getUri()->willReturn($uriProphecy2->reveal());
-        $requestProphecy2->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy2->getAttribute('routingResults')->willReturn(null);
         $requestProphecy2->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2476,8 +2471,8 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(Argument::exact('route'))->willReturn($route);
-        $requestProphecy->getAttribute(Argument::exact('routingResults'))->willReturn(null);
+        $requestProphecy->getAttribute('route')->willReturn($route);
+        $requestProphecy->getAttribute('routingResults')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1571,13 +1571,12 @@ class AppTest extends TestCase
 
     public function testInvokeWithMatchingRouteWithSetArgument()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1613,13 +1612,12 @@ class AppTest extends TestCase
 
     public function testInvokeWithMatchingRouteWithSetArguments()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1655,13 +1653,12 @@ class AppTest extends TestCase
 
     public function testInvokeWithMatchingRouteWithNamedParameter()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1697,13 +1694,12 @@ class AppTest extends TestCase
 
     public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseArgStrategy()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1740,13 +1736,12 @@ class AppTest extends TestCase
 
     public function testInvokeWithMatchingRouteWithNamedParameterOverwritesSetArgument()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1877,13 +1872,12 @@ class AppTest extends TestCase
 
     public function testInvokeWithCallableInContainerViaCallMagicMethod()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1923,13 +1917,12 @@ class AppTest extends TestCase
 
     public function testInvokeFunctionName()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1969,13 +1962,12 @@ class AppTest extends TestCase
 
     public function testCurrentRequestAttributesAreNotLostWhenAddingRouteArguments()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -2011,13 +2003,12 @@ class AppTest extends TestCase
 
     public function testCurrentRequestAttributesAreNotLostWhenAddingRouteArgumentsRequestResponseArg()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -2054,16 +2045,15 @@ class AppTest extends TestCase
 
     public function testRun()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
-        });
-        $streamProphecy->read(11)->will(function () use (&$streamBody) {
-            return $streamBody;
+        $streamProphecy->read('11')->will(function () {
+            return $this->reveal()->__toString();
         });
         $streamProphecy->eof()->will(function () {
             $this->eof()->willReturn(true);
@@ -2109,19 +2099,18 @@ class AppTest extends TestCase
 
     public function testHandleReturnsEmptyResponseBodyWithHeadRequestMethod()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
         $responseProphecy->getBody()->willReturn($streamProphecy->reveal());
-        $responseProphecy->withBody(Argument::any())->will(function ($args) use (&$streamBody) {
-            $streamBody = '';
+        $responseProphecy->withBody(Argument::any())->will(function ($args) use ($streamProphecy) {
+            $streamProphecy->__toString()->willReturn('');
             $clone = clone $this;
             $clone->getBody()->willReturn($args[0]);
             return $clone;
@@ -2159,13 +2148,12 @@ class AppTest extends TestCase
 
     public function testCanBeReExecutedRecursivelyDuringDispatch()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseHeaders = [];
@@ -2329,13 +2317,12 @@ class AppTest extends TestCase
 
     public function testInvokeSequentialProccessToAPathWithOptionalArgsAndWithoutOptionalArgs()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -2379,20 +2366,19 @@ class AppTest extends TestCase
             return $clone;
         });
 
-        $streamBody = '';
+        $streamProphecy->__toString()->willReturn('');
         $response = $app->handle($requestProphecy2->reveal());
         $this->assertEquals('0', (string) $response->getBody());
     }
 
     public function testInvokeSequentialProccessToAPathWithOptionalArgsAndWithoutOptionalArgsAndKeepSetedArgs()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -2436,20 +2422,19 @@ class AppTest extends TestCase
             return $clone;
         });
 
-        $streamBody = '';
+        $streamProphecy->__toString()->willReturn('');
         $response = $app->handle($requestProphecy2->reveal());
         $this->assertEquals('1', (string) $response->getBody());
     }
 
     public function testInvokeSequentialProccessAfterAddingAnotherRouteArgument()
     {
-        $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
-        $streamProphecy->__toString()->will(function () use (&$streamBody) {
-            return $streamBody;
-        });
-        $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
-            $streamBody .= $args[0];
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -2483,7 +2468,7 @@ class AppTest extends TestCase
 
         $route->setArgument('extra2', 'value2');
 
-        $streamBody = '';
+        $streamProphecy->__toString()->willReturn('');
         $response = $app->handle($requestProphecy->reveal());
         $this->assertEquals('3', (string) $response->getBody());
     }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -349,7 +349,7 @@ class AppTest extends TestCase
 
     /**
      * @param string $pattern
-     * @dataProvider  routePatternsProvider
+     * @dataProvider routePatternsProvider
      */
     public function testRoutePatterns(string $pattern)
     {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1819,18 +1819,15 @@ class AppTest extends TestCase
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
-        $handlerMock = $this->getMockBuilder('MockRouteHandler')
-            ->disableOriginalClone()
-            ->setMethods(['foo'])
-            ->getMock();
-
-        $handlerMock
-            ->method('foo')
-            ->willReturn($responseProphecy->reveal());
+        $handler = new Class {
+            public function foo(ServerRequestInterface $request, ResponseInterface $response) {
+                return $response;
+            }
+        };
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
         $containerProphecy->has(Argument::exact('handler'))->willReturn(true);
-        $containerProphecy->get(Argument::exact('handler'))->willReturn($handlerMock);
+        $containerProphecy->get(Argument::exact('handler'))->willReturn($handler);
 
         $app = new App($responseFactoryProphecy->reveal(), $containerProphecy->reveal());
         $app->get('/', 'handler:foo');
@@ -1863,13 +1860,12 @@ class AppTest extends TestCase
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
-        $handlerMock = $this
-            ->getMockBuilder(stdClass::class)
-            ->getMock();
+        $handler = new Class {
+        };
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
         $containerProphecy->has(Argument::exact('handler'))->willReturn(true);
-        $containerProphecy->get(Argument::exact('handler'))->willReturn($handlerMock);
+        $containerProphecy->get(Argument::exact('handler'))->willReturn($handler);
 
         $app = new App($responseFactoryProphecy->reveal(), $containerProphecy->reveal());
         $app->get('/', 'handler:method_does_not_exist');

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -155,6 +155,20 @@ class AppTest extends TestCase
         $this->assertEquals(['PUT'], $methodsProperty->getValue($route));
     }
 
+    public function testPatchRoute()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $app = new App($responseFactoryProphecy->reveal());
+        $route = $app->patch('/', function () {
+        });
+
+        $methodsProperty = new ReflectionProperty(Route::class, 'methods');
+        $methodsProperty->setAccessible(true);
+
+        $this->assertInstanceOf(Route::class, $route);
+        $this->assertEquals(['PATCH'], $methodsProperty->getValue($route));
+    }
+
     public function testDeleteRoute()
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -2054,7 +2054,6 @@ class AppTest extends TestCase
 
     public function testRun()
     {
-        $hasBeenRead = false;
         $streamBody = '';
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->will(function () use (&$streamBody) {
@@ -2063,12 +2062,12 @@ class AppTest extends TestCase
         $streamProphecy->write(Argument::type('string'))->will(function ($args) use (&$streamBody) {
             $streamBody .= $args[0];
         });
-        $streamProphecy->read(11)->will(function () use (&$hasBeenRead, &$streamBody) {
-            $hasBeenRead = true;
+        $streamProphecy->read(11)->will(function () use (&$streamBody) {
             return $streamBody;
         });
-        $streamProphecy->eof()->will(function () use (&$hasBeenRead) {
-            return $hasBeenRead;
+        $streamProphecy->eof()->will(function () {
+            $this->eof()->willReturn(true);
+            return false;
         });
         $streamProphecy->isSeekable()->willReturn(true);
         $streamProphecy->rewind()->willReturn(true);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -17,7 +17,6 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use ReflectionProperty;
 use RuntimeException;
 use Slim\App;
 use Slim\CallableResolver;
@@ -363,10 +362,7 @@ class AppTest extends TestCase
         $router = $app->getRouter();
         $route = $router->lookupRoute('route0');
 
-        $patternProperty = new ReflectionProperty(Route::class, 'pattern');
-        $patternProperty->setAccessible(true);
-
-        $this->assertEquals($pattern, $patternProperty->getValue($route));
+        $this->assertEquals($pattern, $route->getPattern());
     }
 
     /********************************************************************************
@@ -456,10 +452,7 @@ class AppTest extends TestCase
         $router = $app->getRouter();
         $route = $router->lookupRoute('route0');
 
-        $patternProperty = new ReflectionProperty(Route::class, 'pattern');
-        $patternProperty->setAccessible(true);
-
-        $this->assertEquals($expectedPath, $patternProperty->getValue($route));
+        $this->assertEquals($expectedPath, $route->getPattern());
     }
 
     /********************************************************************************


### PR DESCRIPTION
This is a continuation of migrating towards the usage of `phpspec/prophecy`.

- Prophesized PSR-7 Object Interfaces
- Prophesized ContainerInterface
- Prophesized MiddlewareInterface
- No more deprecated `$this->assertAttributeEquals()` calls!

@bnf and @akrabat please review!