### PR TITLE
4.x - App Factory & ServerRequest Creator Auto-Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 4.0.0 - 2019-07-03
 
 ### Added
+- [#2642](https://github.com/slimphp/Slim/pull/2642) Add `AppFactory` to enable PSR-7 implementation and ServerRequest creator auto-detection.
 - [#2641](https://github.com/slimphp/Slim/pull/2641) Add `RouteCollectorProxyInterface` which extracts all the route mapping functionality from app into its own interface.
 - [#2640](https://github.com/slimphp/Slim/pull/2640) Add `RouteParserInterface` and decouple FastRoute route parser entirely from core. The methods `relativePathFor()`, `urlFor()` and `fullUrlFor()` are now located on this interface.
 - [#2639](https://github.com/slimphp/Slim/pull/2639) Add `DispatcherInterface` and decouple FastRoute dispatcher entirely from core. This enables us to swap out our router implementation for any other router.

--- a/README.md
+++ b/README.md
@@ -17,18 +17,49 @@ $ composer require "slim/slim:4.x-dev"
 
 This will install Slim and all required dependencies. Slim requires PHP 7.1 or newer.
 
-## Choose a PSR-7 Implementation
+## Choose a PSR-7 Implementation & ServerRequest Creator
 
 Before you can get up and running with Slim you will need to choose a PSR-7 implementation that best fits your application. A few notable ones:
-- [Nyholm/psr7](https://github.com/Nyholm/psr7) - This is the fastest, strictest and most lightweight implementation at the moment
-- [Guzzle/psr7](https://github.com/guzzle/psr7) - This is the implementation used by the Guzzle Client. It is not as strict but adds some nice functionality for Streams and file handling. It is the second fastest implementation but is a bit bulkier
-- [zend-diactoros](https://github.com/zendframework/zend-diactoros) - This is the Zend implementation. It is the slowest implementation of the 3.
 - [Slim-Psr7](https://github.com/slimphp/Slim-Psr7) - This is the Slim Framework projects PSR-7 implementation.
+- [Nyholm/psr7](https://github.com/Nyholm/psr7) & [Nyholm/psr7-server](https://github.com/Nyholm/psr7-server) - This is the fastest, strictest and most lightweight implementation at the moment
+- [Guzzle/psr7](https://github.com/guzzle/psr7) & [http-interop/http-factory-guzzle](https://github.com/http-interop/http-factory-guzzle) - This is the implementation used by the Guzzle Client. It is not as strict but adds some nice functionality for Streams and file handling. It is the second fastest implementation but is a bit bulkier
+- [zend-diactoros](https://github.com/zendframework/zend-diactoros) - This is the Zend implementation. It is the slowest implementation of the 3.
 
 
 ## Slim-Http Decorators
 
 [Slim-Http](https://github.com/slimphp/Slim-Http) is a set of decorators for any PSR-7 implementation that we recommend is used with Slim Framework.
+
+## Hello World using PSR-7 & ServerRequest creator auto detection
+In order for auto-detection to work and enable you to use `AppFactory::create()` and `App::run()` without having to manually create a `ServerRequest` you need to install one of the following implementations:
+- [Slim-Psr7](https://github.com/slimphp/Slim-Psr7) - Install using `composer require slim/psr7:dev-master`
+- [Nyholm/psr7](https://github.com/Nyholm/psr7) & [Nyholm/psr7-server](https://github.com/Nyholm/psr7-server) - Install using `composer require nyholm/psr-7 nyholm/psr7-server`
+- [Guzzle/psr7](https://github.com/guzzle/psr7) & [http-interop/http-factory-guzzle](https://github.com/http-interop/http-factory-guzzle) - `composer require guzzlehttp/psr7 http-interop/http-factory-guzzle`
+- [zend-diactoros](https://github.com/zendframework/zend-diactoros) - Install using `zendframework/zend-diactoros`
+
+```php
+<?php
+require 'vendor/autoload.php';
+
+use Slim\AppFactory;
+
+/**
+ * The AppFactory::create() method takes 5 optional parameters
+ * 
+ * @param ResponseFactoryInterface Any implementation of a ResponseFactory
+ * @param ContainerInterface|null Any implementation of a Container
+ * @param CallableResolverInterface|null Any implementation of a CallableResolver
+ * @param RouteCollectorInterface|null Any implementation of a RouteCollector
+ * @param RouteResolverInterface|null Any implementation of a RouteResolverInterface
+ */
+$app = AppFactory::create();
+$app->get('/hello/{name}', function ($request, $response, $args) {
+    $response->getBody()->write("Hello, " . $args['name']);
+    return $response;
+});
+
+$app->run();
+```
 
 ## Hello World with Slim-Http & Slim-Psr7
 
@@ -82,11 +113,12 @@ $serverRequestFactory = new ServerRequestCreator(
 
 /**
  * The App::__constructor() method takes 1 mandatory parameter and 4 optional parameters
+ * 
  * @param ResponseFactoryInterface Any implementation of a ResponseFactory
  * @param ContainerInterface|null Any implementation of a Container
- * @param array Settings array
  * @param CallableResolverInterface|null Any implementation of a CallableResolver
- * @param RouterInterface|null Any implementation of a Router
+ * @param RouteCollectorInterface|null Any implementation of a RouteCollector
+ * @param RouteResolverInterface|null Any implementation of a RouteResolverInterface
  */
 $app = new Slim\App($psr17Factory);
 $app->get('/hello/{name}', function ($request, $response, $args) {
@@ -96,6 +128,7 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
 
 /**
  * The App::run() method takes 1 parameter
+ * 
  * @param ServerRequestInterface An instantiation of a ServerRequest
  */
 $request = $serverRequestFactory->fromGlobals();
@@ -118,9 +151,9 @@ $serverRequestFactory = new ServerRequestFactory();
  * The App::__constructor() method takes 1 mandatory parameter and 4 optional parameters
  * @param ResponseFactoryInterface Any implementation of a ResponseFactory
  * @param ContainerInterface|null Any implementation of a Container
- * @param array Settings array
  * @param CallableResolverInterface|null Any implementation of a CallableResolver
- * @param RouterInterface|null Any implementation of a Router
+ * @param RouteCollectorInterface|null Any implementation of a RouteCollector
+ * @param RouteResolverInterface|null Any implementation of a RouteResolverInterface
  */
 $app = new Slim\App($responseFactory);
 $app->get('/hello/{name}', function ($request, $response, $args) {
@@ -131,6 +164,7 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
 /**
  * The App::handle() method takes 1 parameter
  * Note we are using handle() and not run() since we want to emit the response using Zend's Response Emitter
+ * 
  * @param ServerRequestInterface An instantiation of a ServerRequest
  */
 $request = ServerRequestFactory::fromGlobals();
@@ -165,11 +199,12 @@ $serverRequestFactory = new ServerRequestFactory();
  * The App::__constructor() method takes 1 mandatory parameter and 4 optional parameters
  * Note that we pass in the decorated response factory which will give us access to the Slim\Http
  * decorated Response methods like withJson()
+ * 
  * @param ResponseFactoryInterface Any implementation of a ResponseFactory
  * @param ContainerInterface|null Any implementation of a Container
- * @param array Settings array
  * @param CallableResolverInterface|null Any implementation of a CallableResolver
- * @param RouterInterface|null Any implementation of a Router
+ * @param RouteCollectorInterface|null Any implementation of a RouteCollector
+ * @param RouteResolverInterface|null Any implementation of a RouteResolverInterface
  */
 $app = new Slim\App($decoratedResponseFactory);
 $app->get('/hello/{name}', function ($request, $response, $args) {
@@ -180,6 +215,7 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
  * The App::run() method takes 1 parameter
  * Note that we pass in the decorated server request object which will give us access to the Slim\Http
  * decorated ServerRequest methods like withRedirect()
+ * 
  * @param ServerRequestInterface An instantiation of a ServerRequest
  */
 $request = ServerRequestFactory::fromGlobals();
@@ -199,11 +235,12 @@ $responseFactory = new ResponseFactory();
 
 /**
  * The App::__constructor() method takes 1 mandatory parameter and 4 optional parameters
+ * 
  * @param ResponseFactoryInterface Any implementation of a ResponseFactory
  * @param ContainerInterface|null Any implementation of a Container
- * @param array Settings array
  * @param CallableResolverInterface|null Any implementation of a CallableResolver
- * @param RouterInterface|null Any implementation of a Router
+ * @param RouteCollectorInterface|null Any implementation of a RouteCollector
+ * @param RouteResolverInterface|null Any implementation of a RouteResolverInterface
  */
 $app = new Slim\App($responseFactory);
 $app->get('/hello/{name}', function ($request, $response, $args) {
@@ -213,6 +250,7 @@ $app->get('/hello/{name}', function ($request, $response, $args) {
 
 /**
  * The App::run() method takes 1 parameter
+ * 
  * @param ServerRequestInterface An instantiation of a ServerRequest
  */
 $request = ServerRequest::fromGlobals();

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Factory\ServerRequestCreatorFactory;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteResolverInterface;
@@ -25,7 +26,6 @@ use Slim\Routing\RouteRunner;
 /**
  * This is the primary class with which you instantiate,
  * configure, and run a Slim Framework application.
- * The \Slim\App class also accepts Slim Framework middleware.
  */
 class App extends RouteCollectorProxy implements RequestHandlerInterface
 {
@@ -107,11 +107,16 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
      * This method traverses the application middleware stack and then sends the
      * resultant Response object to the HTTP client.
      *
-     * @param ServerRequestInterface $request
+     * @param ServerRequestInterface|null $request
      * @return void
      */
-    public function run(ServerRequestInterface $request): void
+    public function run(ServerRequestInterface $request = null): void
     {
+        if (!$request) {
+            $serverRequestCreator = ServerRequestCreatorFactory::create();
+            $request = $serverRequestCreator->createServerRequestFromGlobals();
+        }
+
         $response = $this->handle($request);
         $responseEmitter = new ResponseEmitter();
         $responseEmitter->emit($response);

--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Factory;
+
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
+use RuntimeException;
+use Slim\App;
+use Slim\Factory\Psr17\GuzzlePsr17Factory;
+use Slim\Factory\Psr17\NyholmPsr17Factory;
+use Slim\Factory\Psr17\Psr17Factory;
+use Slim\Factory\Psr17\SlimPsr17Factory;
+use Slim\Factory\Psr17\ZendDiactorosPsr17Factory;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Interfaces\RouteResolverInterface;
+
+class AppFactory
+{
+    /**
+     * @var array
+     */
+    protected static $implementations = [
+        SlimPsr17Factory::class,
+        NyholmPsr17Factory::class,
+        ZendDiactorosPsr17Factory::class,
+        GuzzlePsr17Factory::class,
+    ];
+
+    /**
+     * @return ResponseFactoryInterface
+     * @throws RuntimeException
+     */
+    public static function determineResponseFactory(): ResponseFactoryInterface
+    {
+        /** @var Psr17Factory $implementation */
+        foreach (self::$implementations as $implementation) {
+            if ($implementation::isResponseFactoryAvailable()) {
+                return $implementation::getResponseFactory();
+            }
+        }
+
+        throw new RuntimeException('Could not detect any PSR-17 ResponseFactory implementations.');
+    }
+
+    /**
+     * @param ResponseFactoryInterface|null  $responseFactory
+     * @param ContainerInterface|null        $container
+     * @param CallableResolverInterface|null $callableResolver
+     * @param RouteCollectorInterface|null   $routeCollector
+     * @param RouteResolverInterface|null    $routeResolver
+     * @return App
+     */
+    public static function create(
+        ResponseFactoryInterface $responseFactory = null,
+        ContainerInterface $container = null,
+        CallableResolverInterface $callableResolver = null,
+        RouteCollectorInterface $routeCollector = null,
+        RouteResolverInterface $routeResolver = null
+    ): App {
+        $responseFactory = $responseFactory ?? self::determineResponseFactory();
+        return new App(
+            $responseFactory,
+            $container,
+            $callableResolver,
+            $routeCollector,
+            $routeResolver
+        );
+    }
+}

--- a/Slim/Factory/Psr17/GuzzlePsr17Factory.php
+++ b/Slim/Factory/Psr17/GuzzlePsr17Factory.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Factory\Psr17;
+
+class GuzzlePsr17Factory extends Psr17Factory
+{
+    protected static $responseFactoryClass = 'Http\Factory\Guzzle\ResponseFactory';
+    protected static $serverRequestCreatorClass = 'GuzzleHttp\Psr7\ServerRequest';
+    protected static $serverRequestCreatorMethod = 'fromGlobals';
+}

--- a/Slim/Factory/Psr17/NyholmPsr17Factory.php
+++ b/Slim/Factory/Psr17/NyholmPsr17Factory.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Slim\Factory\Psr17;
+
+use Slim\Interfaces\ServerRequestCreatorInterface;
+
+class NyholmPsr17Factory extends Psr17Factory
+{
+    protected static $responseFactoryClass = 'Nyholm\Psr7\Factory\Psr17Factory';
+    protected static $serverRequestCreatorClass = 'Nyholm\Psr7Server\ServerRequestCreator';
+    protected static $serverRequestCreatorMethod = 'fromGlobals';
+
+    public static function getServerRequestCreator(): ServerRequestCreatorInterface
+    {
+        /*
+         * Nyholm Psr17Factory implements all factories in one unified
+         * factory which implements all of the PSR-17 factory interfaces
+         */
+        $psr17Factory = new static::$responseFactoryClass;
+
+        $serverRequestCreator = new static::$serverRequestCreatorClass(
+            $psr17Factory,
+            $psr17Factory,
+            $psr17Factory,
+            $psr17Factory
+        );
+
+        return new ServerRequestCreator($serverRequestCreator, static::$serverRequestCreatorMethod);
+    }
+}

--- a/Slim/Factory/Psr17/Psr17Factory.php
+++ b/Slim/Factory/Psr17/Psr17Factory.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Factory\Psr17;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Slim\Interfaces\Psr17FactoryInterface;
+use Slim\Interfaces\ServerRequestCreatorInterface;
+
+abstract class Psr17Factory implements Psr17FactoryInterface
+{
+    /**
+     * @var string
+     */
+    protected static $responseFactoryClass;
+
+    /**
+     * @var string
+     */
+    protected static $serverRequestCreatorClass;
+
+    /**
+     * @var string
+     */
+    protected static $serverRequestCreatorMethod;
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getResponseFactory(): ResponseFactoryInterface
+    {
+        return new static::$responseFactoryClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getServerRequestCreator(): ServerRequestCreatorInterface
+    {
+        return new ServerRequestCreator(static::$serverRequestCreatorClass, static::$serverRequestCreatorMethod);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function isResponseFactoryAvailable(): bool
+    {
+        return class_exists(static::$responseFactoryClass);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function isServerRequestCreatorAvailable(): bool
+    {
+        return class_exists(static::$serverRequestCreatorClass);
+    }
+}

--- a/Slim/Factory/Psr17/ServerRequestCreator.php
+++ b/Slim/Factory/Psr17/ServerRequestCreator.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Factory\Psr17;
+
+use Closure;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Interfaces\ServerRequestCreatorInterface;
+
+class ServerRequestCreator implements ServerRequestCreatorInterface
+{
+    /**
+     * @var object|string
+     */
+    protected $serverRequestCreator;
+
+    /**
+     * @var string
+     */
+    protected $serverRequestCreatorMethod;
+
+    /**
+     * @param object|string     $serverRequestCreator
+     * @param string            $serverRequestCreatorMethod
+     */
+    public function __construct($serverRequestCreator, string $serverRequestCreatorMethod) {
+        $this->serverRequestCreator= $serverRequestCreator;
+        $this->serverRequestCreatorMethod = $serverRequestCreatorMethod;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createServerRequestFromGlobals(): ServerRequestInterface
+    {
+        $callable = Closure::fromCallable([$this->serverRequestCreator, $this->serverRequestCreatorMethod]);
+        return $callable();
+    }
+}

--- a/Slim/Factory/Psr17/ServerRequestCreator.php
+++ b/Slim/Factory/Psr17/ServerRequestCreator.php
@@ -40,7 +40,8 @@ class ServerRequestCreator implements ServerRequestCreatorInterface
      */
     public function createServerRequestFromGlobals(): ServerRequestInterface
     {
-        $callable = Closure::fromCallable([$this->serverRequestCreator, $this->serverRequestCreatorMethod]);
-        return $callable();
+        /** @var callable $callable */
+        $callable = [$this->serverRequestCreator, $this->serverRequestCreatorMethod];
+        return (Closure::fromCallable($callable))();
     }
 }

--- a/Slim/Factory/Psr17/ServerRequestCreator.php
+++ b/Slim/Factory/Psr17/ServerRequestCreator.php
@@ -29,7 +29,8 @@ class ServerRequestCreator implements ServerRequestCreatorInterface
      * @param object|string     $serverRequestCreator
      * @param string            $serverRequestCreatorMethod
      */
-    public function __construct($serverRequestCreator, string $serverRequestCreatorMethod) {
+    public function __construct($serverRequestCreator, string $serverRequestCreatorMethod)
+    {
         $this->serverRequestCreator= $serverRequestCreator;
         $this->serverRequestCreatorMethod = $serverRequestCreatorMethod;
     }

--- a/Slim/Factory/Psr17/SlimPsr17Factory.php
+++ b/Slim/Factory/Psr17/SlimPsr17Factory.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Factory\Psr17;
+
+class SlimPsr17Factory extends Psr17Factory
+{
+    protected static $responseFactoryClass = 'Slim\Psr7\Factory\ResponseFactory';
+    protected static $serverRequestCreatorClass = 'Slim\Psr7\Factory\ServerRequestFactory';
+    protected static $serverRequestCreatorMethod = 'createFromGlobals';
+}

--- a/Slim/Factory/Psr17/ZendDiactorosPsr17Factory.php
+++ b/Slim/Factory/Psr17/ZendDiactorosPsr17Factory.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Factory\Psr17;
+
+class ZendDiactorosPsr17Factory extends Psr17Factory
+{
+    protected static $responseFactoryClass = 'Zend\Diactoros\ResponseFactory';
+    protected static $serverRequestCreatorClass = 'Zend\Diactoros\ServerRequestFactory';
+    protected static $serverRequestCreatorMethod = 'fromGlobals';
+}

--- a/Slim/Factory/ServerRequestCreatorFactory.php
+++ b/Slim/Factory/ServerRequestCreatorFactory.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Factory;
+
+use RuntimeException;
+use Slim\Factory\Psr17\GuzzlePsr17Factory;
+use Slim\Factory\Psr17\NyholmPsr17Factory;
+use Slim\Factory\Psr17\Psr17Factory;
+use Slim\Factory\Psr17\SlimPsr17Factory;
+use Slim\Factory\Psr17\ZendDiactorosPsr17Factory;
+use Slim\Interfaces\ServerRequestCreatorInterface;
+
+class ServerRequestCreatorFactory
+{
+    /**
+     * @var array
+     */
+    protected static $implementations = [
+        SlimPsr17Factory::class,
+        NyholmPsr17Factory::class,
+        ZendDiactorosPsr17Factory::class,
+        GuzzlePsr17Factory::class,
+    ];
+
+    /**
+     * @return ServerRequestCreatorInterface
+     * @throws RuntimeException
+     */
+    public static function determineServerRequestCreator(): ServerRequestCreatorInterface
+    {
+        /** @var Psr17Factory $implementation */
+        foreach (self::$implementations as $implementation) {
+            if ($implementation::isServerRequestCreatorAvailable()) {
+                return $implementation::getServerRequestCreator();
+            }
+        }
+
+        throw new RuntimeException('Could not detect any ServerRequest creator implementations.');
+    }
+
+    /**
+     * @return ServerRequestCreatorInterface
+     */
+    public static function create(): ServerRequestCreatorInterface
+    {
+        return static::determineServerRequestCreator();
+    }
+}

--- a/Slim/Interfaces/Psr17FactoryInterface.php
+++ b/Slim/Interfaces/Psr17FactoryInterface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Interfaces;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+
+interface Psr17FactoryInterface
+{
+    /**
+     * @return ResponseFactoryInterface
+     */
+    public static function getResponseFactory(): ResponseFactoryInterface;
+
+    /**
+     * @return ServerRequestCreatorInterface
+     */
+    public static function getServerRequestCreator(): ServerRequestCreatorInterface;
+
+    /**
+     * Is the PSR-17 ResponseFactory available
+     *
+     * @return bool
+     */
+    public static function isResponseFactoryAvailable(): bool;
+
+    /**
+     * Is the ServerRequest creator available
+     *
+     * @return bool
+     */
+    public static function isServerRequestCreatorAvailable(): bool;
+}

--- a/Slim/Interfaces/ServerRequestCreatorInterface.php
+++ b/Slim/Interfaces/ServerRequestCreatorInterface.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Interfaces;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+interface ServerRequestCreatorInterface
+{
+    /**
+     * @return ServerRequestInterface
+     */
+    public function createServerRequestFromGlobals(): ServerRequestInterface;
+}

--- a/composer.json
+++ b/composer.json
@@ -44,11 +44,16 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
+        "guzzlehttp/psr7": "^1.5",
+        "http-interop/http-factory-guzzle": "^1.0",
         "nyholm/psr7": "^1.1",
+        "nyholm/psr7-server": "^0.3.0",
         "phpunit/phpunit": "^7.5",
         "phpspec/prophecy": "^1.8",
         "phpstan/phpstan": "^0.11.5",
-        "squizlabs/php_codesniffer": "^3.4.2"
+        "slim/psr7": "dev-master",
+        "squizlabs/php_codesniffer": "^3.4.2",
+        "zendframework/zend-diactoros": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Factory;
+
+use Http\Factory\Guzzle\ResponseFactory as GuzzleResponseFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use ReflectionProperty;
+use Slim\Factory\AppFactory;
+use Slim\Factory\Psr17\GuzzlePsr17Factory;
+use Slim\Factory\Psr17\NyholmPsr17Factory;
+use Slim\Factory\Psr17\SlimPsr17Factory;
+use Slim\Factory\Psr17\ZendDiactorosPsr17Factory;
+use Slim\Psr7\Factory\ResponseFactory as SlimResponseFactory;
+use Slim\Routing\RouteCollector;
+use Slim\Tests\TestCase;
+use Zend\Diactoros\ResponseFactory as ZendDiactorosResponseFactory;
+
+class AppFactoryTest extends TestCase
+{
+    public function provideImplementations()
+    {
+        return [
+            [SlimPsr17Factory::class, SlimResponseFactory::class],
+            [NyholmPsr17Factory::class, Psr17Factory::class],
+            [GuzzlePsr17Factory::class, GuzzleResponseFactory::class],
+            [ZendDiactorosPsr17Factory::class, ZendDiactorosResponseFactory::class],
+        ];
+    }
+
+    /**
+     * @dataProvider provideImplementations
+     * @param string $implementation
+     * @param string $expectedResponseFactoryClass
+     */
+    public function testCreateAppWithAllImplementations(string $implementation, string $expectedResponseFactoryClass)
+    {
+        $implementationsProperty = new ReflectionProperty(AppFactory::class, 'implementations');
+        $implementationsProperty->setAccessible(true);
+        $implementationsProperty->setValue([$implementation]);
+
+        $app = AppFactory::create();
+
+        $routeCollector = $app->getRouteCollector();
+
+        $responseFactoryProperty = new ReflectionProperty(RouteCollector::class, 'responseFactory');
+        $responseFactoryProperty->setAccessible(true);
+
+        $responseFactory = $responseFactoryProperty->getValue($routeCollector);
+
+        $this->assertInstanceOf($expectedResponseFactoryClass, $responseFactory);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testDetermineResponseFactoryThrowsRuntimeException()
+    {
+        $implementationsProperty = new ReflectionProperty(AppFactory::class, 'implementations');
+        $implementationsProperty->setAccessible(true);
+        $implementationsProperty->setValue([]);
+
+        AppFactory::create();
+    }
+}

--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Factory;
+
+use GuzzleHttp\Psr7\ServerRequest as GuzzleServerRequest;
+use Nyholm\Psr7\ServerRequest as NyholmServerRequest;
+use ReflectionProperty;
+use Slim\Factory\Psr17\GuzzlePsr17Factory;
+use Slim\Factory\Psr17\NyholmPsr17Factory;
+use Slim\Factory\Psr17\SlimPsr17Factory;
+use Slim\Factory\Psr17\ZendDiactorosPsr17Factory;
+use Slim\Factory\ServerRequestCreatorFactory;
+use Slim\Psr7\Request as SlimServerRequest;
+use Slim\Tests\TestCase;
+use Zend\Diactoros\ServerRequest as ZendServerRequest;
+
+class ServerRequestCreatorFactoryTest extends TestCase
+{
+    public function provideImplementations()
+    {
+        return [
+            [SlimPsr17Factory::class, SlimServerRequest::class],
+            [NyholmPsr17Factory::class, NyholmServerRequest::class],
+            [GuzzlePsr17Factory::class, GuzzleServerRequest::class],
+            [ZendDiactorosPsr17Factory::class, ZendServerRequest::class],
+        ];
+    }
+
+    /**
+     * @dataProvider provideImplementations
+     * @param string $implementation
+     * @param string $expectedServerRequestClass
+     */
+    public function testCreateAppWithAllImplementations(string $implementation, string $expectedServerRequestClass)
+    {
+        $implementationsProperty = new ReflectionProperty(ServerRequestCreatorFactory::class, 'implementations');
+        $implementationsProperty->setAccessible(true);
+        $implementationsProperty->setValue([$implementation]);
+
+        $serverRequestCreator = ServerRequestCreatorFactory::create();
+        $serverRequest = $serverRequestCreator->createServerRequestFromGlobals();
+
+        $this->assertInstanceOf($expectedServerRequestClass, $serverRequest);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testDetermineServerRequestCreatorThrowsRuntimeException()
+    {
+        $implementationsProperty = new ReflectionProperty(ServerRequestCreatorFactory::class, 'implementations');
+        $implementationsProperty->setAccessible(true);
+        $implementationsProperty->setValue([]);
+
+        ServerRequestCreatorFactory::create();
+    }
+}


### PR DESCRIPTION
This PR introduces `AppFactory` which enables you to create an app without having to create `ResponseFactory` and also gives the ability to the end user to run the app without having to manually create a `ServerRequest` given that they have installed one of the supported PSR-7 implementations / ServerRequest creator combos.

**In order for auto-detection to work you need to install one of the following supported combos:**
- [Slim-Psr7](https://github.com/slimphp/Slim-Psr7) - Install using `composer require slim/psr7:dev-master`
- [Nyholm/psr7](https://github.com/Nyholm/psr7) & [Nyholm/psr7-server](https://github.com/Nyholm/psr7-server) - Install using `composer require nyholm/psr-7 nyholm/psr7-server`
- [Guzzle/psr7](https://github.com/guzzle/psr7) & [http-interop/http-factory-guzzle](https://github.com/http-interop/http-factory-guzzle) - `composer require guzzlehttp/psr7 http-interop/http-factory-guzzle`
- [zend-diactoros](https://github.com/zendframework/zend-diactoros) - Install using `zendframework/zend-diactoros`

## Hello World using PSR-7 & ServerRequest creator auto-detection
```php
<?php
require 'vendor/autoload.php';

use Slim\AppFactory;

/**
 * The AppFactory::create() method takes 5 optional parameters
 * 
 * @param ResponseFactoryInterface Any implementation of a ResponseFactory
 * @param ContainerInterface|null Any implementation of a Container
 * @param CallableResolverInterface|null Any implementation of a CallableResolver
 * @param RouteCollectorInterface|null Any implementation of a RouteCollector
 * @param RouteResolverInterface|null Any implementation of a RouteResolverInterface
 */
$app = AppFactory::create();
$app->get('/hello/{name}', function ($request, $response, $args) {
    $response->getBody()->write("Hello, " . $args['name']);
    return $response;
});

$app->run();
```

Closes #2621