### PR TITLE
4.x - Decouple FastRoute Dispatcher From RouteResolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
 
-## 4.0.0 - TBD
+## 4.0.0 - 2019-07-03
 
 ### Added
+- [#2639](https://github.com/slimphp/Slim/pull/2639) Add `DispatcherInterface` and decouple FastRoute dispatcher entirely from core. This enables us to swap out our router implementation for any other router.
+- [#2638](https://github.com/slimphp/Slim/pull/2638) Add `RouteCollector::fullUrlFor()` to give the ability to generate fully qualified URLs
 - [#2634](https://github.com/slimphp/Slim/pull/2634) Added ability to set invocation strategy on a per-route basis.
 - [#2555](https://github.com/slimphp/Slim/pull/2555) Added PSR-15 Middleware Support
 - [#2529](https://github.com/slimphp/Slim/pull/2529) Slim no longer ships with a PSR-7 implementation. You need to provide a PSR-7 ServerRequest and a PSR-17 ResponseFactory to run Slim.
@@ -21,6 +23,7 @@
 
 ### Deprecated
 
+- [#2638](https://github.com/slimphp/Slim/pull/2638) Deprecate `RouteCollector::pathFor()` which gets replaced by `RouteCollector::urlFor()` preserving the orignal functionality
 - [#2555](https://github.com/slimphp/Slim/pull/2555) Double-Pass Middleware Support has been deprecated
 
 ### Removed

--- a/Slim/Interfaces/DispatcherInterface.php
+++ b/Slim/Interfaces/DispatcherInterface.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Slim\Interfaces;
+
+use Slim\Routing\RoutingResults;
+
+interface DispatcherInterface
+{
+    /**
+     * Get allowed methods for a given request method and uri
+     *
+     * @param string $method
+     * @param string $uri
+     * @return array
+     */
+    public function getAllowedMethods(string $method, string $uri): array;
+
+    /**
+     * Get routing results for a given request method and uri
+     *
+     * @param string $method
+     * @param string $uri
+     * @return RoutingResults
+     */
+    public function dispatch(string $method, string $uri): RoutingResults;
+}

--- a/Slim/Interfaces/DispatcherInterface.php
+++ b/Slim/Interfaces/DispatcherInterface.php
@@ -8,13 +8,12 @@ use Slim\Routing\RoutingResults;
 interface DispatcherInterface
 {
     /**
-     * Get allowed methods for a given request method and uri
+     * Get allowed methods for a given uri
      *
-     * @param string $method
      * @param string $uri
      * @return array
      */
-    public function getAllowedMethods(string $method, string $uri): array;
+    public function getAllowedMethods(string $uri): array;
 
     /**
      * Get routing results for a given request method and uri

--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -96,7 +96,7 @@ interface RouteCollectorInterface
      *
      * @return RouteInterface
      *
-     * @throws RuntimeException
+     * @throws RuntimeException   If route of identifier does not exist
      */
     public function lookupRoute(string $identifier): RouteInterface;
 

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Slim\Middleware;
 
-use FastRoute\Dispatcher;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -18,6 +17,7 @@ use RuntimeException;
 use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
 use Slim\Interfaces\RouteResolverInterface;
+use Slim\Routing\RoutingResults;
 
 /**
  * Class RoutingMiddleware
@@ -74,7 +74,7 @@ class RoutingMiddleware implements MiddlewareInterface
         $routeStatus = $routingResults->getRouteStatus();
 
         switch ($routeStatus) {
-            case Dispatcher::FOUND:
+            case RoutingResults::FOUND:
                 $routeArguments = $routingResults->getRouteArguments();
                 $routeIdentifier = $routingResults->getRouteIdentifier() ?? '';
                 $route = $this->routeResolver
@@ -84,10 +84,10 @@ class RoutingMiddleware implements MiddlewareInterface
                     ->withAttribute('route', $route)
                     ->withAttribute('routingResults', $routingResults);
 
-            case Dispatcher::NOT_FOUND:
+            case RoutingResults::NOT_FOUND:
                 throw new HttpNotFoundException($request);
 
-            case Dispatcher::METHOD_NOT_ALLOWED:
+            case RoutingResults::METHOD_NOT_ALLOWED:
                 $exception = new HttpMethodNotAllowedException($request);
                 $exception->setAllowedMethods($routingResults->getAllowedMethods());
                 throw $exception;

--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -27,7 +27,7 @@ class Dispatcher implements DispatcherInterface
     private $routeParser;
 
     /**
-     * @var FastRouteDispatcher
+     * @var FastRouteDispatcher|null
      */
     private $dispatcher;
 

--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -1,132 +1,96 @@
 <?php
-/**
- * Slim Framework (https://slimframework.com)
- *
- * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
- */
-
 declare(strict_types=1);
 
 namespace Slim\Routing;
 
-use FastRoute\Dispatcher\GroupCountBased;
+use FastRoute\RouteCollector;
+use FastRoute\RouteParser;
+use FastRoute\RouteParser\Std;
+use Slim\Interfaces\DispatcherInterface;
+use Slim\Interfaces\RouteCollectorInterface;
 
-class Dispatcher extends GroupCountBased
+/**
+ * Class Dispatcher
+ *
+ * @package Slim\Routing
+ */
+class Dispatcher implements DispatcherInterface
 {
     /**
-     * @var string
+     * @var RouteCollectorInterface
      */
-    private $httpMethod;
+    private $routeCollector;
 
     /**
-     * @var string
+     * @var RouteParser
      */
-    private $uri;
+    private $routeParser;
 
     /**
-     * @var array
+     * @var FastRouteDispatcher
      */
-    private $allowedMethods = [];
+    private $dispatcher;
 
     /**
-     * @param string $httpMethod
-     * @param string $uri
-     * @return RoutingResults
+     * Dispatcher constructor.
+     *
+     * @param RouteCollectorInterface   $routeCollector
+     * @param RouteParser|null          $routeParser
      */
-    public function dispatch($httpMethod, $uri): RoutingResults
+    public function __construct(RouteCollectorInterface $routeCollector, RouteParser $routeParser = null)
     {
-        $this->httpMethod = $httpMethod;
-        $this->uri = $uri;
-
-        if (isset($this->staticRouteMap[$httpMethod][$uri])) {
-            return $this->routingResults(self::FOUND, $this->staticRouteMap[$httpMethod][$uri]);
-        }
-
-        $varRouteData = $this->variableRouteData;
-        if (isset($varRouteData[$httpMethod])) {
-            $result = $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
-            $routingResults = $this->routingResultsFromVariableRouteResults($result);
-            if ($routingResults->getRouteStatus() === self::FOUND) {
-                return $routingResults;
-            }
-        }
-
-        // For HEAD requests, attempt fallback to GET
-        if ($httpMethod === 'HEAD') {
-            if (isset($this->staticRouteMap['GET'][$uri])) {
-                return $this->routingResults(self::FOUND, $this->staticRouteMap['GET'][$uri]);
-            }
-            if (isset($varRouteData['GET'])) {
-                $result = $this->dispatchVariableRoute($varRouteData['GET'], $uri);
-                return $this->routingResultsFromVariableRouteResults($result);
-            }
-        }
-
-        // If nothing else matches, try fallback routes
-        if (isset($this->staticRouteMap['*'][$uri])) {
-            return $this->routingResults(self::FOUND, $this->staticRouteMap['*'][$uri]);
-        }
-        if (isset($varRouteData['*'])) {
-            $result = $this->dispatchVariableRoute($varRouteData['*'], $uri);
-            return $this->routingResultsFromVariableRouteResults($result);
-        }
-
-        if (count($this->getAllowedMethods($httpMethod, $uri))) {
-            return $this->routingResults(self::METHOD_NOT_ALLOWED);
-        }
-
-        return $this->routingResults(self::NOT_FOUND);
+        $this->routeCollector = $routeCollector;
+        $this->routeParser = $routeParser ?? new Std();
     }
 
     /**
-     * @param int $status
-     * @param string|null $handler
-     * @param array $arguments
-     * @return RoutingResults
+     * @return FastRouteDispatcher
      */
-    protected function routingResults(int $status, string $handler = null, array $arguments = []): RoutingResults
+    protected function createDispatcher(): FastRouteDispatcher
     {
-        return new RoutingResults($this, $this->httpMethod, $this->uri, $status, $handler, $arguments);
+        if ($this->dispatcher) {
+            return $this->dispatcher;
+        }
+
+        $routeDefinitionCallback = function (RouteCollector $r) {
+            foreach ($this->routeCollector->getRoutes() as $route) {
+                $r->addRoute($route->getMethods(), $route->getPattern(), $route->getIdentifier());
+            }
+        };
+
+        if ($cacheFile = $this->routeCollector->getCacheFile()) {
+            /** @var FastRouteDispatcher $dispatcher */
+            $dispatcher = \FastRoute\cachedDispatcher($routeDefinitionCallback, [
+                'dispatcher' => FastRouteDispatcher::class,
+                'routeParser' => $this->routeParser,
+                'cacheFile' => $cacheFile,
+            ]);
+        } else {
+            /** @var FastRouteDispatcher $dispatcher */
+            $dispatcher = \FastRoute\simpleDispatcher($routeDefinitionCallback, [
+                'dispatcher' => FastRouteDispatcher::class,
+                'routeParser' => $this->routeParser,
+            ]);
+        }
+
+        $this->dispatcher = $dispatcher;
+        return $this->dispatcher;
     }
 
     /**
-     * @param array $result
-     * @return RoutingResults
+     * {@inheritdoc}
      */
-    protected function routingResultsFromVariableRouteResults(array $result): RoutingResults
+    public function getAllowedMethods(string $method, string $uri): array
     {
-        if ($result[0] === self::FOUND) {
-            return $this->routingResults(self::FOUND, $result[1], $result[2]);
-        }
-        return $this->routingResults(self::NOT_FOUND);
+        return $this->dispatcher->getAllowedMethods($method, $uri);
     }
 
     /**
-     * @param string $httpMethod
-     * @param string $uri
-     * @return array
+     * {@inheritdoc}
      */
-    public function getAllowedMethods(string $httpMethod, string $uri): array
+    public function dispatch(string $method, string $uri): RoutingResults
     {
-        if (isset($this->allowedMethods[$uri])) {
-            return $this->allowedMethods[$uri];
-        }
-
-        $this->allowedMethods[$uri] = [];
-        foreach ($this->staticRouteMap as $method => $uriMap) {
-            if ($method !== $httpMethod && isset($uriMap[$uri])) {
-                $this->allowedMethods[$uri][] = $method;
-            }
-        }
-
-        $varRouteData = $this->variableRouteData;
-        foreach ($varRouteData as $method => $routeData) {
-            $result = $this->dispatchVariableRoute($routeData, $uri);
-            if ($result[0] === self::FOUND) {
-                $this->allowedMethods[$uri][] = $method;
-            }
-        }
-
-        return $this->allowedMethods[$uri];
+        $dispatcher = $this->createDispatcher();
+        return $dispatcher->dispatch($method, $uri);
     }
 }

--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -58,7 +58,8 @@ class Dispatcher implements DispatcherInterface
             }
         };
 
-        if ($cacheFile = $this->routeCollector->getCacheFile()) {
+        $cacheFile = $this->routeCollector->getCacheFile();
+        if ($cacheFile) {
             /** @var FastRouteDispatcher $dispatcher */
             $dispatcher = \FastRoute\cachedDispatcher($routeDefinitionCallback, [
                 'dispatcher' => FastRouteDispatcher::class,
@@ -80,9 +81,10 @@ class Dispatcher implements DispatcherInterface
     /**
      * {@inheritdoc}
      */
-    public function getAllowedMethods(string $method, string $uri): array
+    public function getAllowedMethods(string $uri): array
     {
-        return $this->dispatcher->getAllowedMethods($method, $uri);
+        $dispatcher = $this->createDispatcher();
+        return $dispatcher->getAllowedMethods($uri);
     }
 
     /**
@@ -91,6 +93,7 @@ class Dispatcher implements DispatcherInterface
     public function dispatch(string $method, string $uri): RoutingResults
     {
         $dispatcher = $this->createDispatcher();
-        return $dispatcher->dispatch($method, $uri);
+        $results = $dispatcher->dispatch($method, $uri);
+        return new RoutingResults($this, $method, $uri, $results[0], $results[1], $results[2]);
     }
 }

--- a/Slim/Routing/FastRouteDispatcher.php
+++ b/Slim/Routing/FastRouteDispatcher.php
@@ -14,16 +14,6 @@ use FastRoute\Dispatcher\GroupCountBased;
 class FastRouteDispatcher extends GroupCountBased
 {
     /**
-     * @var string
-     */
-    private $httpMethod;
-
-    /**
-     * @var string
-     */
-    private $uri;
-
-    /**
      * @var array
      */
     private $allowedMethods = [];
@@ -31,22 +21,19 @@ class FastRouteDispatcher extends GroupCountBased
     /**
      * @param string $httpMethod
      * @param string $uri
-     * @return RoutingResults
+     * @return array
      */
-    public function dispatch($httpMethod, $uri): RoutingResults
+    public function dispatch($httpMethod, $uri): array
     {
-        $this->httpMethod = $httpMethod;
-        $this->uri = $uri;
-
         if (isset($this->staticRouteMap[$httpMethod][$uri])) {
-            return $this->routingResults(self::FOUND, $this->staticRouteMap[$httpMethod][$uri]);
+            return [self::FOUND, $this->staticRouteMap[$httpMethod][$uri], []];
         }
 
         $varRouteData = $this->variableRouteData;
         if (isset($varRouteData[$httpMethod])) {
             $result = $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
             $routingResults = $this->routingResultsFromVariableRouteResults($result);
-            if ($routingResults->getRouteStatus() === self::FOUND) {
+            if ($routingResults[0] === self::FOUND) {
                 return $routingResults;
             }
         }
@@ -54,7 +41,7 @@ class FastRouteDispatcher extends GroupCountBased
         // For HEAD requests, attempt fallback to GET
         if ($httpMethod === 'HEAD') {
             if (isset($this->staticRouteMap['GET'][$uri])) {
-                return $this->routingResults(self::FOUND, $this->staticRouteMap['GET'][$uri]);
+                return [self::FOUND, $this->staticRouteMap['GET'][$uri], []];
             }
             if (isset($varRouteData['GET'])) {
                 $result = $this->dispatchVariableRoute($varRouteData['GET'], $uri);
@@ -64,49 +51,37 @@ class FastRouteDispatcher extends GroupCountBased
 
         // If nothing else matches, try fallback routes
         if (isset($this->staticRouteMap['*'][$uri])) {
-            return $this->routingResults(self::FOUND, $this->staticRouteMap['*'][$uri]);
+            return [self::FOUND, $this->staticRouteMap['*'][$uri], []];
         }
         if (isset($varRouteData['*'])) {
             $result = $this->dispatchVariableRoute($varRouteData['*'], $uri);
             return $this->routingResultsFromVariableRouteResults($result);
         }
 
-        if (count($this->getAllowedMethods($httpMethod, $uri))) {
-            return $this->routingResults(self::METHOD_NOT_ALLOWED);
+        if (count($this->getAllowedMethods($uri))) {
+            return [self::METHOD_NOT_ALLOWED, null, []];
         }
 
-        return $this->routingResults(self::NOT_FOUND);
-    }
-
-    /**
-     * @param int $status
-     * @param string|null $handler
-     * @param array $arguments
-     * @return RoutingResults
-     */
-    protected function routingResults(int $status, string $handler = null, array $arguments = []): RoutingResults
-    {
-        return new RoutingResults($this, $this->httpMethod, $this->uri, $status, $handler, $arguments);
+        return [self::NOT_FOUND, null, []];
     }
 
     /**
      * @param array $result
-     * @return RoutingResults
+     * @return array
      */
-    protected function routingResultsFromVariableRouteResults(array $result): RoutingResults
+    protected function routingResultsFromVariableRouteResults(array $result): array
     {
         if ($result[0] === self::FOUND) {
-            return $this->routingResults(self::FOUND, $result[1], $result[2]);
+            return [self::FOUND, $result[1], $result[2]];
         }
-        return $this->routingResults(self::NOT_FOUND);
+        return [self::NOT_FOUND, null, []];
     }
 
     /**
-     * @param string $httpMethod
      * @param string $uri
      * @return array
      */
-    public function getAllowedMethods(string $httpMethod, string $uri): array
+    public function getAllowedMethods(string $uri): array
     {
         if (isset($this->allowedMethods[$uri])) {
             return $this->allowedMethods[$uri];
@@ -114,7 +89,7 @@ class FastRouteDispatcher extends GroupCountBased
 
         $this->allowedMethods[$uri] = [];
         foreach ($this->staticRouteMap as $method => $uriMap) {
-            if ($method !== $httpMethod && isset($uriMap[$uri])) {
+            if (isset($uriMap[$uri])) {
                 $this->allowedMethods[$uri][] = $method;
             }
         }

--- a/Slim/Routing/FastRouteDispatcher.php
+++ b/Slim/Routing/FastRouteDispatcher.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Routing;
+
+use FastRoute\Dispatcher\GroupCountBased;
+
+class FastRouteDispatcher extends GroupCountBased
+{
+    /**
+     * @var string
+     */
+    private $httpMethod;
+
+    /**
+     * @var string
+     */
+    private $uri;
+
+    /**
+     * @var array
+     */
+    private $allowedMethods = [];
+
+    /**
+     * @param string $httpMethod
+     * @param string $uri
+     * @return RoutingResults
+     */
+    public function dispatch($httpMethod, $uri): RoutingResults
+    {
+        $this->httpMethod = $httpMethod;
+        $this->uri = $uri;
+
+        if (isset($this->staticRouteMap[$httpMethod][$uri])) {
+            return $this->routingResults(self::FOUND, $this->staticRouteMap[$httpMethod][$uri]);
+        }
+
+        $varRouteData = $this->variableRouteData;
+        if (isset($varRouteData[$httpMethod])) {
+            $result = $this->dispatchVariableRoute($varRouteData[$httpMethod], $uri);
+            $routingResults = $this->routingResultsFromVariableRouteResults($result);
+            if ($routingResults->getRouteStatus() === self::FOUND) {
+                return $routingResults;
+            }
+        }
+
+        // For HEAD requests, attempt fallback to GET
+        if ($httpMethod === 'HEAD') {
+            if (isset($this->staticRouteMap['GET'][$uri])) {
+                return $this->routingResults(self::FOUND, $this->staticRouteMap['GET'][$uri]);
+            }
+            if (isset($varRouteData['GET'])) {
+                $result = $this->dispatchVariableRoute($varRouteData['GET'], $uri);
+                return $this->routingResultsFromVariableRouteResults($result);
+            }
+        }
+
+        // If nothing else matches, try fallback routes
+        if (isset($this->staticRouteMap['*'][$uri])) {
+            return $this->routingResults(self::FOUND, $this->staticRouteMap['*'][$uri]);
+        }
+        if (isset($varRouteData['*'])) {
+            $result = $this->dispatchVariableRoute($varRouteData['*'], $uri);
+            return $this->routingResultsFromVariableRouteResults($result);
+        }
+
+        if (count($this->getAllowedMethods($httpMethod, $uri))) {
+            return $this->routingResults(self::METHOD_NOT_ALLOWED);
+        }
+
+        return $this->routingResults(self::NOT_FOUND);
+    }
+
+    /**
+     * @param int $status
+     * @param string|null $handler
+     * @param array $arguments
+     * @return RoutingResults
+     */
+    protected function routingResults(int $status, string $handler = null, array $arguments = []): RoutingResults
+    {
+        return new RoutingResults($this, $this->httpMethod, $this->uri, $status, $handler, $arguments);
+    }
+
+    /**
+     * @param array $result
+     * @return RoutingResults
+     */
+    protected function routingResultsFromVariableRouteResults(array $result): RoutingResults
+    {
+        if ($result[0] === self::FOUND) {
+            return $this->routingResults(self::FOUND, $result[1], $result[2]);
+        }
+        return $this->routingResults(self::NOT_FOUND);
+    }
+
+    /**
+     * @param string $httpMethod
+     * @param string $uri
+     * @return array
+     */
+    public function getAllowedMethods(string $httpMethod, string $uri): array
+    {
+        if (isset($this->allowedMethods[$uri])) {
+            return $this->allowedMethods[$uri];
+        }
+
+        $this->allowedMethods[$uri] = [];
+        foreach ($this->staticRouteMap as $method => $uriMap) {
+            if ($method !== $httpMethod && isset($uriMap[$uri])) {
+                $this->allowedMethods[$uri][] = $method;
+            }
+        }
+
+        $varRouteData = $this->variableRouteData;
+        foreach ($varRouteData as $method => $routeData) {
+            $result = $this->dispatchVariableRoute($routeData, $uri);
+            if ($result[0] === self::FOUND) {
+                $this->allowedMethods[$uri][] = $method;
+            }
+        }
+
+        return $this->allowedMethods[$uri];
+    }
+}

--- a/Slim/Routing/RouteResolver.php
+++ b/Slim/Routing/RouteResolver.php
@@ -9,9 +9,7 @@ declare(strict_types=1);
 
 namespace Slim\Routing;
 
-use FastRoute\RouteCollector;
-use FastRoute\RouteParser;
-use FastRoute\RouteParser\Std as StdParser;
+use Slim\Interfaces\DispatcherInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouteResolverInterface;
@@ -28,26 +26,20 @@ class RouteResolver implements RouteResolverInterface
     protected $routeCollector;
 
     /**
-     * Parser
-     *
-     * @var RouteParser
-     */
-    protected $routeParser;
-
-    /**
-     * @var Dispatcher|null
+     * @var DispatcherInterface
      */
     private $dispatcher;
 
     /**
      * RouteResolver constructor.
-     * @param RouteCollectorInterface $routeCollector
-     * @param RouteParser $routeParser
+     *
+     * @param RouteCollectorInterface   $routeCollector
+     * @param DispatcherInterface|null  $dispatcher
      */
-    public function __construct(RouteCollectorInterface $routeCollector, RouteParser $routeParser = null)
+    public function __construct(RouteCollectorInterface $routeCollector, ?DispatcherInterface $dispatcher = null)
     {
         $this->routeCollector = $routeCollector;
-        $this->routeParser = $routeParser ?? new StdParser();
+        $this->dispatcher = $dispatcher ?? new Dispatcher($routeCollector);
     }
 
     /**
@@ -58,7 +50,7 @@ class RouteResolver implements RouteResolverInterface
     public function computeRoutingResults(string $uri, string $method): RoutingResults
     {
         $uri = '/' . ltrim(rawurldecode($uri), '/');
-        return $this->createDispatcher()->dispatch($method, $uri);
+        return $this->dispatcher->dispatch($method, $uri);
     }
 
     /**
@@ -68,47 +60,5 @@ class RouteResolver implements RouteResolverInterface
     public function resolveRoute(string $identifier): RouteInterface
     {
         return $this->routeCollector->lookupRoute($identifier);
-    }
-
-    /**
-     * @return Dispatcher
-     */
-    protected function createDispatcher(): Dispatcher
-    {
-        if ($this->dispatcher) {
-            return $this->dispatcher;
-        }
-
-        $routeDefinitionCallback = function (RouteCollector $r) {
-            foreach ($this->routeCollector->getRoutes() as $route) {
-                $r->addRoute($route->getMethods(), $route->getPattern(), $route->getIdentifier());
-            }
-        };
-
-        if ($cacheFile = $this->routeCollector->getCacheFile()) {
-            /** @var Dispatcher $dispatcher */
-            $dispatcher = \FastRoute\cachedDispatcher($routeDefinitionCallback, [
-                'dispatcher' => Dispatcher::class,
-                'routeParser' => $this->routeParser,
-                'cacheFile' => $cacheFile,
-            ]);
-        } else {
-            /** @var Dispatcher $dispatcher */
-            $dispatcher = \FastRoute\simpleDispatcher($routeDefinitionCallback, [
-                'dispatcher' => Dispatcher::class,
-                'routeParser' => $this->routeParser,
-            ]);
-        }
-
-        $this->dispatcher = $dispatcher;
-        return $this->dispatcher;
-    }
-
-    /**
-     * @param Dispatcher $dispatcher
-     */
-    public function setDispatcher(Dispatcher $dispatcher): void
-    {
-        $this->dispatcher = $dispatcher;
     }
 }

--- a/Slim/Routing/RouteResolver.php
+++ b/Slim/Routing/RouteResolver.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Slim\Routing;
 
+use RuntimeException;
 use Slim\Interfaces\DispatcherInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteInterface;
@@ -56,6 +57,7 @@ class RouteResolver implements RouteResolverInterface
     /**
      * @param string $identifier
      * @return RouteInterface
+     * @throws RuntimeException
      */
     public function resolveRoute(string $identifier): RouteInterface
     {

--- a/Slim/Routing/RoutingResults.php
+++ b/Slim/Routing/RoutingResults.php
@@ -9,10 +9,16 @@ declare(strict_types=1);
 
 namespace Slim\Routing;
 
+use Slim\Interfaces\DispatcherInterface;
+
 class RoutingResults
 {
+    public const NOT_FOUND = 0;
+    public const FOUND = 1;
+    public const METHOD_NOT_ALLOWED = 2;
+
     /**
-     * @var Dispatcher
+     * @var DispatcherInterface
      */
     protected $dispatcher;
 
@@ -28,12 +34,10 @@ class RoutingResults
 
     /**
      * @var int
-     * The following statuses are constants from Slim\Dispatcher
-     * Slim\Dispatcher extends FastRoute\Dispatcher\GroupCountBased
-     * Which implements the interface FastRoute\Dispatcher where the original constants are located
-     * Slim\Dispatcher::NOT_FOUND = 0
-     * Slim\Dispatcher::FOUND = 1
-     * Slim\Dispatcher::NOT_ALLOWED = 2
+     * The status is one of the constants shown above
+     * NOT_FOUND = 0
+     * FOUND = 1
+     * METHOD_NOT_ALLOWED = 2
      */
     protected $routeStatus;
 
@@ -49,15 +53,16 @@ class RoutingResults
 
     /**
      * RoutingResults constructor.
-     * @param Dispatcher $dispatcher
-     * @param string $httpMethod
-     * @param string $uri
-     * @param int $routeStatus
-     * @param string|null $routeIdentifier
-     * @param array $routeArguments
+     *
+     * @param DispatcherInterface   $dispatcher
+     * @param string                $httpMethod
+     * @param string                $uri
+     * @param int                   $routeStatus
+     * @param string|null           $routeIdentifier
+     * @param array                 $routeArguments
      */
     public function __construct(
-        Dispatcher $dispatcher,
+        DispatcherInterface $dispatcher,
         string $httpMethod,
         string $uri,
         int $routeStatus,
@@ -73,9 +78,9 @@ class RoutingResults
     }
 
     /**
-     * @return Dispatcher
+     * @return DispatcherInterface
      */
-    public function getDispatcher(): Dispatcher
+    public function getDispatcher(): DispatcherInterface
     {
         return $this->dispatcher;
     }

--- a/Slim/Routing/RoutingResults.php
+++ b/Slim/Routing/RoutingResults.php
@@ -25,7 +25,7 @@ class RoutingResults
     /**
      * @var string
      */
-    protected $httpMethod;
+    protected $method;
 
     /**
      * @var string
@@ -55,7 +55,7 @@ class RoutingResults
      * RoutingResults constructor.
      *
      * @param DispatcherInterface   $dispatcher
-     * @param string                $httpMethod
+     * @param string                $method
      * @param string                $uri
      * @param int                   $routeStatus
      * @param string|null           $routeIdentifier
@@ -63,14 +63,14 @@ class RoutingResults
      */
     public function __construct(
         DispatcherInterface $dispatcher,
-        string $httpMethod,
+        string $method,
         string $uri,
         int $routeStatus,
         string $routeIdentifier = null,
         array $routeArguments = []
     ) {
         $this->dispatcher = $dispatcher;
-        $this->httpMethod = $httpMethod;
+        $this->method = $method;
         $this->uri = $uri;
         $this->routeStatus = $routeStatus;
         $this->routeIdentifier = $routeIdentifier;
@@ -88,9 +88,9 @@ class RoutingResults
     /**
      * @return string
      */
-    public function getHttpMethod(): string
+    public function getMethod(): string
     {
-        return $this->httpMethod;
+        return $this->method;
     }
 
     /**
@@ -140,6 +140,6 @@ class RoutingResults
      */
     public function getAllowedMethods(): array
     {
-        return $this->dispatcher->getAllowedMethods($this->httpMethod, $this->uri);
+        return $this->dispatcher->getAllowedMethods($this->uri);
     }
 }

--- a/tests/Routing/DispatcherTest.php
+++ b/tests/Routing/DispatcherTest.php
@@ -125,10 +125,11 @@ class DispatcherTest extends TestCase
         $results = $dispatcher->dispatch('GET', '/hello/Foo%20Bar');
 
         $this->assertEquals(RoutingResults::FOUND, $results->getRouteStatus());
+        $this->assertEquals('GET', $results->getMethod());
+        $this->assertEquals('/hello/Foo%20Bar', $results->getUri());
         $this->assertEquals($route->getIdentifier(), $results->getRouteIdentifier());
         $this->assertEquals(['name' => 'Foo Bar'], $results->getRouteArguments());
         $this->assertEquals(['name' => 'Foo%20Bar'], $results->getRouteArguments(false));
-        $this->assertEquals('GET', $results->getMethod());
         $this->assertEquals($methods, $results->getAllowedMethods());
         $this->assertSame($dispatcher, $results->getDispatcher());
     }

--- a/tests/Routing/DispatcherTest.php
+++ b/tests/Routing/DispatcherTest.php
@@ -9,634 +9,127 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Routing;
 
-use FastRoute\DataGenerator\GroupCountBased;
-use FastRoute\RouteCollector;
+use Psr\Http\Message\ResponseFactoryInterface;
+use ReflectionMethod;
+use Slim\Interfaces\CallableResolverInterface;
 use Slim\Routing\Dispatcher;
+use Slim\Routing\FastRouteDispatcher;
+use Slim\Routing\RouteCollector;
 use Slim\Routing\RoutingResults;
 use Slim\Tests\TestCase;
 
-/**
- * Class DispatcherTest
- * @package Slim\Tests
- */
 class DispatcherTest extends TestCase
 {
-    protected function getDispatcherClass()
+    public function testCreateDispatcher()
     {
-        return Dispatcher::class;
-    }
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $dispatcher = new Dispatcher($routeCollector);
 
-    protected function getDataGeneratorClass()
-    {
-        return GroupCountBased::class;
-    }
+        $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
+        $method->setAccessible(true);
 
-    /**
-     * Set appropriate options for the specific Dispatcher class we're testing
-     */
-    private function generateDispatcherOptions()
-    {
-        return [
-            'dataGenerator' => $this->getDataGeneratorClass(),
-            'dispatcher' => $this->getDispatcherClass()
-        ];
-    }
-
-    public function testGetDispatcher()
-    {
-        $dispatcher = \FastRoute\simpleDispatcher(function (RouteCollector $r) {
-            $r->addRoute('GET', '/foo', 'handler0'); // oops, forgot \d+ restriction ;)
-        }, $this->generateDispatcherOptions());
-
-        /**
-         * @var RoutingResults $results
-         */
-        $results = $dispatcher->dispatch('GET', '/foo');
-
-        $this->assertInstanceOf(Dispatcher::class, $results->getDispatcher());
+        $this->assertInstanceOf(FastRouteDispatcher::class, $method->invoke($dispatcher));
     }
 
     /**
-     * @dataProvider provideFoundDispatchCases
+     * Test cached routes file is created & that it holds our routes.
      */
-    public function testFoundDispatches($method, $uri, $callback, $handler, $argDict)
+    public function testRouteCacheFileCanBeDispatched()
     {
-        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $dispatcher = new Dispatcher($routeCollector);
 
-        /**
-         * @var RoutingResults $results
-         */
-        $results = $dispatcher->dispatch($method, $uri);
+        $route = $routeCollector->map(['GET'], '/', function () {
+        });
+        $route->setName('foo');
 
-        $this->assertSame($dispatcher::FOUND, $results->getRouteStatus());
-        $this->assertSame($handler, $results->getRouteIdentifier());
-        $this->assertSame($argDict, $results->getRouteArguments());
-        $this->assertSame($method, $results->getHttpMethod());
-        $this->assertSame($uri, $results->getUri());
+        $cacheFile = dirname(__FILE__) . '/' . uniqid((string) microtime(true));
+        $routeCollector->setCacheFile($cacheFile);
+
+        $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
+        $method->setAccessible(true);
+        $method->invoke($dispatcher);
+        $this->assertFileExists($cacheFile, 'cache file was not created');
+
+        $routeCollector2 = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $routeCollector2->setCacheFile($cacheFile);
+        $dispatcher2 = new Dispatcher($routeCollector2);
+
+        $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
+        $method->setAccessible(true);
+        $method->invoke($dispatcher2);
+
+        /** @var RoutingResults $result */
+        $result = $dispatcher2->dispatch('GET', '/');
+        $this->assertEquals(FastRouteDispatcher::FOUND, $result->getRouteStatus());
+
+        unlink($cacheFile);
     }
 
     /**
-     * @dataProvider provideNotFoundDispatchCases
+     * Calling createDispatcher as second time should give you back the same
+     * dispatcher as when you called it the first time.
      */
-    public function testNotFoundDispatches($method, $uri, $callback)
+    public function testCreateDispatcherReturnsSameDispatcherASecondTime()
     {
-        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $dispatcher = new Dispatcher($routeCollector);
 
-        /**
-         * @var RoutingResults $results
-         */
-        $results = $dispatcher->dispatch($method, $uri);
+        $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
+        $method->setAccessible(true);
 
-        $this->assertSame($dispatcher::NOT_FOUND, $results->getRouteStatus());
+        $fastRouteDispatcher = $method->invoke($dispatcher);
+        $fastRouteDispatcher2 = $method->invoke($dispatcher);
+
+        $this->assertSame($fastRouteDispatcher, $fastRouteDispatcher2);
     }
 
-    /**
-     * @dataProvider provideMethodNotAllowedDispatchCases
-     */
-    public function testMethodNotAllowedDispatches($method, $uri, $callback, $availableMethods)
+    public function testGetAllowedMethods()
     {
-        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+        $methods = ['GET', 'POST', 'PUT'];
+        $uri = '/';
 
-        /**
-         * @var RoutingResults $results
-         */
-        $results = $dispatcher->dispatch($method, $uri);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
 
-        $this->assertSame($dispatcher::METHOD_NOT_ALLOWED, $results->getRouteStatus());
-        $this->assertSame($availableMethods, $results->getAllowedMethods());
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $routeCollector->map($methods, $uri, function () {
+        });
+
+        $dispatcher = new Dispatcher($routeCollector);
+        $results = $dispatcher->getAllowedMethods('/');
+
+        $this->assertEquals($methods, $results);
     }
 
-    public function testRouteArgumentsAreUrlDecoded()
+    public function testDispatch()
     {
-        $dispatcher = \FastRoute\simpleDispatcher(function (RouteCollector $r) {
-            $r->addRoute('GET', '/{name}', 'handler0');
-        }, $this->generateDispatcherOptions());
+        $methods = ['GET', 'POST'];
+        $uri = '/hello/{name}';
 
-        /**
-         * @var RoutingResults $results
-         */
-        $results = $dispatcher->dispatch('GET', '/Foo%20Bar');
-        $this->assertEquals($results->getRouteArguments()['name'], 'Foo Bar');
-        $this->assertEquals($results->getRouteArguments(false)['name'], 'Foo%20Bar');
-    }
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
 
-    /**
-     * @expectedException \FastRoute\BadRouteException
-     * @expectedExceptionMessage Cannot use the same placeholder "test" twice
-     */
-    public function testDuplicateVariableNameError()
-    {
-        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
-            $r->addRoute('GET', '/foo/{test}/{test:\d+}', 'handler0');
-        }, $this->generateDispatcherOptions());
-    }
-
-    /**
-     * @expectedException \FastRoute\BadRouteException
-     * @expectedExceptionMessage Cannot register two routes matching "/user/([^/]+)" for method "GET"
-     */
-    public function testDuplicateVariableRoute()
-    {
-        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
-            $r->addRoute('GET', '/user/{id}', 'handler0'); // oops, forgot \d+ restriction ;)
-            $r->addRoute('GET', '/user/{name}', 'handler1');
-        }, $this->generateDispatcherOptions());
-    }
-
-    /**
-     * @expectedException \FastRoute\BadRouteException
-     * @expectedExceptionMessage Cannot register two routes matching "/user" for method "GET"
-     */
-    public function testDuplicateStaticRoute()
-    {
-        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
-            $r->addRoute('GET', '/user', 'handler0');
-            $r->addRoute('GET', '/user', 'handler1');
-        }, $this->generateDispatcherOptions());
-    }
-
-    /**
-     * @codingStandardsIgnoreStart
-     * @expectedException \FastRoute\BadRouteException
-     * @expectedExceptionMessage Static route "/user/nikic" is shadowed by previously defined variable route "/user/([^/]+)" for method "GET"
-     * @codingStandardsIgnoreEnd
-     */
-    public function testShadowedStaticRoute()
-    {
-        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
-            $r->addRoute('GET', '/user/{name}', 'handler0');
-            $r->addRoute('GET', '/user/nikic', 'handler1');
-        }, $this->generateDispatcherOptions());
-    }
-
-    /**
-     * @expectedException \FastRoute\BadRouteException
-     * @expectedExceptionMessage Regex "(en|de)" for parameter "lang" contains a capturing group
-     */
-    public function testCapturing()
-    {
-        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
-            $r->addRoute('GET', '/{lang:(en|de)}', 'handler0');
-        }, $this->generateDispatcherOptions());
-    }
-
-    public function provideFoundDispatchCases()
-    {
-        $cases = [];
-
-        // 0 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/resource/123/456', 'handler0');
+        $callable = function () {
         };
-
-        $method = 'GET';
-        $uri = '/resource/123/456';
-        $handler = 'handler0';
-        $argDict = [];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 1 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/handler0', 'handler0');
-            $r->addRoute('GET', '/handler1', 'handler1');
-            $r->addRoute('GET', '/handler2', 'handler2');
-        };
-
-        $method = 'GET';
-        $uri = '/handler2';
-        $handler = 'handler2';
-        $argDict = [];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 2 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler0');
-            $r->addRoute('GET', '/user/{id:[0-9]+}', 'handler1');
-            $r->addRoute('GET', '/user/{name}', 'handler2');
-        };
-
-        $method = 'GET';
-        $uri = '/user/rdlowrey';
-        $handler = 'handler2';
-        $argDict = ['name' => 'rdlowrey'];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 3 -------------------------------------------------------------------------------------->
-
-        // reuse $callback from #2
-
-        $method = 'GET';
-        $uri = '/user/12345';
-        $handler = 'handler1';
-        $argDict = ['id' => '12345'];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 4 -------------------------------------------------------------------------------------->
-
-        // reuse $callback from #3
-
-        $method = 'GET';
-        $uri = '/user/NaN';
-        $handler = 'handler2';
-        $argDict = ['name' => 'NaN'];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 5 -------------------------------------------------------------------------------------->
-
-        // reuse $callback from #4
-
-        $method = 'GET';
-        $uri = '/user/rdlowrey/12345';
-        $handler = 'handler0';
-        $argDict = ['name' => 'rdlowrey', 'id' => '12345'];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 6 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/user/{id:[0-9]+}', 'handler0');
-            $r->addRoute('GET', '/user/12345/extension', 'handler1');
-            $r->addRoute('GET', '/user/{id:[0-9]+}.{extension}', 'handler2');
-        };
-
-        $method = 'GET';
-        $uri = '/user/12345.svg';
-        $handler = 'handler2';
-        $argDict = ['id' => '12345', 'extension' => 'svg'];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 7 ----- Test GET method fallback on HEAD route miss ------------------------------------>
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/user/{name}', 'handler0');
-            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler1');
-            $r->addRoute('GET', '/static0', 'handler2');
-            $r->addRoute('GET', '/static1', 'handler3');
-            $r->addRoute('HEAD', '/static1', 'handler4');
-        };
-
-        $method = 'HEAD';
-        $uri = '/user/rdlowrey';
-        $handler = 'handler0';
-        $argDict = ['name' => 'rdlowrey'];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 8 ----- Test GET method fallback on HEAD route miss ------------------------------------>
-
-        // reuse $callback from #7
-
-        $method = 'HEAD';
-        $uri = '/user/rdlowrey/1234';
-        $handler = 'handler1';
-        $argDict = ['name' => 'rdlowrey', 'id' => '1234'];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 9 ----- Test GET method fallback on HEAD route miss ------------------------------------>
-
-        // reuse $callback from #8
-
-        $method = 'HEAD';
-        $uri = '/static0';
-        $handler = 'handler2';
-        $argDict = [];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 10 ---- Test existing HEAD route used if available (no fallback) ----------------------->
-
-        // reuse $callback from #9
-
-        $method = 'HEAD';
-        $uri = '/static1';
-        $handler = 'handler4';
-        $argDict = [];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 11 ---- More specified routes are not shadowed by less specific of another method ------>
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/user/{name}', 'handler0');
-            $r->addRoute('POST', '/user/{name:[a-z]+}', 'handler1');
-        };
-
-        $method = 'POST';
-        $uri = '/user/rdlowrey';
-        $handler = 'handler1';
-        $argDict = ['name' => 'rdlowrey'];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 12 ---- Handler of more specific routes is used, if it occurs first -------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/user/{name}', 'handler0');
-            $r->addRoute('POST', '/user/{name:[a-z]+}', 'handler1');
-            $r->addRoute('POST', '/user/{name}', 'handler2');
-        };
-
-        $method = 'POST';
-        $uri = '/user/rdlowrey';
-        $handler = 'handler1';
-        $argDict = ['name' => 'rdlowrey'];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 13 ---- Route with constant suffix ----------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/user/{name}', 'handler0');
-            $r->addRoute('GET', '/user/{name}/edit', 'handler1');
-        };
-
-        $method = 'GET';
-        $uri = '/user/rdlowrey/edit';
-        $handler = 'handler1';
-        $argDict = ['name' => 'rdlowrey'];
-
-        $cases[] = [$method, $uri, $callback, $handler, $argDict];
-
-        // 14 ---- Handle multiple methods with the same handler ---------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute(['GET', 'POST'], '/user', 'handlerGetPost');
-            $r->addRoute(['DELETE'], '/user', 'handlerDelete');
-            $r->addRoute([], '/user', 'handlerNone');
-        };
-
-        $argDict = [];
-        $cases[] = ['GET', '/user', $callback, 'handlerGetPost', $argDict];
-        $cases[] = ['POST', '/user', $callback, 'handlerGetPost', $argDict];
-        $cases[] = ['DELETE', '/user', $callback, 'handlerDelete', $argDict];
-
-        // 17 ----
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('POST', '/user.json', 'handler0');
-            $r->addRoute('GET', '/{entity}.json', 'handler1');
-        };
-
-        $cases[] = ['GET', '/user.json', $callback, 'handler1', ['entity' => 'user']];
-
-        // 18 ----
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '', 'handler0');
-        };
-
-        $cases[] = ['GET', '', $callback, 'handler0', []];
-
-        // 19 ----
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('HEAD', '/a/{foo}', 'handler0');
-            $r->addRoute('GET', '/b/{foo}', 'handler1');
-        };
-
-        $cases[] = ['HEAD', '/b/bar', $callback, 'handler1', ['foo' => 'bar']];
-
-        // 20 ----
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('HEAD', '/a', 'handler0');
-            $r->addRoute('GET', '/b', 'handler1');
-        };
-
-        $cases[] = ['HEAD', '/b', $callback, 'handler1', []];
-
-        // 21 ----
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/foo', 'handler0');
-            $r->addRoute('HEAD', '/{bar}', 'handler1');
-        };
-
-        $cases[] = ['HEAD', '/foo', $callback, 'handler1', ['bar' => 'foo']];
-
-        // 22 ----
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('*', '/user', 'handler0');
-            $r->addRoute('*', '/{user}', 'handler1');
-            $r->addRoute('GET', '/user', 'handler2');
-        };
-
-        $cases[] = ['GET', '/user', $callback, 'handler2', []];
-
-        // 23 ----
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('*', '/user', 'handler0');
-            $r->addRoute('GET', '/user', 'handler1');
-        };
-
-        $cases[] = ['POST', '/user', $callback, 'handler0', []];
-
-        // 24 ----
-
-        $cases[] = ['HEAD', '/user', $callback, 'handler1', []];
-
-        // 25 ----
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/{bar}', 'handler0');
-            $r->addRoute('*', '/foo', 'handler1');
-        };
-
-        $cases[] = ['GET', '/foo', $callback, 'handler0', ['bar' => 'foo']];
-
-        // 26 ----
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/user', 'handler0');
-            $r->addRoute('*', '/{foo:.*}', 'handler1');
-        };
-
-        $cases[] = ['POST', '/bar', $callback, 'handler1', ['foo' => 'bar']];
-
-        // 27 --- International characters
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/новости/{name}', 'handler0');
-        };
-
-        $cases[] = ['GET', '/новости/rdlowrey', $callback, 'handler0', ['name' => 'rdlowrey']];
-
-        // x -------------------------------------------------------------------------------------->
-
-        return $cases;
-    }
-
-    public function provideNotFoundDispatchCases()
-    {
-        $cases = [];
-
-        // 0 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/resource/123/456', 'handler0');
-        };
-
-        $method = 'GET';
-        $uri = '/not-found';
-
-        $cases[] = [$method, $uri, $callback];
-
-        // 1 -------------------------------------------------------------------------------------->
-
-        // reuse callback from #0
-        $method = 'POST';
-        $uri = '/not-found';
-
-        $cases[] = [$method, $uri, $callback];
-
-        // 2 -------------------------------------------------------------------------------------->
-
-        // reuse callback from #1
-        $method = 'PUT';
-        $uri = '/not-found';
-
-        $cases[] = [$method, $uri, $callback];
-
-        // 3 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/handler0', 'handler0');
-            $r->addRoute('GET', '/handler1', 'handler1');
-            $r->addRoute('GET', '/handler2', 'handler2');
-        };
-
-        $method = 'GET';
-        $uri = '/not-found';
-
-        $cases[] = [$method, $uri, $callback];
-
-        // 4 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler0');
-            $r->addRoute('GET', '/user/{id:[0-9]+}', 'handler1');
-            $r->addRoute('GET', '/user/{name}', 'handler2');
-        };
-
-        $method = 'GET';
-        $uri = '/not-found';
-
-        $cases[] = [$method, $uri, $callback];
-
-        // 5 -------------------------------------------------------------------------------------->
-
-        // reuse callback from #4
-        $method = 'GET';
-        $uri = '/user/rdlowrey/12345/not-found';
-
-        $cases[] = [$method, $uri, $callback];
-
-        // 6 -------------------------------------------------------------------------------------->
-
-        // reuse callback from #5
-        $method = 'HEAD';
-
-        $cases[] = [$method, $uri, $callback];
-
-        // x -------------------------------------------------------------------------------------->
-
-        return $cases;
-    }
-
-    public function provideMethodNotAllowedDispatchCases()
-    {
-        $cases = [];
-
-        // 0 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/resource/123/456', 'handler0');
-        };
-
-        $method = 'POST';
-        $uri = '/resource/123/456';
-        $allowedMethods = ['GET'];
-
-        $cases[] = [$method, $uri, $callback, $allowedMethods];
-
-        // 1 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/resource/123/456', 'handler0');
-            $r->addRoute('POST', '/resource/123/456', 'handler1');
-            $r->addRoute('PUT', '/resource/123/456', 'handler2');
-            $r->addRoute('*', '/', 'handler3');
-        };
-
-        $method = 'DELETE';
-        $uri = '/resource/123/456';
-        $allowedMethods = ['GET', 'POST', 'PUT'];
-
-        $cases[] = [$method, $uri, $callback, $allowedMethods];
-
-        // 2 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler0');
-            $r->addRoute('POST', '/user/{name}/{id:[0-9]+}', 'handler1');
-            $r->addRoute('PUT', '/user/{name}/{id:[0-9]+}', 'handler2');
-            $r->addRoute('PATCH', '/user/{name}/{id:[0-9]+}', 'handler3');
-        };
-
-        $method = 'DELETE';
-        $uri = '/user/rdlowrey/42';
-        $allowedMethods = ['GET', 'POST', 'PUT', 'PATCH'];
-
-        $cases[] = [$method, $uri, $callback, $allowedMethods];
-
-        // 3 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('POST', '/user/{name}', 'handler1');
-            $r->addRoute('PUT', '/user/{name:[a-z]+}', 'handler2');
-            $r->addRoute('PATCH', '/user/{name:[a-z]+}', 'handler3');
-        };
-
-        $method = 'GET';
-        $uri = '/user/rdlowrey';
-        $allowedMethods = ['POST', 'PUT', 'PATCH'];
-
-        $cases[] = [$method, $uri, $callback, $allowedMethods];
-
-        // 4 -------------------------------------------------------------------------------------->
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute(['GET', 'POST'], '/user', 'handlerGetPost');
-            $r->addRoute(['DELETE'], '/user', 'handlerDelete');
-            $r->addRoute([], '/user', 'handlerNone');
-        };
-
-        $cases[] = ['PUT', '/user', $callback, ['GET', 'POST', 'DELETE']];
-
-        // 5
-
-        $callback = function (RouteCollector $r) {
-            $r->addRoute('POST', '/user.json', 'handler0');
-            $r->addRoute('GET', '/{entity}.json', 'handler1');
-        };
-
-        $cases[] = ['PUT', '/user.json', $callback, ['POST', 'GET']];
-
-        // x -------------------------------------------------------------------------------------->
-
-        return $cases;
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $route = $routeCollector->map($methods, $uri, $callable);
+
+        $dispatcher = new Dispatcher($routeCollector);
+        $results = $dispatcher->dispatch('GET', '/hello/Foo%20Bar');
+
+        $this->assertEquals(RoutingResults::FOUND, $results->getRouteStatus());
+        $this->assertEquals($route->getIdentifier(), $results->getRouteIdentifier());
+        $this->assertEquals(['name' => 'Foo Bar'], $results->getRouteArguments());
+        $this->assertEquals(['name' => 'Foo%20Bar'], $results->getRouteArguments(false));
+        $this->assertEquals('GET', $results->getMethod());
+        $this->assertEquals($methods, $results->getAllowedMethods());
+        $this->assertSame($dispatcher, $results->getDispatcher());
     }
 }

