### PR TITLE
4.x - Add Default Constructor Argument Setters To AppFactory

### DIFF
--- a/Slim/Factory/ServerRequestCreatorFactory.php
+++ b/Slim/Factory/ServerRequestCreatorFactory.php
@@ -52,7 +52,8 @@ class ServerRequestCreatorFactory
 
         throw new RuntimeException(
             "Could not detect any ServerRequest creator implementations. " .
-            "Please install a supported implementation in order to use `App::run()` without having to pass in a `ServerRequest` object. " .
+            "Please install a supported implementation in order to use `App::run()` " .
+            "without having to pass in a `ServerRequest` object. " .
             "See https://github.com/slimphp/Slim/blob/4.x/README.md for a list of supported implementations."
         );
     }

--- a/Slim/Factory/ServerRequestCreatorFactory.php
+++ b/Slim/Factory/ServerRequestCreatorFactory.php
@@ -22,7 +22,7 @@ class ServerRequestCreatorFactory
     /**
      * @var array
      */
-    protected static $implementations = [
+    protected static $psr17Factories = [
         SlimPsr17Factory::class,
         NyholmPsr17Factory::class,
         ZendDiactorosPsr17Factory::class,
@@ -43,13 +43,17 @@ class ServerRequestCreatorFactory
      */
     public static function determineServerRequestCreator(): ServerRequestCreatorInterface
     {
-        /** @var Psr17Factory $implementation */
-        foreach (self::$implementations as $implementation) {
-            if ($implementation::isServerRequestCreatorAvailable()) {
-                return $implementation::getServerRequestCreator();
+        /** @var Psr17Factory $psr17Factory */
+        foreach (self::$psr17Factories as $psr17Factory) {
+            if ($psr17Factory::isServerRequestCreatorAvailable()) {
+                return $psr17Factory::getServerRequestCreator();
             }
         }
 
-        throw new RuntimeException('Could not detect any ServerRequest creator implementations.');
+        throw new RuntimeException(
+            "Could not detect any ServerRequest creator implementations. " .
+            "Please install a supported implementation in order to use `App::run()` without having to pass in a `ServerRequest` object. " .
+            "See https://github.com/slimphp/Slim/blob/4.x/README.md for a list of supported implementations."
+        );
     }
 }

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -91,8 +91,8 @@ class AppFactoryTest extends TestCase
         $app = AppFactory::create();
 
         $this->assertSame(
-          $responseFactoryProphecy->reveal(),
-          $app->getResponseFactory()
+            $responseFactoryProphecy->reveal(),
+            $app->getResponseFactory()
         );
 
         $this->assertSame(

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -11,12 +11,17 @@ namespace Slim\Tests\Factory;
 
 use Http\Factory\Guzzle\ResponseFactory as GuzzleResponseFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use ReflectionProperty;
 use Slim\Factory\AppFactory;
 use Slim\Factory\Psr17\GuzzlePsr17Factory;
 use Slim\Factory\Psr17\NyholmPsr17Factory;
 use Slim\Factory\Psr17\SlimPsr17Factory;
 use Slim\Factory\Psr17\ZendDiactorosPsr17Factory;
+use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Interfaces\RouteResolverInterface;
 use Slim\Psr7\Factory\ResponseFactory as SlimResponseFactory;
 use Slim\Routing\RouteCollector;
 use Slim\Tests\TestCase;
@@ -36,14 +41,14 @@ class AppFactoryTest extends TestCase
 
     /**
      * @dataProvider provideImplementations
-     * @param string $implementation
+     * @param string $psr17factory
      * @param string $expectedResponseFactoryClass
      */
-    public function testCreateAppWithAllImplementations(string $implementation, string $expectedResponseFactoryClass)
+    public function testCreateAppWithAllImplementations(string $psr17factory, string $expectedResponseFactoryClass)
     {
-        $implementationsProperty = new ReflectionProperty(AppFactory::class, 'implementations');
-        $implementationsProperty->setAccessible(true);
-        $implementationsProperty->setValue([$implementation]);
+        $psr17FactoriesProperty = new ReflectionProperty(AppFactory::class, 'psr17Factories');
+        $psr17FactoriesProperty->setAccessible(true);
+        $psr17FactoriesProperty->setValue([$psr17factory]);
 
         $app = AppFactory::create();
 
@@ -62,10 +67,94 @@ class AppFactoryTest extends TestCase
      */
     public function testDetermineResponseFactoryThrowsRuntimeException()
     {
-        $implementationsProperty = new ReflectionProperty(AppFactory::class, 'implementations');
-        $implementationsProperty->setAccessible(true);
-        $implementationsProperty->setValue([]);
+        $psr17FactoriesProperty = new ReflectionProperty(AppFactory::class, 'psr17Factories');
+        $psr17FactoriesProperty->setAccessible(true);
+        $psr17FactoriesProperty->setValue([]);
 
         AppFactory::create();
+    }
+
+    public function testAppIsCreatedWithInstancesFromSetters()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+        $routeResolverProphecy = $this->prophesize(RouteResolverInterface::class);
+
+        AppFactory::setResponseFactory($responseFactoryProphecy->reveal());
+        AppFactory::setContainer($containerProphecy->reveal());
+        AppFactory::setCallableResolver($callableResolverProphecy->reveal());
+        AppFactory::setRouteCollector($routeCollectorProphecy->reveal());
+        AppFactory::setRouteResolver($routeResolverProphecy->reveal());
+
+        $app = AppFactory::create();
+
+        $this->assertSame(
+          $responseFactoryProphecy->reveal(),
+          $app->getResponseFactory()
+        );
+
+        $this->assertSame(
+            $containerProphecy->reveal(),
+            $app->getContainer()
+        );
+
+        $this->assertSame(
+            $callableResolverProphecy->reveal(),
+            $app->getCallableResolver()
+        );
+
+        $this->assertSame(
+            $routeCollectorProphecy->reveal(),
+            $app->getRouteCollector()
+        );
+
+        $this->assertSame(
+            $routeResolverProphecy->reveal(),
+            $app->getRouteResolver()
+        );
+    }
+
+    public function testAppIsCreatedWithInjectedInstancesFromFunctionArguments()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+        $routeResolverProphecy = $this->prophesize(RouteResolverInterface::class);
+
+        $app = AppFactory::create(
+            $responseFactoryProphecy->reveal(),
+            $containerProphecy->reveal(),
+            $callableResolverProphecy->reveal(),
+            $routeCollectorProphecy->reveal(),
+            $routeResolverProphecy->reveal()
+        );
+
+        $this->assertSame(
+            $responseFactoryProphecy->reveal(),
+            $app->getResponseFactory()
+        );
+
+        $this->assertSame(
+            $containerProphecy->reveal(),
+            $app->getContainer()
+        );
+
+        $this->assertSame(
+            $callableResolverProphecy->reveal(),
+            $app->getCallableResolver()
+        );
+
+        $this->assertSame(
+            $routeCollectorProphecy->reveal(),
+            $app->getRouteCollector()
+        );
+
+        $this->assertSame(
+            $routeResolverProphecy->reveal(),
+            $app->getRouteResolver()
+        );
     }
 }

--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -35,14 +35,14 @@ class ServerRequestCreatorFactoryTest extends TestCase
 
     /**
      * @dataProvider provideImplementations
-     * @param string $implementation
+     * @param string $psr17factory
      * @param string $expectedServerRequestClass
      */
-    public function testCreateAppWithAllImplementations(string $implementation, string $expectedServerRequestClass)
+    public function testCreateAppWithAllImplementations(string $psr17factory, string $expectedServerRequestClass)
     {
-        $implementationsProperty = new ReflectionProperty(ServerRequestCreatorFactory::class, 'implementations');
-        $implementationsProperty->setAccessible(true);
-        $implementationsProperty->setValue([$implementation]);
+        $psr17FactoriesProperty = new ReflectionProperty(ServerRequestCreatorFactory::class, 'psr17Factories');
+        $psr17FactoriesProperty->setAccessible(true);
+        $psr17FactoriesProperty->setValue([$psr17factory]);
 
         $serverRequestCreator = ServerRequestCreatorFactory::create();
         $serverRequest = $serverRequestCreator->createServerRequestFromGlobals();
@@ -55,9 +55,9 @@ class ServerRequestCreatorFactoryTest extends TestCase
      */
     public function testDetermineServerRequestCreatorThrowsRuntimeException()
     {
-        $implementationsProperty = new ReflectionProperty(ServerRequestCreatorFactory::class, 'implementations');
-        $implementationsProperty->setAccessible(true);
-        $implementationsProperty->setValue([]);
+        $psr17FactoriesProperty = new ReflectionProperty(ServerRequestCreatorFactory::class, 'psr17Factories');
+        $psr17FactoriesProperty->setAccessible(true);
+        $psr17FactoriesProperty->setValue([]);
 
         ServerRequestCreatorFactory::create();
     }


### PR DESCRIPTION
This PR adds the ability to set the default constructor arguments for the created `App` component when using `AppFactory::create()`.

**The following methods are added on AppFactory:**
- `AppFactory::setResponseFactory()` - Set the ResponseFactory used to create `App`
- `AppFactory::setContainer()` - Set the Container used to create `App`
- `AppFactory::setCallableResolver()` - Set the CallableResolver used to create `App`
- `AppFactory::setRouteCollector()` - Set the RouteCollector used to create `App`
- `AppFactory::setRouteResolver()` - Set the RouteResolver used to create `App`

This PR also adds more descriptive messages to the errors thrown by `AppFactory` and `ServerRequestCreatorFactory` when a PSR-7/Server Request Creator implementation cannot be detected.