### PR TITLE
4.x - Remove pathFor() and rename relativePathFor() with relativeUrlFor()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 4.0.0 - 2019-07-03
 
 ### Added
+- [#2654](https://github.com/slimphp/Slim/pull/2654) `RouteParser::pathFor()` and `RouteParser::relativePathFor()` are deprecated. Use `RouteParser::urlFor()` and `RouteParser::relativeUrlFor()`
 - [#2642](https://github.com/slimphp/Slim/pull/2642) Add `AppFactory` to enable PSR-7 implementation and ServerRequest creator auto-detection.
 - [#2641](https://github.com/slimphp/Slim/pull/2641) Add `RouteCollectorProxyInterface` which extracts all the route mapping functionality from app into its own interface.
 - [#2640](https://github.com/slimphp/Slim/pull/2640) Add `RouteParserInterface` and decouple FastRoute route parser entirely from core. The methods `relativePathFor()`, `urlFor()` and `fullUrlFor()` are now located on this interface.

--- a/Slim/Interfaces/RouteParserInterface.php
+++ b/Slim/Interfaces/RouteParserInterface.php
@@ -18,7 +18,8 @@ interface RouteParserInterface
     /**
      * Build the path for a named route excluding the base path
      *
-     * @param string $name        Route name
+     *
+     * @param string $routeName   Route name
      * @param array  $data        Named argument replacement data
      * @param array  $queryParams Optional query string parameters
      *
@@ -27,14 +28,12 @@ interface RouteParserInterface
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
-    public function relativePathFor(string $name, array $data = [], array $queryParams = []): string;
+    public function relativeUrlFor(string $routeName, array $data = [], array $queryParams = []): string;
 
     /**
      * Build the path for a named route including the base path
      *
-     * This method is deprecated. Use urlFor() from now on.
-     *
-     * @param string $name        Route name
+     * @param string $routeName   Route name
      * @param array  $data        Named argument replacement data
      * @param array  $queryParams Optional query string parameters
      *
@@ -43,21 +42,7 @@ interface RouteParserInterface
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
-    public function pathFor(string $name, array $data = [], array $queryParams = []): string;
-
-    /**
-     * Build the path for a named route including the base path
-     *
-     * @param string $name        Route name
-     * @param array  $data        Named argument replacement data
-     * @param array  $queryParams Optional query string parameters
-     *
-     * @return string
-     *
-     * @throws RuntimeException         If named route does not exist
-     * @throws InvalidArgumentException If required data not provided
-     */
-    public function urlFor(string $name, array $data = [], array $queryParams = []): string;
+    public function urlFor(string $routeName, array $data = [], array $queryParams = []): string;
 
     /**
      * Get fully qualified URL for named route

--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -39,9 +39,9 @@ class RouteParser implements RouteParserInterface
     /**
      * {@inheritdoc}
      */
-    public function relativePathFor(string $name, array $data = [], array $queryParams = []): string
+    public function relativeUrlFor(string $routeName, array $data = [], array $queryParams = []): string
     {
-        $route = $this->routeCollector->getNamedRoute($name);
+        $route = $this->routeCollector->getNamedRoute($routeName);
         $pattern = $route->getPattern();
 
         $segments = [];
@@ -102,19 +102,10 @@ class RouteParser implements RouteParserInterface
     /**
      * {@inheritdoc}
      */
-    public function pathFor(string $name, array $data = [], array $queryParams = []): string
-    {
-        trigger_error('pathFor() is deprecated. Use urlFor() instead.', E_USER_DEPRECATED);
-        return $this->urlFor($name, $data, $queryParams);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function urlFor(string $name, array $data = [], array $queryParams = []): string
+    public function urlFor(string $routeName, array $data = [], array $queryParams = []): string
     {
         $basePath = $this->routeCollector->getBasePath();
-        $url = $this->relativePathFor($name, $data, $queryParams);
+        $url = $this->relativeUrlFor($routeName, $data, $queryParams);
 
         if ($basePath) {
             $url = $basePath . $url;

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,6 @@
 # How to upgrade
 
+* [2654] - `RouteParser::pathFor()` and `RouteParser::relativePathFor()` are deprecated. Use `RouteParser::urlFor()` and `RouteParser::relativeUrlFor()`
 * [2638] - `RouteCollector::pathFor()` is now deprecated. Use `RouteParser::urlFor()`
 * [2622] - `Router` has been removed. It is now split into `RouteCollector`, `RouteRunner` and `RouteParser`
 * [2555] - PSR-15 Middleware support was implemented at the cost of Double-Pass middleware being deprecated.
@@ -13,6 +14,7 @@
 * [2254] - You need to add the `Middleware\ContentLengthMiddleware` middleware if you want Slim to add the Content-Length header this automatically.
 * [2166] - You need to add the `Middleware\OutputBuffering` middleware to capture echo'd or var_dump'd output from your code.
 
+[2654]: https://github.com/slimphp/Slim/pull/2654
 [2638]: https://github.com/slimphp/Slim/pull/2638
 [2622]: https://github.com/slimphp/Slim/pull/2622
 [2555]: https://github.com/slimphp/Slim/pull/2555

--- a/tests/Routing/RouteParserTest.php
+++ b/tests/Routing/RouteParserTest.php
@@ -74,7 +74,7 @@ class RouteParserTest extends TestCase
         $route->setName('test');
 
         $routeParser = $routeCollector->getRouteParser();
-        $results = $routeParser->relativePathFor('test', ['first' => 'hello', 'second' => 'world']);
+        $results = $routeParser->relativeUrlFor('test', ['first' => 'hello', 'second' => 'world']);
 
         $this->assertEquals('/hello/world', $results);
     }
@@ -92,7 +92,7 @@ class RouteParserTest extends TestCase
         $route->setName('test');
 
         $routeParser = $routeCollector->getRouteParser();
-        $results = $routeParser->relativePathFor('test', ['first' => 'hello', 'second' => 'world']);
+        $results = $routeParser->relativeUrlFor('test', ['first' => 'hello', 'second' => 'world']);
 
         $this->assertEquals('/hello/world', $results);
     }
@@ -155,40 +155,6 @@ class RouteParserTest extends TestCase
         $routeParser = $routeCollector->getRouteParser();
 
         $routeParser->urlFor('test');
-    }
-
-    /**
-     * Test that the router pathFor will proxy into a urlFor method, and trigger
-     * the user deprecated warning
-     */
-    public function testPathForAliasesUrlFor()
-    {
-        $errorString = null;
-
-        set_error_handler(function ($no, $str) use (&$errorString) {
-            $errorString = $str;
-        }, E_USER_DEPRECATED);
-
-        $name = 'foo';
-        $data = ['name' => 'josh'];
-        $queryParams = ['a' => 'b', 'c' => 'd'];
-
-        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
-
-        /** @var RouteParser $routeParser */
-        $routeParser = $this
-            ->getMockBuilder(RouteParser::class)
-            ->setConstructorArgs([$routeCollectorProphecy->reveal()])
-            ->setMethods(['urlFor'])
-            ->getMock();
-
-        $routeParser->expects($this->once())->method('urlFor')->with($name, $data, $queryParams);
-        $routeParser->pathFor($name, $data, $queryParams);
-
-        //check that our error was triggered
-        $this->assertEquals($errorString, 'pathFor() is deprecated. Use urlFor() instead.');
-
-        restore_error_handler();
     }
 
     public function testFullUrlFor()


### PR DESCRIPTION
As per the discussion in #2493 and the [stack overflow post explaining relative/absolute](https://stackoverflow.com/questions/2005079/absolute-vs-relative-urls/39545949#39545949)

`relativePathFor()` and `pathFor()` are getting entirely removed from the `RouteParser` component. Since this is a new interface that is the result of the fragmentation of the now deprecated `Router` component the user will need to re-learn the new interface so no point in implementing a warning of deprecation.

The `RouteParser` will now have this interface:
* RouteParser::fullUrlFor() - Absolute URL
* RouteParser::urlFor() - Root Relative URL formerly `pathFor()`
* RouteParser::relativeUrlFor() - Relative URL formerly `relativePathFor()`
