### PR TITLE
4.x - Route InvocationStrategy Setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 4.0.0 - TBD
 
 ### Added
+- [#2634](https://github.com/slimphp/Slim/pull/2634) Added ability to set invocation strategy on a per-route basis.
 - [#2555](https://github.com/slimphp/Slim/pull/2555) Added PSR-15 Middleware Support
 - [#2529](https://github.com/slimphp/Slim/pull/2529) Slim no longer ships with a PSR-7 implementation. You need to provide a PSR-7 ServerRequest and a PSR-17 ResponseFactory to run Slim.
 - [#2507](https://github.com/slimphp/Slim/pull/2507) Method names are now case-sensitive in Router::map(), and so, by extension, in App::map() 

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -23,6 +23,14 @@ interface RouteInterface
     public function getInvocationStrategy(): InvocationStrategyInterface;
 
     /**
+     * Set route invocation strategy
+     *
+     * @param InvocationStrategyInterface $invocationStrategy
+     * @return RouteInterface
+     */
+    public function setInvocationStrategy(InvocationStrategyInterface $invocationStrategy): RouteInterface;
+
+    /**
      * Get route methods
      *
      * @return string[]

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -168,6 +168,15 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    public function setInvocationStrategy(InvocationStrategyInterface $invocationStrategy): RouteInterface
+    {
+        $this->invocationStrategy = $invocationStrategy;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getMethods(): array
     {
         return $this->methods;

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -134,7 +134,7 @@ class RouteTest extends TestCase
         $route = new Route(['GET'], '/', $callable, $responseFactory, $callableResolver);
         $route->setInvocationStrategy($strategy);
 
-        $this->assertEquals($strategy, $route->getInvocationStrategy());
+        $this->assertSame($strategy, $route->getInvocationStrategy());
     }
 
     public function testGetGroups()

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -121,6 +121,22 @@ class RouteTest extends TestCase
         $this->assertEquals($strategy, $route->getInvocationStrategy());
     }
 
+    public function testSetInvocationStrategy()
+    {
+        $callable = function (ServerRequestInterface $request, ResponseInterface $response, $args) {
+            return $response;
+        };
+
+        $responseFactory = $this->getResponseFactory();
+        $callableResolver = new CallableResolver();
+        $strategy = new RequestResponse();
+
+        $route = new Route(['GET'], '/', $callable, $responseFactory, $callableResolver);
+        $route->setInvocationStrategy($strategy);
+
+        $this->assertEquals($strategy, $route->getInvocationStrategy());
+    }
+
     public function testGetGroups()
     {
         $callable = function (ServerRequestInterface $request, ResponseInterface $response, $args) {


### PR DESCRIPTION
This is pull 3 out of 7 to complete the goals set in #2604 

This PR adds the capability to set a `Route`'s invocation strategy per route.

Closes #2597

**Example usage:**
```php
use Slim\App;
use Slim\Handlers\Strategies\RequestResponse;

$app = new App(...);

$invocationStrategy = new RequestResponse();
$app
    ->get('/', function () {...})
    ->setInvocationStrategy(...);
```