### PR TITLE
4.x - Fix For RouteCollector::group() Nesting Bug

### DIFF
--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -36,6 +36,22 @@ interface RouteCollectorProxyInterface
     public function getRouteCollector(): RouteCollectorInterface;
 
     /**
+     * Get the RouteCollectorProxy's base path
+     *
+     * @return string
+     */
+    public function getBasePath(): string;
+
+    /**
+     * Set the RouteCollectorProxy's base path
+     *
+     * @param string $basePath
+     *
+     * @return RouteCollectorProxyInterface
+     */
+    public function setBasePath(string $basePath): RouteCollectorProxyInterface;
+
+    /**
      * Add GET route
      *
      * @param  string          $pattern  The route URI pattern
@@ -117,17 +133,6 @@ interface RouteCollectorProxyInterface
     public function map(array $methods, string $pattern, $callable): RouteInterface;
 
     /**
-     * Add a route that sends an HTTP redirect
-     *
-     * @param string              $from
-     * @param string|UriInterface $to
-     * @param int                 $status
-     *
-     * @return RouteInterface
-     */
-    public function redirect(string $from, $to, int $status = 302): RouteInterface;
-
-    /**
      * Route Groups
      *
      * This method accepts a route pattern and a callback. All route
@@ -142,18 +147,13 @@ interface RouteCollectorProxyInterface
     public function group(string $pattern, $callable): RouteGroupInterface;
 
     /**
-     * Get the RouteCollectorProxy's base path
+     * Add a route that sends an HTTP redirect
      *
-     * @return string
+     * @param string              $from
+     * @param string|UriInterface $to
+     * @param int                 $status
+     *
+     * @return RouteInterface
      */
-    public function getBasePath(): string;
-
-    /**
-     * Set the RouteCollectorProxy's base path
-     *
-     * @param string $basePath
-     *
-     * @return RouteCollectorProxyInterface
-     */
-    public function setBasePath(string $basePath): RouteCollectorProxyInterface;
+    public function redirect(string $from, $to, int $status = 302): RouteInterface;
 }

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -238,7 +238,8 @@ class RouteCollector implements RouteCollectorInterface
             $this->responseFactory,
             $this->callableResolver,
             $this->container,
-            $this
+            $this,
+            $pattern
         );
 
         $routeGroup = new RouteGroup($pattern, $callable, $this->callableResolver, $routeCollectorProxy);
@@ -255,32 +256,12 @@ class RouteCollector implements RouteCollectorInterface
      */
     public function map(array $methods, string $pattern, $handler): RouteInterface
     {
-        // Prepend parent group pattern(s)
-        if ($this->routeGroups) {
-            $pattern = $this->computeRoutePatternPrefix() . $pattern;
-        }
 
         $route = $this->createRoute($methods, $pattern, $handler);
         $this->routes[$route->getIdentifier()] = $route;
         $this->routeCounter++;
 
         return $route;
-    }
-
-    /**
-     * Process current route groups and compute the pattern
-     * that will prefix all subsequent routes being added while processing
-     * the current route group
-     *
-     * @return string
-     */
-    protected function computeRoutePatternPrefix(): string
-    {
-        $pattern = '';
-        foreach ($this->routeGroups as $group) {
-            $pattern .= $group->getPattern();
-        }
-        return $pattern;
     }
 
     /**

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -118,23 +118,17 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
-    public function post(string $pattern, $callable): RouteInterface
+    public function get(string $pattern, $callable): RouteInterface
     {
-        return $this->map(['POST'], $pattern, $callable);
+        return $this->map(['GET'], $pattern, $callable);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function map(array $methods, string $pattern, $callable): RouteInterface
+    public function post(string $pattern, $callable): RouteInterface
     {
-        $pattern = $this->basePath . $pattern;
-
-        if ($this->container && $callable instanceof Closure) {
-            $callable = $callable->bindTo($this->container);
-        }
-
-        return $this->routeCollector->map($methods, $pattern, $callable);
+        return $this->map(['POST'], $pattern, $callable);
     }
 
     /**
@@ -180,22 +174,15 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
-    public function redirect(string $from, $to, int $status = 302): RouteInterface
+    public function map(array $methods, string $pattern, $callable): RouteInterface
     {
-        $handler = function () use ($to, $status) {
-            $response = $this->responseFactory->createResponse($status);
-            return $response->withHeader('Location', (string) $to);
-        };
+        $pattern = $this->basePath . $pattern;
 
-        return $this->get($from, $handler);
-    }
+        if ($this->container && $callable instanceof Closure) {
+            $callable = $callable->bindTo($this->container);
+        }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function get(string $pattern, $callable): RouteInterface
-    {
-        return $this->map(['GET'], $pattern, $callable);
+        return $this->routeCollector->map($methods, $pattern, $callable);
     }
 
     /**
@@ -205,5 +192,18 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     {
         $pattern = $this->basePath . $pattern;
         return $this->routeCollector->group($pattern, $callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function redirect(string $from, $to, int $status = 302): RouteInterface
+    {
+        $handler = function () use ($to, $status) {
+            $response = $this->responseFactory->createResponse($status);
+            return $response->withHeader('Location', (string) $to);
+        };
+
+        return $this->get($from, $handler);
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.7/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.1/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="true"

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -505,7 +505,7 @@ class AppTest extends TestCase
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $app = new App($responseFactoryProphecy->reveal());
 
-        $processSequence = function (App $app, array $sequence, $processSequence) {
+        $processSequence = function (RouteCollectorProxy $app, array $sequence, $processSequence) {
             $path = array_shift($sequence);
 
             /**
@@ -513,8 +513,8 @@ class AppTest extends TestCase
              * The very tail of the sequence uses the $app->get() method
              */
             if (count($sequence)) {
-                $app->group($path, function () use ($app, &$sequence, $processSequence) {
-                    $processSequence($app, $sequence, $processSequence);
+                $app->group($path, function (RouteCollectorProxy $group) use (&$sequence, $processSequence) {
+                    $processSequence($group, $sequence, $processSequence);
                 });
             } else {
                 $app->get($path, function () {


### PR DESCRIPTION
`RouteCollector::group()` instantiates a new instance of `RouteCollectorProxy` and passes it into the group's callable. The group's pattern was not being passed as the `RouteCollectorProxy`'s basepath which caused the inability to create groups within groups.

This bug was missed with the existing `App` tests as the `AppTest::testRouteGroupCombinations()` was using the wrong instance of the `RouteCollectorProxy` to process the group sequences which faked a false positive test.