### PR TITLE
4.x - Remove Copyright In File Headers

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/DeferredCallable.php
+++ b/Slim/DeferredCallable.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Dispatcher.php
+++ b/Slim/Dispatcher.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Error/AbstractErrorRenderer.php
+++ b/Slim/Error/AbstractErrorRenderer.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Error/Renderers/XmlErrorRenderer.php
+++ b/Slim/Error/Renderers/XmlErrorRenderer.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Exception/HttpBadRequestException.php
+++ b/Slim/Exception/HttpBadRequestException.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Exception/HttpException.php
+++ b/Slim/Exception/HttpException.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Exception/HttpForbiddenException.php
+++ b/Slim/Exception/HttpForbiddenException.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Exception/HttpInternalServerErrorException.php
+++ b/Slim/Exception/HttpInternalServerErrorException.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Exception/HttpMethodNotAllowedException.php
+++ b/Slim/Exception/HttpMethodNotAllowedException.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Exception/HttpNotFoundException.php
+++ b/Slim/Exception/HttpNotFoundException.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Exception/HttpNotImplementedException.php
+++ b/Slim/Exception/HttpNotImplementedException.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Exception/HttpSpecializedException.php
+++ b/Slim/Exception/HttpSpecializedException.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Exception/HttpUnauthorizedException.php
+++ b/Slim/Exception/HttpUnauthorizedException.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Handlers/Strategies/RequestHandler.php
+++ b/Slim/Handlers/Strategies/RequestHandler.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Handlers/Strategies/RequestResponse.php
+++ b/Slim/Handlers/Strategies/RequestResponse.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Interfaces/ErrorHandlerInterface.php
+++ b/Slim/Interfaces/ErrorHandlerInterface.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Interfaces/ErrorRendererInterface.php
+++ b/Slim/Interfaces/ErrorRendererInterface.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Interfaces/InvocationStrategyInterface.php
+++ b/Slim/Interfaces/InvocationStrategyInterface.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Interfaces/RouteGroupInterface.php
+++ b/Slim/Interfaces/RouteGroupInterface.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Middleware/ContentLengthMiddleware.php
+++ b/Slim/Middleware/ContentLengthMiddleware.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Middleware/MethodOverrideMiddleware.php
+++ b/Slim/Middleware/MethodOverrideMiddleware.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Route.php
+++ b/Slim/Route.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/RouteDispatcher.php
+++ b/Slim/RouteDispatcher.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/RouteGroup.php
+++ b/Slim/RouteGroup.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/Slim/RoutingResults.php
+++ b/Slim/RoutingResults.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 declare(strict_types=1);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests;
 
 use Prophecy\Argument;

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests;
 
 use Prophecy\Argument;

--- a/tests/DeferredCallableTest.php
+++ b/tests/DeferredCallableTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests;
 
 use Psr\Container\ContainerInterface;

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
 namespace Slim\Tests;
 
 use FastRoute\DataGenerator\GroupCountBased;

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Error;
 
 use Exception;

--- a/tests/Exception/HttpExceptionTest.php
+++ b/tests/Exception/HttpExceptionTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Exception;
 
 use Psr\Http\Message\ServerRequestInterface;

--- a/tests/Exception/HttpUnauthorizedExceptionTest.php
+++ b/tests/Exception/HttpUnauthorizedExceptionTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Exception;
 
 use Slim\Exception\HttpUnauthorizedException;

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Handlers;
 
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Middleware/ContentLengthMiddlewareTest.php
+++ b/tests/Middleware/ContentLengthMiddlewareTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Middleware;
 
 use Psr\Http\Server\RequestHandlerInterface;

--- a/tests/Middleware/ErrorMiddlewareTest.php
+++ b/tests/Middleware/ErrorMiddlewareTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Middleware;
 
 use Error;

--- a/tests/Middleware/MethodOverrideMiddlewareTest.php
+++ b/tests/Middleware/MethodOverrideMiddlewareTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Middleware;
 
 use Psr\Http\Server\RequestHandlerInterface;

