### PR TITLE
4.x - Add ResponseFactory Getter To RouteCollectorProxyInterface

### DIFF
--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -10,10 +10,16 @@ declare(strict_types=1);
 namespace Slim\Interfaces;
 
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
 interface RouteCollectorProxyInterface
 {
+    /**
+     * @return ResponseFactoryInterface
+     */
+    public function getResponseFactory(): ResponseFactoryInterface;
+
     /**
      * @return CallableResolverInterface
      */

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -69,6 +69,14 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    public function getResponseFactory(): ResponseFactoryInterface
+    {
+        return $this->responseFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getCallableResolver(): CallableResolverInterface
     {
         return $this->callableResolver;

--- a/tests/Routing/RouteCollectorProxyTest.php
+++ b/tests/Routing/RouteCollectorProxyTest.php
@@ -22,6 +22,22 @@ use Slim\Tests\TestCase;
 
 class RouteCollectorProxyTest extends TestCase
 {
+    public function testGetResponseFactory()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $routeCollectorProxy = new RouteCollectorProxy(
+            $responseFactoryProphecy->reveal(),
+            $callableResolverProphecy->reveal()
+        );
+
+        $this->assertSame(
+            $responseFactoryProphecy->reveal(),
+            $routeCollectorProxy->getResponseFactory()
+        );
+    }
+
     public function testGetCallableResolver()
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);


### PR DESCRIPTION
Add method `getResponseFactory()` to `RouteCollectorProxyInterface` for better user experience when instantiating middleware outside the app and being able to retrieve the detected `ResponseFactory`