### PR TITLE
4.x - Decouple FastRoute RouteParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 4.0.0 - 2019-07-03
 
 ### Added
+- [#2640](https://github.com/slimphp/Slim/pull/2640) Add `RouteParserInterface` and decouple FastRoute route parser entirely from core. The methods `relativePathFor()`, `urlFor()` and `fullUrlFor()` are now located on this interface.
 - [#2639](https://github.com/slimphp/Slim/pull/2639) Add `DispatcherInterface` and decouple FastRoute dispatcher entirely from core. This enables us to swap out our router implementation for any other router.
 - [#2638](https://github.com/slimphp/Slim/pull/2638) Add `RouteCollector::fullUrlFor()` to give the ability to generate fully qualified URLs
 - [#2634](https://github.com/slimphp/Slim/pull/2634) Added ability to set invocation strategy on a per-route basis.

--- a/Slim/Interfaces/DispatcherInterface.php
+++ b/Slim/Interfaces/DispatcherInterface.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
 declare(strict_types=1);
 
 namespace Slim\Interfaces;

--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -10,11 +10,17 @@ declare(strict_types=1);
 namespace Slim\Interfaces;
 
 use InvalidArgumentException;
-use Psr\Http\Message\UriInterface;
 use RuntimeException;
 
 interface RouteCollectorInterface
 {
+    /**
+     * Get the route parser
+     *
+     * @return RouteParserInterface
+     */
+    public function getRouteParser(): RouteParserInterface;
+
     /**
      * Get default route invocation strategy
      *
@@ -127,60 +133,4 @@ interface RouteCollectorInterface
      * @return RouteInterface
      */
     public function map(array $methods, string $pattern, $handler): RouteInterface;
-
-    /**
-     * Build the path for a named route excluding the base path
-     *
-     * @param string $name        Route name
-     * @param array  $data        Named argument replacement data
-     * @param array  $queryParams Optional query string parameters
-     *
-     * @return string
-     *
-     * @throws RuntimeException         If named route does not exist
-     * @throws InvalidArgumentException If required data not provided
-     */
-    public function relativePathFor(string $name, array $data = [], array $queryParams = []): string;
-
-    /**
-     * Build the path for a named route including the base path
-     *
-     * This method is deprecated. Use urlFor() from now on.
-     *
-     * @param string $name        Route name
-     * @param array  $data        Named argument replacement data
-     * @param array  $queryParams Optional query string parameters
-     *
-     * @return string
-     *
-     * @throws RuntimeException         If named route does not exist
-     * @throws InvalidArgumentException If required data not provided
-     */
-    public function pathFor(string $name, array $data = [], array $queryParams = []): string;
-
-    /**
-     * Build the path for a named route including the base path
-     *
-     * @param string $name        Route name
-     * @param array  $data        Named argument replacement data
-     * @param array  $queryParams Optional query string parameters
-     *
-     * @return string
-     *
-     * @throws RuntimeException         If named route does not exist
-     * @throws InvalidArgumentException If required data not provided
-     */
-    public function urlFor(string $name, array $data = [], array $queryParams = []): string;
-
-    /**
-     * Get fully qualified URL for named route
-     *
-     * @param UriInterface  $uri
-     * @param string        $routeName Route name
-     * @param array         $data Named argument replacement data
-     * @param array         $queryParams Optional query string parameters
-     *
-     * @return string
-     */
-    public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string;
 }

--- a/Slim/Interfaces/RouteParserInterface.php
+++ b/Slim/Interfaces/RouteParserInterface.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Interfaces;
+
+use InvalidArgumentException;
+use Psr\Http\Message\UriInterface;
+use RuntimeException;
+
+/**
+ * Interface RouteParserInterface
+ *
+ * @package Slim\Interfaces
+ */
+interface RouteParserInterface
+{
+    /**
+     * Build the path for a named route excluding the base path
+     *
+     * @param string $name        Route name
+     * @param array  $data        Named argument replacement data
+     * @param array  $queryParams Optional query string parameters
+     *
+     * @return string
+     *
+     * @throws RuntimeException         If named route does not exist
+     * @throws InvalidArgumentException If required data not provided
+     */
+    public function relativePathFor(string $name, array $data = [], array $queryParams = []): string;
+
+    /**
+     * Build the path for a named route including the base path
+     *
+     * This method is deprecated. Use urlFor() from now on.
+     *
+     * @param string $name        Route name
+     * @param array  $data        Named argument replacement data
+     * @param array  $queryParams Optional query string parameters
+     *
+     * @return string
+     *
+     * @throws RuntimeException         If named route does not exist
+     * @throws InvalidArgumentException If required data not provided
+     */
+    public function pathFor(string $name, array $data = [], array $queryParams = []): string;
+
+    /**
+     * Build the path for a named route including the base path
+     *
+     * @param string $name        Route name
+     * @param array  $data        Named argument replacement data
+     * @param array  $queryParams Optional query string parameters
+     *
+     * @return string
+     *
+     * @throws RuntimeException         If named route does not exist
+     * @throws InvalidArgumentException If required data not provided
+     */
+    public function urlFor(string $name, array $data = [], array $queryParams = []): string;
+
+    /**
+     * Get fully qualified URL for named route
+     *
+     * @param UriInterface  $uri
+     * @param string        $routeName Route name
+     * @param array         $data Named argument replacement data
+     * @param array         $queryParams Optional query string parameters
+     *
+     * @return string
+     */
+    public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string;
+}

--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Routing;
+
+use FastRoute\RouteParser\Std;
+use InvalidArgumentException;
+use Psr\Http\Message\UriInterface;
+use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Interfaces\RouteParserInterface;
+
+/**
+ * Class RouteParser
+ *
+ * @package Slim\Routing
+ */
+class RouteParser implements RouteParserInterface
+{
+    /**
+     * @var RouteCollectorInterface
+     */
+    private $routeCollector;
+
+    /**
+     * @var Std
+     */
+    private $routeParser;
+
+    /**
+     * RouteParser constructor.
+     *
+     * @param RouteCollectorInterface $routeCollector
+     */
+    public function __construct(RouteCollectorInterface $routeCollector)
+    {
+        $this->routeCollector = $routeCollector;
+        $this->routeParser = new Std();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function relativePathFor(string $name, array $data = [], array $queryParams = []): string
+    {
+        $route = $this->routeCollector->getNamedRoute($name);
+        $pattern = $route->getPattern();
+
+        $segments = [];
+        $segmentName = '';
+
+        /*
+         * $routes is an associative array of expressions representing a route as multiple segments
+         * There is an expression for each optional parameter plus one without the optional parameters
+         * The most specific is last, hence why we reverse the array before iterating over it
+         */
+        $expressions = array_reverse($this->routeParser->parse($pattern));
+        foreach ($expressions as $expression) {
+            foreach ($expression as $segment) {
+                /*
+                 * Each $segment is either a string or an array of strings
+                 * containing optional parameters of an expression
+                 */
+                if (is_string($segment)) {
+                    $segments[] = $segment;
+                    continue;
+                }
+
+                /*
+                 * If we don't have a data element for this segment in the provided $data
+                 * we cancel testing to move onto the next expression with a less specific item
+                 */
+                if (!array_key_exists($segment[0], $data)) {
+                    $segments = [];
+                    $segmentName = $segment[0];
+                    break;
+                }
+
+                $segments[] = $data[$segment[0]];
+            }
+
+            /*
+             * If we get to this logic block we have found all the parameters
+             * for the provided $data which means we don't need to continue testing
+             * less specific expressions
+             */
+            if (!empty($segments)) {
+                break;
+            }
+        }
+
+        if (empty($segments)) {
+            throw new InvalidArgumentException('Missing data for URL segment: ' . $segmentName);
+        }
+
+        $url = implode('', $segments);
+        if ($queryParams) {
+            $url .= '?' . http_build_query($queryParams);
+        }
+
+        return $url;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pathFor(string $name, array $data = [], array $queryParams = []): string
+    {
+        trigger_error('pathFor() is deprecated. Use urlFor() instead.', E_USER_DEPRECATED);
+        return $this->urlFor($name, $data, $queryParams);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function urlFor(string $name, array $data = [], array $queryParams = []): string
+    {
+        $basePath = $this->routeCollector->getBasePath();
+        $url = $this->relativePathFor($name, $data, $queryParams);
+
+        if ($basePath) {
+            $url = $basePath . $url;
+        }
+
+        return $url;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string
+    {
+        $path = $this->urlFor($routeName, $data, $queryParams);
+        $scheme = $uri->getScheme();
+        $authority = $uri->getAuthority();
+        $protocol = ($scheme ? $scheme . ':' : '') . ($authority ? '//' . $authority : '');
+        return $protocol . $path;
+    }
+}

--- a/tests/Routing/RouteParserTest.php
+++ b/tests/Routing/RouteParserTest.php
@@ -1,0 +1,236 @@
+<?php
+declare(strict_types=1);
+
+namespace Slim\Tests\Routing;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\UriInterface;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Interfaces\RouteInterface;
+use Slim\Routing\RouteCollector;
+use Slim\Routing\RouteParser;
+use Slim\Tests\TestCase;
+
+/**
+ * Class RouteParserTest
+ *
+ * @package Slim\Tests\Routing
+ */
+class RouteParserTest extends TestCase
+{
+    public function urlForCases()
+    {
+        return [
+            'with base path' => [
+                true,
+                '/{first}/{second}',
+                ['first' => 'hello', 'second' => 'world'],
+                [],
+                '/app/hello/world',
+            ],
+            'without base path' => [
+                false,
+                '/{first}/{second}',
+                ['first' => 'hello', 'second' => 'world'],
+                [],
+                '/hello/world',
+            ],
+            'without query parameters' => [
+                false,
+                '/{first}/{second}',
+                ['first' => 'hello', 'second' => 'world'],
+                ['a' => 'b', 'c' => 'd'],
+                '/hello/world?a=b&c=d',
+            ],
+            'with argument without optional parameter' => [
+                false,
+                '/archive/{year}[/{month:[\d:{2}]}[/d/{day}]]',
+                ['year' => '2015'],
+                [],
+                '/archive/2015',
+            ],
+            'with argument and optional parameter' => [
+                false,
+                '/archive/{year}[/{month:[\d:{2}]}[/d/{day}]]',
+                ['year' => '2015', 'month' => '07'],
+                [],
+                '/archive/2015/07',
+            ],
+            'with argument and optional parameters' => [
+                false,
+                '/archive/{year}[/{month:[\d:{2}]}[/d/{day}]]',
+                ['year' => '2015', 'month' => '07', 'day' => '19'],
+                [],
+                '/archive/2015/07/d/19',
+            ],
+        ];
+    }
+
+    public function testRelativePathForWithNoBasePath()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+
+        $route = $routeCollector->map(['GET'], '/{first}/{second}', function () {
+        });
+        $route->setName('test');
+
+        $routeParser = $routeCollector->getRouteParser();
+        $results = $routeParser->relativePathFor('test', ['first' => 'hello', 'second' => 'world']);
+
+        $this->assertEquals('/hello/world', $results);
+    }
+
+    public function testBasePathIsIgnoreInRelativePathFor()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $routeCollector->setBasePath('/app');
+
+        $route = $routeCollector->map(['GET'], '/{first}/{second}', function () {
+        });
+        $route->setName('test');
+
+        $routeParser = $routeCollector->getRouteParser();
+        $results = $routeParser->relativePathFor('test', ['first' => 'hello', 'second' => 'world']);
+
+        $this->assertEquals('/hello/world', $results);
+    }
+
+    /**
+     * @dataProvider urlForCases
+     * @param $withBasePath
+     * @param $pattern
+     * @param $arguments
+     * @param $queryParams
+     * @param $expectedResult
+     */
+    public function testUrlForWithBasePath($withBasePath, $pattern, $arguments, $queryParams, $expectedResult)
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+
+        if ($withBasePath) {
+            $routeCollector->setBasePath('/app');
+        }
+
+        $route = $routeCollector->map(['GET'], $pattern, function () {
+        });
+        $route->setName('test');
+
+        $routeParser = $routeCollector->getRouteParser();
+        $results = $routeParser->urlFor('test', $arguments, $queryParams);
+
+        $this->assertEquals($expectedResult, $results);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testUrlForWithMissingSegmentData()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $route = $routeCollector->map(['GET'], '/{first}/{last}', function () {
+        });
+        $route->setName('test');
+
+        $routeParser = $routeCollector->getRouteParser();
+        $routeParser->urlFor('test', ['last' => 'world']);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testUrlForRouteThatDoesNotExist()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $routeParser = $routeCollector->getRouteParser();
+
+        $routeParser->urlFor('test');
+    }
+
+    /**
+     * Test that the router pathFor will proxy into a urlFor method, and trigger
+     * the user deprecated warning
+     */
+    public function testPathForAliasesUrlFor()
+    {
+        $errorString = null;
+
+        set_error_handler(function ($no, $str) use (&$errorString) {
+            $errorString = $str;
+        }, E_USER_DEPRECATED);
+
+        $name = 'foo';
+        $data = ['name' => 'josh'];
+        $queryParams = ['a' => 'b', 'c' => 'd'];
+
+        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+
+        /** @var RouteParser $routeParser */
+        $routeParser = $this
+            ->getMockBuilder(RouteParser::class)
+            ->setConstructorArgs([$routeCollectorProphecy->reveal()])
+            ->setMethods(['urlFor'])
+            ->getMock();
+
+        $routeParser->expects($this->once())->method('urlFor')->with($name, $data, $queryParams);
+        $routeParser->pathFor($name, $data, $queryParams);
+
+        //check that our error was triggered
+        $this->assertEquals($errorString, 'pathFor() is deprecated. Use urlFor() instead.');
+
+        restore_error_handler();
+    }
+
+    public function testFullUrlFor()
+    {
+        $uriProphecy = $this->prophesize(UriInterface::class);
+        $uriProphecy
+            ->getScheme()
+            ->willReturn('http')
+            ->shouldBeCalledOnce();
+
+        $uriProphecy
+            ->getAuthority()
+            ->willReturn('example.com:8080')
+            ->shouldBeCalledOnce();
+
+        $routeProphecy = $this->prophesize(RouteInterface::class);
+        $routeProphecy
+            ->getPattern()
+            ->willReturn('/{token}')
+            ->shouldBeCalledOnce();
+
+        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+
+        $routeCollectorProphecy
+            ->getBasePath()
+            ->willReturn('/app')
+            ->shouldBeCalledOnce();
+
+        $routeCollectorProphecy
+            ->getNamedRoute('test')
+            ->willReturn($routeProphecy->reveal())
+            ->shouldBeCalledOnce();
+
+        $routeParser = new RouteParser($routeCollectorProphecy->reveal());
+        $result = $routeParser->fullUrlFor($uriProphecy->reveal(), 'test', ['token' => '123']);
+
+        $expectedResult = 'http://example.com:8080/app/123';
+        $this->assertEquals($expectedResult, $result);
+    }
+}


### PR DESCRIPTION
This is pull 6 out of 7 to complete the goals set in #2604

This decouples the FastRoute route parser from `RouteCollector`. It introduces a new interface `RouteParserInterface`.

**The new interface implements the following methods**:
- `RouteParser::relativePathFor()`
- `RouteParser::urlFor()`
- `RouteParser::fullUrlFor()`

**A new method on `RouteCollectorInterface` is introduced**:
- `RouteCollectorInterface::getRouteParser()`

**Example Usage**:
```php
use Slim\App;
use Slim\Http\Factory\DecoratedResponseFactory;
use Slim\Http\ServerRequest;
use Slim\Psr7\Factory\ResponseFactory;
use Slim\Psr7\Factory\ServerRequestFactory;
use Slim\Psr7\Factory\StreamFactory;

$responseFactory = new DecoratedResponseFactory(new ResponseFactory(), new StreamFactory());
$app = new App($responseFactory);
$routeCollector = $app->getRouteCollector();
$routeParser = $routeCollector->getRouteParser();

/**
 * The base app url would be for example:
 * http://example.com
 *
 * If you wanted to generate a fully qualified URL from within a route
 * you would do something like the following
 */
$route = $app->get('/hello/{name}', function ($request, $response, $args) use ($routeParser) {
    /** @var RouteInterface $route */
    $route = $request->getAttribute('route');
    $routeName = $route->getName();

    $uri = $request->getUri();

    /**
     * $fullyQualifiedUrl would be:
     * http://example.com/hello/world
     */
    $fullyQualifiedUrl = $routeParser->fullUrlFor($uri, $routeName, ['name' => 'world']);

    return $response;
});
$route->setName('test');

$request = new ServerRequest(ServerRequestFactory::createFromGlobals());
$app->run($request);
```