### PR TITLE
4.x - RouteCollectorProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 4.0.0 - 2019-07-03
 
 ### Added
+- [#2641](https://github.com/slimphp/Slim/pull/2641) Add `RouteCollectorProxyInterface` which extracts all the route mapping functionality from app into its own interface.
 - [#2640](https://github.com/slimphp/Slim/pull/2640) Add `RouteParserInterface` and decouple FastRoute route parser entirely from core. The methods `relativePathFor()`, `urlFor()` and `fullUrlFor()` are now located on this interface.
 - [#2639](https://github.com/slimphp/Slim/pull/2639) Add `DispatcherInterface` and decouple FastRoute dispatcher entirely from core. This enables us to swap out our router implementation for any other router.
 - [#2638](https://github.com/slimphp/Slim/pull/2638) Add `RouteCollector::fullUrlFor()` to give the ability to generate fully qualified URLs
@@ -24,6 +25,7 @@
 
 ### Deprecated
 
+- [#2641](https://github.com/slimphp/Slim/pull/2641) Deprecate `RouteCollector::pushGroup()`,`RouteCollector::popGroup()` which gets replaced by `RouteCollector::group()`
 - [#2638](https://github.com/slimphp/Slim/pull/2638) Deprecate `RouteCollector::pathFor()` which gets replaced by `RouteCollector::urlFor()` preserving the orignal functionality
 - [#2555](https://github.com/slimphp/Slim/pull/2555) Double-Pass Middleware Support has been deprecated
 

--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -98,6 +98,8 @@ interface RouteCollectorInterface
     public function removeNamedRoute(string $name): RouteCollectorInterface;
 
     /**
+     * Lookup a route via the route's unique identifier
+     *
      * @param string $identifier
      *
      * @return RouteInterface
@@ -107,21 +109,13 @@ interface RouteCollectorInterface
     public function lookupRoute(string $identifier): RouteInterface;
 
     /**
-     * Add a route group to the array
+     * Add route group
      *
-     * @param string   $pattern The group pattern
-     * @param callable $callable A group callable
-     *
+     * @param string            $pattern
+     * @param string|callable   $callable
      * @return RouteGroupInterface
      */
-    public function pushGroup(string $pattern, $callable): RouteGroupInterface;
-
-    /**
-     * Removes the last route group from the array
-     *
-     * @return RouteGroupInterface|null
-     */
-    public function popGroup(): ?RouteGroupInterface;
+    public function group(string $pattern, $callable): RouteGroupInterface;
 
     /**
      * Add route

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Interfaces;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\UriInterface;
+
+interface RouteCollectorProxyInterface
+{
+    /**
+     * @return CallableResolverInterface
+     */
+    public function getCallableResolver(): CallableResolverInterface;
+
+    /**
+     * @return ContainerInterface|null
+     */
+    public function getContainer(): ?ContainerInterface;
+
+    /**
+     * @return RouteCollectorInterface
+     */
+    public function getRouteCollector(): RouteCollectorInterface;
+
+    /**
+     * Add GET route
+     *
+     * @param  string $pattern  The route URI pattern
+     * @param  callable|string  $callable The route callback routine
+     *
+     * @return RouteInterface
+     */
+    public function get(string $pattern, $callable): RouteInterface;
+
+    /**
+     * Add POST route
+     *
+     * @param  string $pattern  The route URI pattern
+     * @param  callable|string  $callable The route callback routine
+     *
+     * @return RouteInterface
+     */
+    public function post(string $pattern, $callable): RouteInterface;
+
+    /**
+     * Add PUT route
+     *
+     * @param  string $pattern  The route URI pattern
+     * @param  callable|string  $callable The route callback routine
+     *
+     * @return RouteInterface
+     */
+    public function put(string $pattern, $callable): RouteInterface;
+
+    /**
+     * Add PATCH route
+     *
+     * @param  string $pattern  The route URI pattern
+     * @param  callable|string  $callable The route callback routine
+     *
+     * @return RouteInterface
+     */
+    public function patch(string $pattern, $callable): RouteInterface;
+
+    /**
+     * Add DELETE route
+     *
+     * @param  string $pattern  The route URI pattern
+     * @param  callable|string  $callable The route callback routine
+     *
+     * @return RouteInterface
+     */
+    public function delete(string $pattern, $callable): RouteInterface;
+
+    /**
+     * Add OPTIONS route
+     *
+     * @param  string $pattern  The route URI pattern
+     * @param  callable|string  $callable The route callback routine
+     *
+     * @return RouteInterface
+     */
+    public function options(string $pattern, $callable): RouteInterface;
+
+    /**
+     * Add route for any HTTP method
+     *
+     * @param  string $pattern  The route URI pattern
+     * @param  callable|string  $callable The route callback routine
+     *
+     * @return RouteInterface
+     */
+    public function any(string $pattern, $callable): RouteInterface;
+
+    /**
+     * Add route with multiple methods
+     *
+     * @param  string[] $methods  Numeric array of HTTP method names
+     * @param  string   $pattern  The route URI pattern
+     * @param  callable|string    $callable The route callback routine
+     *
+     * @return RouteInterface
+     */
+    public function map(array $methods, string $pattern, $callable): RouteInterface;
+
+    /**
+     * Add a route that sends an HTTP redirect
+     *
+     * @param string              $from
+     * @param string|UriInterface $to
+     * @param int                 $status
+     *
+     * @return RouteInterface
+     */
+    public function redirect(string $from, $to, int $status = 302): RouteInterface;
+
+    /**
+     * Route Groups
+     *
+     * This method accepts a route pattern and a callback. All route
+     * declarations in the callback will be prepended by the group(s)
+     * that it is in.
+     *
+     * @param string   $pattern
+     * @param callable $callable
+     *
+     * @return RouteGroupInterface
+     */
+    public function group(string $pattern, $callable): RouteGroupInterface;
+
+    /**
+     * Get the RouteCollectorProxy's base path
+     *
+     * @return string
+     */
+    public function getBasePath(): string;
+
+    /**
+     * Set the RouteCollectorProxy's base path
+     *
+     * @param string $basePath
+     *
+     * @return RouteCollectorProxyInterface
+     */
+    public function setBasePath(string $basePath): RouteCollectorProxyInterface;
+}

--- a/Slim/Interfaces/RouteGroupInterface.php
+++ b/Slim/Interfaces/RouteGroupInterface.php
@@ -10,43 +10,43 @@ declare(strict_types=1);
 namespace Slim\Interfaces;
 
 use Psr\Http\Server\MiddlewareInterface;
-use Slim\App;
 use Slim\MiddlewareDispatcher;
 
 interface RouteGroupInterface
 {
     /**
+     * @return RouteGroupInterface
+     */
+    public function collectRoutes(): RouteGroupInterface;
+
+    /**
+     * Add middleware to the route group
+     *
      * @param MiddlewareInterface|string|callable $middleware
      * @return RouteGroupInterface
      */
     public function add($middleware): RouteGroupInterface;
 
     /**
+     * Add middleware to the route group
+     *
      * @param MiddlewareInterface $middleware
      * @return RouteGroupInterface
      */
     public function addMiddleware(MiddlewareInterface $middleware): RouteGroupInterface;
 
     /**
+     * Append the group's middleware to the MiddlewareDispatcher
+     *
      * @param MiddlewareDispatcher $dispatcher
      * @return RouteGroupInterface
      */
     public function appendMiddlewareToDispatcher(MiddlewareDispatcher $dispatcher): RouteGroupInterface;
 
     /**
-     * Get route pattern
+     * Get the RouteGroup's pattern
      *
      * @return string
      */
     public function getPattern(): string;
-
-    /**
-     * Execute route group callable in the context of the Slim App
-     *
-     * This method invokes the route group object's callable, collecting
-     * nested route objects
-     *
-     * @param App $app
-     */
-    public function __invoke(App $app);
 }

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -9,11 +9,8 @@ declare(strict_types=1);
 
 namespace Slim\Routing;
 
-use FastRoute\RouteParser\Std as StdParser;
-use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
-use Psr\Http\Message\UriInterface;
 use RuntimeException;
 use Slim\Handlers\Strategies\RequestResponse;
 use Slim\Interfaces\CallableResolverInterface;

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Routing;
+
+use Closure;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Interfaces\RouteCollectorProxyInterface;
+use Slim\Interfaces\RouteGroupInterface;
+use Slim\Interfaces\RouteInterface;
+
+/**
+ * Class RouteCollectorProxy
+ *
+ * @package Slim\Routing
+ */
+class RouteCollectorProxy implements RouteCollectorProxyInterface
+{
+    /**
+     * @var ResponseFactoryInterface
+     */
+    protected $responseFactory;
+
+    /**
+     * @var CallableResolverInterface
+     */
+    protected $callableResolver;
+
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @var RouteCollectorInterface
+     */
+    protected $routeCollector;
+
+    /**
+     * @var string
+     */
+    protected $basePath;
+
+    /**
+     * RouteCollectorProxy constructor.
+     *
+     * @param ResponseFactoryInterface      $responseFactory
+     * @param CallableResolverInterface     $callableResolver
+     * @param RouteCollectorInterface|null  $routeCollector
+     * @param ContainerInterface|null       $container
+     * @param string                        $basePath
+     */
+    public function __construct(
+        ResponseFactoryInterface $responseFactory,
+        CallableResolverInterface $callableResolver,
+        ContainerInterface $container = null,
+        RouteCollectorInterface $routeCollector = null,
+        string $basePath = ''
+    ) {
+        $this->responseFactory = $responseFactory;
+        $this->callableResolver = $callableResolver;
+        $this->container = $container;
+        $this->routeCollector = $routeCollector ?? new RouteCollector($responseFactory, $callableResolver, $container);
+        $this->basePath = $basePath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCallableResolver(): CallableResolverInterface
+    {
+        return $this->callableResolver;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContainer(): ?ContainerInterface
+    {
+        return $this->container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRouteCollector(): RouteCollectorInterface
+    {
+        return $this->routeCollector;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBasePath(): string
+    {
+        return $this->basePath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setBasePath(string $basePath): RouteCollectorProxyInterface
+    {
+        $this->basePath = $basePath;
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(string $pattern, $callable): RouteInterface
+    {
+        return $this->routeCollector->map(['GET'], $pattern, $callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function post(string $pattern, $callable): RouteInterface
+    {
+        return $this->routeCollector->map(['POST'], $pattern, $callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function put(string $pattern, $callable): RouteInterface
+    {
+        return $this->routeCollector->map(['PUT'], $pattern, $callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function patch(string $pattern, $callable): RouteInterface
+    {
+        return $this->routeCollector->map(['PATCH'], $pattern, $callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete(string $pattern, $callable): RouteInterface
+    {
+        return $this->routeCollector->map(['DELETE'], $pattern, $callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function options(string $pattern, $callable): RouteInterface
+    {
+        return $this->routeCollector->map(['OPTIONS'], $pattern, $callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function any(string $pattern, $callable): RouteInterface
+    {
+        return $this->routeCollector->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], $pattern, $callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function map(array $methods, string $pattern, $callable): RouteInterface
+    {
+        if ($this->container && $callable instanceof Closure) {
+            $callable = $callable->bindTo($this->container);
+        }
+
+        return $this->routeCollector->map($methods, $pattern, $callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function redirect(string $from, $to, int $status = 302): RouteInterface
+    {
+        $handler = function () use ($to, $status) {
+            $response = $this->responseFactory->createResponse($status);
+            return $response->withHeader('Location', (string) $to);
+        };
+
+        return $this->get($from, $handler);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function group(string $pattern, $callable): RouteGroupInterface
+    {
+        $pattern = $this->basePath . $pattern;
+        return $this->routeCollector->group($pattern, $callable);
+    }
+}

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -36,7 +36,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     protected $callableResolver;
 
     /**
-     * @var ContainerInterface
+     * @var ContainerInterface|null
      */
     protected $container;
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -26,6 +26,7 @@ use Slim\Exception\HttpNotFoundException;
 use Slim\Handlers\Strategies\RequestResponseArgs;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Interfaces\RouteCollectorProxyInterface;
 use Slim\Interfaces\RouteResolverInterface;
 use Slim\Routing\RouteCollector;
 use Slim\Routing\RouteCollectorProxy;
@@ -874,9 +875,16 @@ class AppTest extends TestCase
         });
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->group('/foo', function (RouteCollectorProxy $proxy) use ($middlewareProphecy2, $middlewareProphecy3, &$output) {
-            $proxy->group('/bar', function (RouteCollectorProxy $proxy) use ($middlewareProphecy3, &$output) {
-                $proxy->get('/baz', function (
+        $app->group('/foo', function (RouteCollectorProxyInterface $group) use (
+            $middlewareProphecy2,
+            $middlewareProphecy3,
+            &$output
+        ) {
+            $group->group('/bar', function (RouteCollectorProxyInterface $group) use (
+                $middlewareProphecy3,
+                &$output
+            ) {
+                $group->get('/baz', function (
                     ServerRequestInterface $request,
                     ResponseInterface $response
                 ) use (&$output) {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -28,6 +28,7 @@ use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteResolverInterface;
 use Slim\Routing\RouteCollector;
+use Slim\Routing\RouteCollectorProxy;
 use Slim\Tests\Mocks\MockAction;
 use stdClass;
 
@@ -87,22 +88,6 @@ class AppTest extends TestCase
         $app = new App($responseFactoryProphecy->reveal(), null, null, $routeCollectorProphecy->reveal());
 
         $this->assertSame($routeCollectorProphecy->reveal(), $app->getRouteCollector());
-    }
-
-    public function testGetRouteResolverReturnsInjectedInstance()
-    {
-        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
-        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
-        $routeResolverProphecy = $this->prophesize(RouteResolverInterface::class);
-        $app = new App(
-            $responseFactoryProphecy->reveal(),
-            null,
-            null,
-            $routeCollectorProphecy->reveal(),
-            $routeResolverProphecy->reveal()
-        );
-
-        $this->assertSame($routeResolverProphecy->reveal(), $app->getRouteResolver());
     }
 
     public function testCreatesRouteCollectorWhenNullWithInjectedContainer()
@@ -785,8 +770,8 @@ class AppTest extends TestCase
         });
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->group('/foo', function (App $app) use (&$output) {
-            $app->get('/bar', function (ServerRequestInterface $request, ResponseInterface $response) use (&$output) {
+        $app->group('/foo', function (RouteCollectorProxy $proxy) use (&$output) {
+            $proxy->get('/bar', function (ServerRequestInterface $request, ResponseInterface $response) use (&$output) {
                 $output .= 'Center';
                 return $response;
             });
@@ -889,9 +874,9 @@ class AppTest extends TestCase
         });
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->group('/foo', function (App $app) use ($middlewareProphecy2, $middlewareProphecy3, &$output) {
-            $app->group('/bar', function (App $app) use ($middlewareProphecy3, &$output) {
-                $app->get('/baz', function (
+        $app->group('/foo', function (RouteCollectorProxy $proxy) use ($middlewareProphecy2, $middlewareProphecy3, &$output) {
+            $proxy->group('/bar', function (RouteCollectorProxy $proxy) use ($middlewareProphecy3, &$output) {
+                $proxy->get('/baz', function (
                     ServerRequestInterface $request,
                     ResponseInterface $response
                 ) use (&$output) {

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -751,7 +751,7 @@ class RouteTest extends TestCase
         $containerProphecy->has('CallableTest3')->willReturn(true);
         $containerProphecy->get('CallableTest3')->willReturn(new CallableTest());
         $containerProphecy->has('ClosureMiddleware')->willReturn(true);
-        $containerProphecy->get('ClosureMiddleware')->willReturn(function ($request, $handler) use ($responseFactoryProphecy) {
+        $containerProphecy->get('ClosureMiddleware')->willReturn(function () use ($responseFactoryProphecy) {
             $response = $responseFactoryProphecy->reveal()->createResponse();
             $response->getBody()->write('Hello');
             return $response;

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -415,7 +415,10 @@ class RouteTest extends TestCase
             ->willReturn(function (
                 ServerRequestInterface $request,
                 ResponseInterface $response
-            ) use ($self, $responseProphecy) {
+            ) use (
+                $self,
+                $responseProphecy
+) {
                 $self->assertSame($responseProphecy->reveal(), $response);
                 return $response;
             })


### PR DESCRIPTION
This is pull 7 out of 7 to complete the goals set in #2604

`App` now extends `RouteCollectorProxy` which provides all of the route mapping functionality. 

**`App::group()` Breaking Change**
There is a breaking change with `App::group()`. Now the callable gets a `RouteCollectorProxyInterface` instance injected which used to be `App`. All of the original route mapping functionality remains intact.

**The new interface implements the following methods**:
- `RouteCollectorProxy::getCallableResolver()`
- `RouteCollectorProxy::getContainer()`
- `RouteCollectorProxy::getRouteCollector()`
- `RouteCollectorProxy::get()`
- `RouteCollectorProxy::post()`
- `RouteCollectorProxy::put()`
- `RouteCollectorProxy::patch()`
- `RouteCollectorProxy::delete()`
- `RouteCollectorProxy::options()`
- `RouteCollectorProxy::any()`
- `RouteCollectorProxy::getBasePath()`
- `RouteCollectorProxy::setBasePath()`

**The following methods on `RouteCollectorInterface` are removed**:
- `RouteCollectorInterface::pushGroup()`
- `RouteCollectorInterface::popGroup()`

**The following method on `RouteCollectorInterface` is introduced**:
- `RouteCollectorInterface::group()` which replaces `pushGroup()` and `popGroup()`

**Example Usage**:
```php
use Slim\App;
use Slim\Http\Factory\DecoratedResponseFactory;
use Slim\Http\ServerRequest;
use Slim\Interfaces\RouteCollectorProxyInterface;
use Slim\Psr7\Factory\ResponseFactory;
use Slim\Psr7\Factory\ServerRequestFactory;
use Slim\Psr7\Factory\StreamFactory;

$responseFactory = new DecoratedResponseFactory(new ResponseFactory(), new StreamFactory());
$app = new App($responseFactory);

/**
 * As mentioned above, the breaking change introduced here is
 * that we don't inject App in the route group callable anymore.
 */
$app->group('/app', function (RouteCollectorProxyInterface $group) {
    $group->get('/hello/{name}', function ($request, $response, $args) {
        return $response;
    });
});

$request = new ServerRequest(ServerRequestFactory::createFromGlobals());
$app->run($request);
```