### PR TITLE
4.x - Inject Container Inside Middleware

### DIFF
--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -164,7 +164,9 @@ class MiddlewareDispatcher implements RequestHandlerInterface
                     }
                 }
                 if (is_subclass_of($resolved, MiddlewareInterface::class)) {
-                    return (new $resolved)->process($request, $this->next);
+                    /** @var MiddlewareInterface $resolved */
+                    $resolved = new $resolved($this->container);
+                    return $resolved->process($request, $this->next);
                 }
                 if (is_callable($resolved)) {
                     return $resolved($request, $this->next);

--- a/tests/Mocks/MockMiddlewareWithConstructor.php
+++ b/tests/Mocks/MockMiddlewareWithConstructor.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Slim\Tests\Mocks;
+
+use Prophecy\Prophet;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class MockMiddlewareWithConstructor implements MiddlewareInterface
+{
+    /**
+     * @var ContainerInterface|null
+     */
+    public static $container;
+
+    /**
+     * @param ContainerInterface|null $container
+     */
+    public function __construct(?ContainerInterface $container = null)
+    {
+        self::$container = $container;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $prophet = new Prophet();
+        $responseProphecy = $prophet->prophesize(ResponseInterface::class);
+        return $responseProphecy->reveal();
+    }
+}


### PR DESCRIPTION
Closes #2592 

When deferred middleware cannot be resolved via the container, it is instantiated with the container.