--- a/tests/Middleware/OutputBufferingMiddlewareTest.php
+++ b/tests/Middleware/OutputBufferingMiddlewareTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Middleware;
 
 use Psr\Http\Server\RequestHandlerInterface;

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Middleware;
 
 use FastRoute\Dispatcher;

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests;
 
 use Prophecy\Argument;

--- a/tests/Mocks/CallableTest.php
+++ b/tests/Mocks/CallableTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Slim\Tests\Providers\PSR7ObjectProvider;

--- a/tests/Mocks/InvocationStrategyTest.php
+++ b/tests/Mocks/InvocationStrategyTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Mocks/InvokableTest.php
+++ b/tests/Mocks/InvokableTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 /**

--- a/tests/Mocks/MockAction.php
+++ b/tests/Mocks/MockAction.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use InvalidArgumentException;

--- a/tests/Mocks/MockCustomException.php
+++ b/tests/Mocks/MockCustomException.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Exception;

--- a/tests/Mocks/MockErrorHandler.php
+++ b/tests/Mocks/MockErrorHandler.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Slim\Handlers\ErrorHandler;

--- a/tests/Mocks/MockErrorRenderer.php
+++ b/tests/Mocks/MockErrorRenderer.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Slim\Error\AbstractErrorRenderer;

--- a/tests/Mocks/MockMiddleware.php
+++ b/tests/Mocks/MockMiddleware.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Psr\Http\Message\ResponseFactoryInterface;

--- a/tests/Mocks/MockMiddlewareWithoutConstructor.php
+++ b/tests/Mocks/MockMiddlewareWithoutConstructor.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Mocks/MockMiddlewareWithoutInterface.php
+++ b/tests/Mocks/MockMiddlewareWithoutInterface.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 /**

--- a/tests/Mocks/MockRequestHandler.php
+++ b/tests/Mocks/MockRequestHandler.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
 declare(strict_types=1);
 
 namespace Slim\Tests\Mocks;

--- a/tests/Mocks/MockSequenceMiddleware.php
+++ b/tests/Mocks/MockSequenceMiddleware.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Mocks/MockStream.php
+++ b/tests/Mocks/MockStream.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Psr\Http\Message\StreamInterface;

--- a/tests/Mocks/RequestHandlerTest.php
+++ b/tests/Mocks/RequestHandlerTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Mocks/SmallChunksStream.php
+++ b/tests/Mocks/SmallChunksStream.php
@@ -2,9 +2,7 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
 
 namespace Slim\Tests\Mocks;

--- a/tests/Mocks/StaticCallable.php
+++ b/tests/Mocks/StaticCallable.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Mocks;
 
 use Psr\Http\Message\ResponseInterface;

--- a/tests/Providers/PSR7ObjectProvider.php
+++ b/tests/Providers/PSR7ObjectProvider.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Providers;
 
 use Nyholm\Psr7\Factory\Psr17Factory;

--- a/tests/Providers/PSR7ObjectProviderInterface.php
+++ b/tests/Providers/PSR7ObjectProviderInterface.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Providers;
 
 use Psr\Http\Message\ResponseFactoryInterface;

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests;
 
 use Slim\ResponseEmitter;

--- a/tests/RouteDispatcherTest.php
+++ b/tests/RouteDispatcherTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests;
 
 use Psr\Http\Message\ResponseInterface;

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests;
 
 use Closure;

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests;
 
 use FastRoute\RouteCollector;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,9 @@
 /**
  * Slim Framework (https://slimframework.com)
  *
- * @link      https://github.com/slimphp/Slim
- * @copyright Copyright (c) 2011-2018 Josh Lockhart
- * @license   https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,8 @@
 <?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
 require __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Removing all dated copyright and link lines in file headers as per https://github.com/slimphp/Slim/issues/2594

The new file header format is as follows:
```php
/**
 * Slim Framework (https://slimframework.com)
 *
 * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
 */
```

This pull effectively closes #2594 