--- a/tests/Routing/FastRouteDispatcherTest.php
+++ b/tests/Routing/FastRouteDispatcherTest.php
@@ -1,0 +1,624 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Routing;
+
+use FastRoute\DataGenerator\GroupCountBased;
+use FastRoute\RouteCollector;
+use Slim\Routing\FastRouteDispatcher;
+use Slim\Tests\TestCase;
+
+/**
+ * Class FastRouteDispatcherTest
+ * @package Slim\Tests
+ */
+class FastRouteDispatcherTest extends TestCase
+{
+    protected function getDispatcherClass()
+    {
+        return FastRouteDispatcher::class;
+    }
+
+    protected function getDataGeneratorClass()
+    {
+        return GroupCountBased::class;
+    }
+
+    /**
+     * Set appropriate options for the specific Dispatcher class we're testing
+     */
+    private function generateDispatcherOptions()
+    {
+        return [
+            'dataGenerator' => $this->getDataGeneratorClass(),
+            'dispatcher' => $this->getDispatcherClass()
+        ];
+    }
+
+    /**
+     * @dataProvider provideFoundDispatchCases
+     */
+    public function testFoundDispatches($method, $uri, $callback, $handler, $argDict)
+    {
+        /** @var FastRouteDispatcher $dispatcher */
+        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+
+        $results = $dispatcher->dispatch($method, $uri);
+
+        $this->assertSame($dispatcher::FOUND, $results[0]);
+        $this->assertSame($handler, $results[1]);
+        $this->assertSame($argDict, $results[2]);
+    }
+
+    /**
+     * @dataProvider provideNotFoundDispatchCases
+     */
+    public function testNotFoundDispatches($method, $uri, $callback)
+    {
+        /** @var FastRouteDispatcher $dispatcher */
+        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+
+        $results = $dispatcher->dispatch($method, $uri);
+
+        $this->assertSame($dispatcher::NOT_FOUND, $results[0]);
+    }
+
+    /**
+     * @dataProvider provideMethodNotAllowedDispatchCases
+     * @param $method
+     * @param $uri
+     * @param $callback
+     */
+    public function testMethodNotAllowedDispatches($method, $uri, $callback)
+    {
+        /** @var FastRouteDispatcher $dispatcher */
+        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+
+        $results = $dispatcher->dispatch($method, $uri);
+
+        $this->assertSame($dispatcher::METHOD_NOT_ALLOWED, $results[0]);
+    }
+
+    /**
+     * @dataProvider provideMethodNotAllowedDispatchCases
+     * @param $method
+     * @param $uri
+     * @param $callback
+     * @param $allowedMethods
+     */
+    public function testGetAllowedMethods($method, $uri, $callback, $allowedMethods)
+    {
+        /** @var FastRouteDispatcher $dispatcher */
+        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+
+        $results = $dispatcher->getAllowedMethods($uri);
+
+        $this->assertSame($results, $allowedMethods);
+    }
+
+    /**
+     * @expectedException \FastRoute\BadRouteException
+     * @expectedExceptionMessage Cannot use the same placeholder "test" twice
+     */
+    public function testDuplicateVariableNameError()
+    {
+        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/foo/{test}/{test:\d+}', 'handler0');
+        }, $this->generateDispatcherOptions());
+    }
+
+    /**
+     * @expectedException \FastRoute\BadRouteException
+     * @expectedExceptionMessage Cannot register two routes matching "/user/([^/]+)" for method "GET"
+     */
+    public function testDuplicateVariableRoute()
+    {
+        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{id}', 'handler0'); // oops, forgot \d+ restriction ;)
+            $r->addRoute('GET', '/user/{name}', 'handler1');
+        }, $this->generateDispatcherOptions());
+    }
+
+    /**
+     * @expectedException \FastRoute\BadRouteException
+     * @expectedExceptionMessage Cannot register two routes matching "/user" for method "GET"
+     */
+    public function testDuplicateStaticRoute()
+    {
+        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/user', 'handler0');
+            $r->addRoute('GET', '/user', 'handler1');
+        }, $this->generateDispatcherOptions());
+    }
+
+    /**
+     * @codingStandardsIgnoreStart
+     * @expectedException \FastRoute\BadRouteException
+     * @expectedExceptionMessage Static route "/user/nikic" is shadowed by previously defined variable route "/user/([^/]+)" for method "GET"
+     * @codingStandardsIgnoreEnd
+     */
+    public function testShadowedStaticRoute()
+    {
+        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('GET', '/user/nikic', 'handler1');
+        }, $this->generateDispatcherOptions());
+    }
+
+    /**
+     * @expectedException \FastRoute\BadRouteException
+     * @expectedExceptionMessage Regex "(en|de)" for parameter "lang" contains a capturing group
+     */
+    public function testCapturing()
+    {
+        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/{lang:(en|de)}', 'handler0');
+        }, $this->generateDispatcherOptions());
+    }
+
+    public function provideFoundDispatchCases()
+    {
+        $cases = [];
+
+        // 0 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/resource/123/456', 'handler0');
+        };
+
+        $method = 'GET';
+        $uri = '/resource/123/456';
+        $handler = 'handler0';
+        $argDict = [];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 1 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/handler0', 'handler0');
+            $r->addRoute('GET', '/handler1', 'handler1');
+            $r->addRoute('GET', '/handler2', 'handler2');
+        };
+
+        $method = 'GET';
+        $uri = '/handler2';
+        $handler = 'handler2';
+        $argDict = [];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 2 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler0');
+            $r->addRoute('GET', '/user/{id:[0-9]+}', 'handler1');
+            $r->addRoute('GET', '/user/{name}', 'handler2');
+        };
+
+        $method = 'GET';
+        $uri = '/user/rdlowrey';
+        $handler = 'handler2';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 3 -------------------------------------------------------------------------------------->
+
+        // reuse $callback from #2
+
+        $method = 'GET';
+        $uri = '/user/12345';
+        $handler = 'handler1';
+        $argDict = ['id' => '12345'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 4 -------------------------------------------------------------------------------------->
+
+        // reuse $callback from #3
+
+        $method = 'GET';
+        $uri = '/user/NaN';
+        $handler = 'handler2';
+        $argDict = ['name' => 'NaN'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 5 -------------------------------------------------------------------------------------->
+
+        // reuse $callback from #4
+
+        $method = 'GET';
+        $uri = '/user/rdlowrey/12345';
+        $handler = 'handler0';
+        $argDict = ['name' => 'rdlowrey', 'id' => '12345'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 6 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{id:[0-9]+}', 'handler0');
+            $r->addRoute('GET', '/user/12345/extension', 'handler1');
+            $r->addRoute('GET', '/user/{id:[0-9]+}.{extension}', 'handler2');
+        };
+
+        $method = 'GET';
+        $uri = '/user/12345.svg';
+        $handler = 'handler2';
+        $argDict = ['id' => '12345', 'extension' => 'svg'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 7 ----- Test GET method fallback on HEAD route miss ------------------------------------>
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler1');
+            $r->addRoute('GET', '/static0', 'handler2');
+            $r->addRoute('GET', '/static1', 'handler3');
+            $r->addRoute('HEAD', '/static1', 'handler4');
+        };
+
+        $method = 'HEAD';
+        $uri = '/user/rdlowrey';
+        $handler = 'handler0';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 8 ----- Test GET method fallback on HEAD route miss ------------------------------------>
+
+        // reuse $callback from #7
+
+        $method = 'HEAD';
+        $uri = '/user/rdlowrey/1234';
+        $handler = 'handler1';
+        $argDict = ['name' => 'rdlowrey', 'id' => '1234'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 9 ----- Test GET method fallback on HEAD route miss ------------------------------------>
+
+        // reuse $callback from #8
+
+        $method = 'HEAD';
+        $uri = '/static0';
+        $handler = 'handler2';
+        $argDict = [];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 10 ---- Test existing HEAD route used if available (no fallback) ----------------------->
+
+        // reuse $callback from #9
+
+        $method = 'HEAD';
+        $uri = '/static1';
+        $handler = 'handler4';
+        $argDict = [];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 11 ---- More specified routes are not shadowed by less specific of another method ------>
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('POST', '/user/{name:[a-z]+}', 'handler1');
+        };
+
+        $method = 'POST';
+        $uri = '/user/rdlowrey';
+        $handler = 'handler1';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 12 ---- Handler of more specific routes is used, if it occurs first -------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('POST', '/user/{name:[a-z]+}', 'handler1');
+            $r->addRoute('POST', '/user/{name}', 'handler2');
+        };
+
+        $method = 'POST';
+        $uri = '/user/rdlowrey';
+        $handler = 'handler1';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 13 ---- Route with constant suffix ----------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}', 'handler0');
+            $r->addRoute('GET', '/user/{name}/edit', 'handler1');
+        };
+
+        $method = 'GET';
+        $uri = '/user/rdlowrey/edit';
+        $handler = 'handler1';
+        $argDict = ['name' => 'rdlowrey'];
+
+        $cases[] = [$method, $uri, $callback, $handler, $argDict];
+
+        // 14 ---- Handle multiple methods with the same handler ---------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute(['GET', 'POST'], '/user', 'handlerGetPost');
+            $r->addRoute(['DELETE'], '/user', 'handlerDelete');
+            $r->addRoute([], '/user', 'handlerNone');
+        };
+
+        $argDict = [];
+        $cases[] = ['GET', '/user', $callback, 'handlerGetPost', $argDict];
+        $cases[] = ['POST', '/user', $callback, 'handlerGetPost', $argDict];
+        $cases[] = ['DELETE', '/user', $callback, 'handlerDelete', $argDict];
+
+        // 17 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('POST', '/user.json', 'handler0');
+            $r->addRoute('GET', '/{entity}.json', 'handler1');
+        };
+
+        $cases[] = ['GET', '/user.json', $callback, 'handler1', ['entity' => 'user']];
+
+        // 18 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '', 'handler0');
+        };
+
+        $cases[] = ['GET', '', $callback, 'handler0', []];
+
+        // 19 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('HEAD', '/a/{foo}', 'handler0');
+            $r->addRoute('GET', '/b/{foo}', 'handler1');
+        };
+
+        $cases[] = ['HEAD', '/b/bar', $callback, 'handler1', ['foo' => 'bar']];
+
+        // 20 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('HEAD', '/a', 'handler0');
+            $r->addRoute('GET', '/b', 'handler1');
+        };
+
+        $cases[] = ['HEAD', '/b', $callback, 'handler1', []];
+
+        // 21 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/foo', 'handler0');
+            $r->addRoute('HEAD', '/{bar}', 'handler1');
+        };
+
+        $cases[] = ['HEAD', '/foo', $callback, 'handler1', ['bar' => 'foo']];
+
+        // 22 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('*', '/user', 'handler0');
+            $r->addRoute('*', '/{user}', 'handler1');
+            $r->addRoute('GET', '/user', 'handler2');
+        };
+
+        $cases[] = ['GET', '/user', $callback, 'handler2', []];
+
+        // 23 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('*', '/user', 'handler0');
+            $r->addRoute('GET', '/user', 'handler1');
+        };
+
+        $cases[] = ['POST', '/user', $callback, 'handler0', []];
+
+        // 24 ----
+
+        $cases[] = ['HEAD', '/user', $callback, 'handler1', []];
+
+        // 25 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/{bar}', 'handler0');
+            $r->addRoute('*', '/foo', 'handler1');
+        };
+
+        $cases[] = ['GET', '/foo', $callback, 'handler0', ['bar' => 'foo']];
+
+        // 26 ----
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user', 'handler0');
+            $r->addRoute('*', '/{foo:.*}', 'handler1');
+        };
+
+        $cases[] = ['POST', '/bar', $callback, 'handler1', ['foo' => 'bar']];
+
+        // 27 --- International characters
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/новости/{name}', 'handler0');
+        };
+
+        $cases[] = ['GET', '/новости/rdlowrey', $callback, 'handler0', ['name' => 'rdlowrey']];
+
+        // x -------------------------------------------------------------------------------------->
+
+        return $cases;
+    }
+
+    public function provideNotFoundDispatchCases()
+    {
+        $cases = [];
+
+        // 0 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/resource/123/456', 'handler0');
+        };
+
+        $method = 'GET';
+        $uri = '/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 1 -------------------------------------------------------------------------------------->
+
+        // reuse callback from #0
+        $method = 'POST';
+        $uri = '/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 2 -------------------------------------------------------------------------------------->
+
+        // reuse callback from #1
+        $method = 'PUT';
+        $uri = '/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 3 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/handler0', 'handler0');
+            $r->addRoute('GET', '/handler1', 'handler1');
+            $r->addRoute('GET', '/handler2', 'handler2');
+        };
+
+        $method = 'GET';
+        $uri = '/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 4 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler0');
+            $r->addRoute('GET', '/user/{id:[0-9]+}', 'handler1');
+            $r->addRoute('GET', '/user/{name}', 'handler2');
+        };
+
+        $method = 'GET';
+        $uri = '/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 5 -------------------------------------------------------------------------------------->
+
+        // reuse callback from #4
+        $method = 'GET';
+        $uri = '/user/rdlowrey/12345/not-found';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // 6 -------------------------------------------------------------------------------------->
+
+        // reuse callback from #5
+        $method = 'HEAD';
+
+        $cases[] = [$method, $uri, $callback];
+
+        // x -------------------------------------------------------------------------------------->
+
+        return $cases;
+    }
+
+    public function provideMethodNotAllowedDispatchCases()
+    {
+        $cases = [];
+
+        // 0 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/resource/123/456', 'handler0');
+        };
+
+        $method = 'POST';
+        $uri = '/resource/123/456';
+        $allowedMethods = ['GET'];
+
+        $cases[] = [$method, $uri, $callback, $allowedMethods];
+
+        // 1 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/resource/123/456', 'handler0');
+            $r->addRoute('POST', '/resource/123/456', 'handler1');
+            $r->addRoute('PUT', '/resource/123/456', 'handler2');
+            $r->addRoute('*', '/', 'handler3');
+        };
+
+        $method = 'DELETE';
+        $uri = '/resource/123/456';
+        $allowedMethods = ['GET', 'POST', 'PUT'];
+
+        $cases[] = [$method, $uri, $callback, $allowedMethods];
+
+        // 2 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('GET', '/user/{name}/{id:[0-9]+}', 'handler0');
+            $r->addRoute('POST', '/user/{name}/{id:[0-9]+}', 'handler1');
+            $r->addRoute('PUT', '/user/{name}/{id:[0-9]+}', 'handler2');
+            $r->addRoute('PATCH', '/user/{name}/{id:[0-9]+}', 'handler3');
+        };
+
+        $method = 'DELETE';
+        $uri = '/user/rdlowrey/42';
+        $allowedMethods = ['GET', 'POST', 'PUT', 'PATCH'];
+
+        $cases[] = [$method, $uri, $callback, $allowedMethods];
+
+        // 3 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('POST', '/user/{name}', 'handler1');
+            $r->addRoute('PUT', '/user/{name:[a-z]+}', 'handler2');
+            $r->addRoute('PATCH', '/user/{name:[a-z]+}', 'handler3');
+        };
+
+        $method = 'GET';
+        $uri = '/user/rdlowrey';
+        $allowedMethods = ['POST', 'PUT', 'PATCH'];
+
+        $cases[] = [$method, $uri, $callback, $allowedMethods];
+
+        // 4 -------------------------------------------------------------------------------------->
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute(['GET', 'POST'], '/user', 'handlerGetPost');
+            $r->addRoute(['DELETE'], '/user', 'handlerDelete');
+            $r->addRoute([], '/user', 'handlerNone');
+        };
+
+        $cases[] = ['PUT', '/user', $callback, ['GET', 'POST', 'DELETE']];
+
+        // 5
+
+        $callback = function (RouteCollector $r) {
+            $r->addRoute('POST', '/user.json', 'handler0');
+            $r->addRoute('GET', '/{entity}.json', 'handler1');
+        };
+
+        $cases[] = ['PUT', '/user.json', $callback, ['POST', 'GET']];
+
+        // x -------------------------------------------------------------------------------------->
+
+        return $cases;
+    }
+}

