### PR TITLE
Remove references to unused EnvironmentInterface

### DIFF
--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -21,7 +21,7 @@ use Slim\Exception\ContainerException as SlimContainerException;
  * with these service keys configured and ready for use:
  *
  *  - settings: an array or instance of \ArrayAccess
- *  - environment: an instance of \Slim\Interfaces\Http\EnvironmentInterface
+ *  - environment: an instance of \Slim\Http\Environment
  *  - request: an instance of \Psr\Http\Message\ServerRequestInterface
  *  - response: an instance of \Psr\Http\Message\ResponseInterface
  *  - router: an instance of \Slim\Interfaces\RouterInterface
@@ -32,7 +32,7 @@ use Slim\Exception\ContainerException as SlimContainerException;
  *  - callableResolver: an instance of \Slim\Interfaces\CallableResolverInterface
  *
  * @property-read array $settings
- * @property-read \Slim\Interfaces\Http\EnvironmentInterface $environment
+ * @property-read \Slim\Http\Environment $environment
  * @property-read \Psr\Http\Message\ServerRequestInterface $request
  * @property-read \Psr\Http\Message\ResponseInterface $response
  * @property-read \Slim\Interfaces\RouterInterface $router

--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -20,7 +20,6 @@ use Slim\Http\Headers;
 use Slim\Http\Request;
 use Slim\Http\Response;
 use Slim\Interfaces\CallableResolverInterface;
-use Slim\Interfaces\Http\EnvironmentInterface;
 use Slim\Interfaces\InvocationStrategyInterface;
 use Slim\Interfaces\RouterInterface;
 
@@ -39,9 +38,9 @@ class DefaultServicesProvider
         if (!isset($container['environment'])) {
             /**
              * This service MUST return a shared instance
-             * of \Slim\Interfaces\Http\EnvironmentInterface.
+             * of \Slim\Http\Environment.
              *
-             * @return EnvironmentInterface
+             * @return Environment
              */
             $container['environment'] = function () {
                 return new Environment($_SERVER);


### PR DESCRIPTION
One of the proposed solutions in this issue (https://github.com/slimphp/Slim/issues/2548) is to no longer reference the `EnvironmentInterface` in the docs, which I believe extends to type hints in the code.

I don't think removing `EnvironmentInterface` completely is possible without shipping a breaking change as people might have extended the `Environment` specifically implemented the `EnvironmentInterface` again in their extension.

Unless someone is willing to rework the `EnvironmentInterface` and the rest of the framework to accept any implementation of this interface, I think this fix might be serviceable to manage developer expectations.

If this solution is accepted I will create a similar pull request to the documentation to replace these references: https://github.com/slimphp/Slim-Documentation/search?q=EnvironmentInterface&unscoped_q=EnvironmentInterface
