### PR TITLE
Add type check for $headers

### DIFF
--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -76,12 +76,22 @@ class Headers extends Collection implements HeadersInterface
     public static function determineAuthorization(Environment $environment)
     {
         $authorization = $environment->get('HTTP_AUTHORIZATION');
+        if (!empty($authorization)) {
+            return $environment;
+        }
+        
+        if (!is_callable('getallheaders')) {
+            return $environment;
+        }
+        $headers = getallheaders();
+        
+        if (!is_array($headers)) {
+            return $environment;
+        }
 
-        if (empty($authorization) && is_callable('getallheaders') && $headers = getallheaders()) {
-            $headers = array_change_key_case($headers, CASE_LOWER);
-            if (isset($headers['authorization'])) {
-                $environment->set('HTTP_AUTHORIZATION', $headers['authorization']);
-            }
+        $headers = array_change_key_case($headers, CASE_LOWER);
+        if (isset($headers['authorization'])) {
+            $environment->set('HTTP_AUTHORIZATION', $headers['authorization']);
         }
 
         return $environment;

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -79,9 +79,11 @@ class Headers extends Collection implements HeadersInterface
 
         if (empty($authorization) && is_callable('getallheaders')) {
             $headers = getallheaders();
-            $headers = array_change_key_case($headers, CASE_LOWER);
-            if (isset($headers['authorization'])) {
-                $environment->set('HTTP_AUTHORIZATION', $headers['authorization']);
+            if (is_array($headers)) {
+                $headers = array_change_key_case($headers, CASE_LOWER);
+                if (isset($headers['authorization'])) {
+                    $environment->set('HTTP_AUTHORIZATION', $headers['authorization']);
+                }
             }
         }
 

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -77,11 +77,7 @@ class Headers extends Collection implements HeadersInterface
     {
         $authorization = $environment->get('HTTP_AUTHORIZATION');
 
-        if (
-            empty($authorization) 
-            && is_callable('getallheaders') 
-            && $headers = getallheaders()
-        ) {
+        if (empty($authorization) && is_callable('getallheaders') && $headers = getallheaders()) {
             $headers = array_change_key_case($headers, CASE_LOWER);
             if (isset($headers['authorization'])) {
                 $environment->set('HTTP_AUTHORIZATION', $headers['authorization']);

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -77,13 +77,14 @@ class Headers extends Collection implements HeadersInterface
     {
         $authorization = $environment->get('HTTP_AUTHORIZATION');
 
-        if (empty($authorization) && is_callable('getallheaders')) {
-            $headers = getallheaders();
-            if (is_array($headers)) {
-                $headers = array_change_key_case($headers, CASE_LOWER);
-                if (isset($headers['authorization'])) {
-                    $environment->set('HTTP_AUTHORIZATION', $headers['authorization']);
-                }
+        if (
+            empty($authorization) 
+            && is_callable('getallheaders') 
+            && $headers = getallheaders()
+        ) {
+            $headers = array_change_key_case($headers, CASE_LOWER);
+            if (isset($headers['authorization'])) {
+                $environment->set('HTTP_AUTHORIZATION', $headers['authorization']);
             }
         }
 

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -76,15 +76,11 @@ class Headers extends Collection implements HeadersInterface
     public static function determineAuthorization(Environment $environment)
     {
         $authorization = $environment->get('HTTP_AUTHORIZATION');
-        if (!empty($authorization)) {
+        if (!empty($authorization) || !is_callable('getallheaders')) {
             return $environment;
         }
         
-        if (!is_callable('getallheaders')) {
-            return $environment;
-        }
         $headers = getallheaders();
-        
         if (!is_array($headers)) {
             return $environment;
         }

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
     },
     "autoload-dev": {
         "files": [
-          "tests/Assets/PhpFunctionOverrides.php"
+          "tests/Assets/PhpFunctionOverrides.php",
+          "tests/Assets/PhpHttpFunctionOverrides.php"
         ]
     },
     "scripts": {

--- a/tests/Assets/PhpHttpFunctionOverrides.php
+++ b/tests/Assets/PhpHttpFunctionOverrides.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @link      https://github.com/slimphp/Slim
+ * @copyright Copyright (c) 2011-2017 Josh Lockhart
+ * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
+ */
+
+namespace Slim\Http;
+
+/**
+ * Return the value of the global variable $GLOBALS['getallheaders_return'] if it exists. Otherwise the
+ * function override calls the default php built-in function.
+ *
+ * @return array|false
+ */
+function getallheaders()
+{
+    if (array_key_exists('getallheaders_return', $GLOBALS)) {
+        return $GLOBALS['getallheaders_return'];
+    }
+    
+    return \getallheaders();
+}

--- a/tests/Http/HeadersTest.php
+++ b/tests/Http/HeadersTest.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2011-2017 Josh Lockhart
  * @license   https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
  */
+
 namespace Slim\Tests\Http;
 
 use ReflectionProperty;
@@ -223,5 +224,18 @@ class HeadersTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('electrolytes', $en->get('HTTP_AUTHORIZATION'));
         $this->assertEquals(['electrolytes'], $h->get('Authorization'));
+    }
+
+    public function testDetermineAuthorizationReturnsEarlyIfHeadersIsNotArray()
+    {
+        $e = Environment::mock([]);
+
+        $GLOBALS['getallheaders_return'] = false;
+        $en = Headers::determineAuthorization($e);
+        $h = Headers::createFromEnvironment($e);
+        unset($GLOBALS['getallheaders_return']);
+
+        $this->assertNull($en->get('HTTP_AUTHORIZATION'));
+        $this->assertNull($h->get('Authorization'));
     }
 }


### PR DESCRIPTION
As $headers may not be an array, we added an if statement to avoid any warnings. 
See #2632 