--- a/tests/Routing/RouteResolverTest.php
+++ b/tests/Routing/RouteResolverTest.php
@@ -9,117 +9,55 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Routing;
 
-use FastRoute\RouteCollector as FRouteCollector;
-use ReflectionClass;
-use Slim\CallableResolver;
-use Slim\Routing\Dispatcher;
-use Slim\Routing\RouteCollector;
+use Slim\Interfaces\DispatcherInterface;
+use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Interfaces\RouteInterface;
 use Slim\Routing\RouteResolver;
 use Slim\Routing\RoutingResults;
 use Slim\Tests\TestCase;
 
 class RouteResolverTest extends TestCase
 {
-    /**
-     * @var RouteCollector
-     */
-    protected $routeCollector;
-
-    /**
-     * @var RouteResolver
-     */
-    protected $routeResolver;
-
-    public function setUp()
+    public function testComputeRoutingResults()
     {
-        $callableResolver = new CallableResolver();
-        $responseFactory = $this->getResponseFactory();
-        $this->routeCollector = new RouteCollector($responseFactory, $callableResolver);
-        $this->routeResolver = new RouteResolver($this->routeCollector);
+        $method = 'GET';
+        $uri = '/';
+
+        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+        $routingResultsProphecy = $this->prophesize(RoutingResults::class);
+
+        $dispatcherProphecy = $this->prophesize(DispatcherInterface::class);
+        $dispatcherProphecy
+            ->dispatch($method, $uri)
+            ->willReturn($routingResultsProphecy->reveal())
+            ->shouldBeCalledOnce();
+
+        $routeResolver = new RouteResolver(
+            $routeCollectorProphecy->reveal(),
+            $dispatcherProphecy->reveal()
+        );
+
+        $routeResolver->computeRoutingResults($uri, $method);
     }
 
-    public function testCreateDispatcher()
+    public function testResolveRoute()
     {
-        $class = new ReflectionClass($this->routeResolver);
-        $method = $class->getMethod('createDispatcher');
-        $method->setAccessible(true);
+        $identifier = 'test';
 
-        $this->assertInstanceOf(Dispatcher::class, $method->invoke($this->routeResolver));
-    }
+        $routeProphecy = $this->prophesize(RouteInterface::class);
+        $dispatcherProphecy = $this->prophesize(DispatcherInterface::class);
 
-    public function testSetDispatcher()
-    {
-        /** @var Dispatcher $dispatcher */
-        $dispatcher = \FastRoute\simpleDispatcher(function (FRouteCollector $r) {
-        }, ['dispatcher' => Dispatcher::class]);
+        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+        $routeCollectorProphecy
+            ->lookupRoute($identifier)
+            ->willReturn($routeProphecy->reveal())
+            ->shouldBeCalledOnce();
 
-        $this->routeResolver->setDispatcher($dispatcher);
+        $routeResolver = new RouteResolver(
+            $routeCollectorProphecy->reveal(),
+            $dispatcherProphecy->reveal()
+        );
 
-        $class = new ReflectionClass($this->routeResolver);
-        $prop = $class->getProperty('dispatcher');
-        $prop->setAccessible(true);
-
-        $this->assertEquals($dispatcher, $prop->getValue($this->routeResolver));
-    }
-
-    /**
-     * Test cached routes file is created & that it holds our routes.
-     */
-    public function testRouteCacheFileCanBeDispatched()
-    {
-        $methods = ['GET'];
-        $pattern = '/hello/{first}/{last}';
-        $callable = function ($request, $response, $args) {
-            echo sprintf('Hello %s %s', $args['first'], $args['last']);
-        };
-        $route = $this->routeCollector->map($methods, $pattern, $callable)->setName('foo');
-
-        $cacheFile = dirname(__FILE__) . '/' . uniqid((string) microtime(true));
-        $this->routeCollector->setCacheFile($cacheFile);
-
-        $class = new ReflectionClass($this->routeResolver);
-        $method = $class->getMethod('createDispatcher');
-        $method->setAccessible(true);
-
-        $dispatcher = $method->invoke($this->routeResolver);
-        $this->assertInstanceOf(Dispatcher::class, $dispatcher);
-        $this->assertFileExists($cacheFile, 'cache file was not created');
-
-        // instantiate a new router & load the cached routes file & see if
-        // we can dispatch to the route we cached.
-        $callableResolver = new CallableResolver();
-        $responseFactory = $this->getResponseFactory();
-
-        $routeCollector2 = new RouteCollector($responseFactory, $callableResolver);
-        $routeCollector2->setCacheFile($cacheFile);
-
-        $routeResolver2 = new RouteResolver($routeCollector2);
-
-        $class = new ReflectionClass($routeResolver2);
-        $method = $class->getMethod('createDispatcher');
-        $method->setAccessible(true);
-
-        $dispatcher2 = $method->invoke($routeResolver2);
-
-        /** @var RoutingResults $result */
-        $result = $dispatcher2->dispatch('GET', '/hello/josh/lockhart');
-        $this->assertSame(Dispatcher::FOUND, $result->getRouteStatus());
-
-        unlink($cacheFile);
-    }
-
-    /**
-     * Calling createDispatcher as second time should give you back the same
-     * dispatcher as when you called it the first time.
-     */
-    public function testCreateDispatcherReturnsSameDispatcherASecondTime()
-    {
-        $class = new ReflectionClass($this->routeResolver);
-        $method = $class->getMethod('createDispatcher');
-        $method->setAccessible(true);
-
-        $dispatcher = $method->invoke($this->routeResolver);
-        $dispatcher2 = $method->invoke($this->routeResolver);
-        $this->assertSame($dispatcher2, $dispatcher);
+        $routeResolver->resolveRoute($identifier);
     }
 }


### PR DESCRIPTION
This is pull 5 out of 7 to complete the goals set in #2604

This decouples the FastRoute dispatcher implementation from `RouteResolver`. It introduces a new `DispatcherInterface` so we can implement routers/dispatchers from other frameworks.

This gives a user the ability to implement their own dispatcher, as long as it returns `RoutingResults` and provide functionality to get the allowed methods for a given uri string.