### PR TITLE
Remove unused 'keys' method from `Collection`

### DIFF
--- a/Slim/Collection.php
+++ b/Slim/Collection.php
@@ -88,16 +88,6 @@ class Collection implements CollectionInterface
     }
 
     /**
-     * Get collection keys
-     *
-     * @return array The collection's source data keys
-     */
-    public function keys()
-    {
-        return array_keys($this->data);
-    }
-
-    /**
      * Does this collection have a given key?
      *
      * @param string $key The data key

--- a/tests/CollectionTest.php
+++ b/tests/CollectionTest.php
@@ -90,16 +90,6 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($data, $this->bag->all());
     }
 
-    public function testKeys()
-    {
-        $data = [
-            'abc' => '123',
-            'foo' => 'bar',
-        ];
-        $this->property->setValue($this->bag, $data);
-        $this->assertEquals(['abc', 'foo'], $this->bag->keys());
-    }
-
     public function testHas()
     {
         $this->property->setValue($this->bag, ['foo' => 'bar']);


### PR DESCRIPTION
As far as I can see `CollectionInterface` does not defines `keys` method, therefore, concrete implementation `Collection` does not need `keys` method either.
