### PR TITLE
4.x - Remove Unused Imports

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Slim;
 
-use Closure;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -19,7 +18,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use RuntimeException;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;

--- a/Slim/Routable.php
+++ b/Slim/Routable.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Slim;
 
-use Closure;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Slim\Interfaces\CallableResolverInterface;
 

--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -20,14 +20,11 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use Slim\Handlers\Strategies\RequestResponse;
-use Slim\Exception\HttpMethodNotAllowedException;
-use Slim\Exception\HttpNotFoundException;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\InvocationStrategyInterface;
 use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouterInterface;
-use Slim\Middleware\RoutingMiddleware;
 
 /**
  * Router

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -25,7 +25,6 @@ use Slim\Exception\HttpNotFoundException;
 use Slim\Handlers\Strategies\RequestResponseArgs;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouterInterface;
-use Slim\Route;
 use Slim\Router;
 use Slim\Tests\Mocks\MockAction;
 use stdClass;

--- a/tests/RouteDispatcherTest.php
+++ b/tests/RouteDispatcherTest.php
@@ -15,7 +15,6 @@ use Slim\MiddlewareDispatcher;
 use Slim\RouteDispatcher;
 use Slim\Router;
 use Slim\RoutingResults;
-use Slim\Tests\TestCase;
 
 class RouteDispatcherTest extends TestCase
 {


### PR DESCRIPTION
Removing unused imports in:
- `Slim/App`
- `Slim/Routable`
- `Slim/Router`
- `tests/AppTest`
- `tests/RouteDispatcherTest`