### PR TITLE
Fix incorrect return type hints on NotFound handler

### DIFF
--- a/Slim/Handlers/NotFound.php
+++ b/Slim/Handlers/NotFound.php
@@ -67,7 +67,7 @@ class NotFound extends AbstractHandler
     /**
      * Render plain not found message
      *
-     * @return ResponseInterface
+     * @return string
      */
     protected function renderPlainNotFoundOutput()
     {
@@ -77,7 +77,7 @@ class NotFound extends AbstractHandler
     /**
      * Return a response for application/json content not found
      *
-     * @return ResponseInterface
+     * @return string
      */
     protected function renderJsonNotFoundOutput()
     {
@@ -87,7 +87,7 @@ class NotFound extends AbstractHandler
     /**
      * Return a response for xml content not found
      *
-     * @return ResponseInterface
+     * @return string
      */
     protected function renderXmlNotFoundOutput()
     {
@@ -99,7 +99,7 @@ class NotFound extends AbstractHandler
      *
      * @param  ServerRequestInterface $request  The most recent Request object
      *
-     * @return ResponseInterface
+     * @return string
      */
     protected function renderHtmlNotFoundOutput(ServerRequestInterface $request)
     {


### PR DESCRIPTION
Type hints were incorrect on the NotFound handler. Methods were returning strings when the type hint said ResponseInterface: the calling method is expecting strings.