### PR TITLE
4.x - Port RouteCollector::fullUrlFor()

### DIFF
--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Slim\Interfaces;
 
 use InvalidArgumentException;
+use Psr\Http\Message\UriInterface;
 use RuntimeException;
 
 interface RouteCollectorInterface
@@ -144,6 +145,8 @@ interface RouteCollectorInterface
     /**
      * Build the path for a named route including the base path
      *
+     * This method is deprecated. Use urlFor() from now on.
+     *
      * @param string $name        Route name
      * @param array  $data        Named argument replacement data
      * @param array  $queryParams Optional query string parameters
@@ -156,9 +159,7 @@ interface RouteCollectorInterface
     public function pathFor(string $name, array $data = [], array $queryParams = []): string;
 
     /**
-     * Build the path for a named route.
-     *
-     * This method is deprecated. Use pathFor() from now on.
+     * Build the path for a named route including the base path
      *
      * @param string $name        Route name
      * @param array  $data        Named argument replacement data
@@ -170,4 +171,16 @@ interface RouteCollectorInterface
      * @throws InvalidArgumentException If required data not provided
      */
     public function urlFor(string $name, array $data = [], array $queryParams = []): string;
+
+    /**
+     * Get fully qualified URL for named route
+     *
+     * @param UriInterface  $uri
+     * @param string        $routeName Route name
+     * @param array         $data Named argument replacement data
+     * @param array         $queryParams Optional query string parameters
+     *
+     * @return string
+     */
+    public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string;
 }

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -14,6 +14,7 @@ use FastRoute\RouteParser\Std as StdParser;
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\UriInterface;
 use RuntimeException;
 use Slim\Handlers\Strategies\RequestResponse;
 use Slim\Interfaces\CallableResolverInterface;
@@ -377,6 +378,15 @@ class RouteCollector implements RouteCollectorInterface
      */
     public function pathFor(string $name, array $data = [], array $queryParams = []): string
     {
+        trigger_error('pathFor() is deprecated. Use urlFor() instead.', E_USER_DEPRECATED);
+        return $this->urlFor($name, $data, $queryParams);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function urlFor(string $name, array $data = [], array $queryParams = []): string
+    {
         $url = $this->relativePathFor($name, $data, $queryParams);
 
         if ($this->basePath) {
@@ -389,9 +399,12 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * {@inheritdoc}
      */
-    public function urlFor(string $name, array $data = [], array $queryParams = []): string
+    public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string
     {
-        trigger_error('urlFor() is deprecated. Use pathFor() instead.', E_USER_DEPRECATED);
-        return $this->pathFor($name, $data, $queryParams);
+        $path = $this->urlFor($routeName, $data, $queryParams);
+        $scheme = $uri->getScheme();
+        $authority = $uri->getAuthority();
+        $protocol = ($scheme ? $scheme . ':' : '') . ($authority ? '//' . $authority : '');
+        return $protocol . $path;
     }
 }


### PR DESCRIPTION
This is pull 4 out of 7 to complete the goals set in #2604 

The functionality is ported from #2493 and adds the ability to create full urls relative to a `UriInterface`.

It also changes the deprecation of the method `urlFor()` to `pathFor()` since it was determined that `urlFor()` is a more used terminology.

**Example usage:**
```php
use Slim\App;
use Slim\Http\Factory\DecoratedResponseFactory;
use Slim\Http\ServerRequest;
use Slim\Middleware\ErrorMiddleware;
use Slim\Psr7\Factory\ResponseFactory;
use Slim\Psr7\Factory\ServerRequestFactory;
use Slim\Psr7\Factory\StreamFactory;

$responseFactory = new DecoratedResponseFactory(new ResponseFactory(), new StreamFactory());
$app = new App($responseFactory);
$routeCollector = $app->getRouteCollector();

/**
 * The base app url would be for example:
 * http://example.com
 *
 * If you wanted to generate a fully qualified URL from within a route
 * you would do something like the following
 */
$route = $app->get('/hello/{name}', function ($request, $response, $args) use ($routeCollector) {
    /** @var RouteInterface $route */
    $route = $request->getAttribute('route');
    $routeName = $route->getName();

    $uri = $request->getUri();

    /**
     * $fullyQualifiedUrl would be:
     * http://example.com/hello/world
     */
    $fullyQualifiedUrl = $routeCollector->fullUrlFor($uri, $routeName, ['name' => 'world']);

    return $response;
});
$route->setName('test');

$request = new ServerRequest(ServerRequestFactory::createFromGlobals());
$app->run($request);