### PR TITLE
Slim 4 Alpha Release

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -34,7 +34,7 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
      *
      * @var string
      */
-    public const VERSION = '4.0.0-dev';
+    public const VERSION = '4.0.0-alpha';
 
     /**
      * @var MiddlewareDispatcher


### PR DESCRIPTION
# Slim 4.0.0-alpha Release

We are excited to announce the Slim 4.0.0 alpha release. Please direct all your feedback for this release to the [Slim 4 Alpha Release Feedback Thread](https://github.com/slimphp/Slim/issues/2653). The new docs are located [here](http://dev.slimframework.com/docs/v4).

# General Direction

For this major release the focus was on the following:
* Implementing PSR-15 Middleware Support
* Decoupling our dependency on Slim's PSR-7 implementation and enabling usage of any PSR-7 implementation
* Decoupling our dependency on Pimple and enabling usage of any PSR-11 ContainerInterface implementation
* Decoupling our dependency on FastRoute and implement interfaces enabling the user to use any routing library
* Decoupling error handling from the core and enable users to easily use their own implementations
* Decoupling response emitting from the core and enable users to easily use their own implementation
* Remove all traits for a cleaner call stack trace when debugging
* Create an app factory that makes it easier to create an `App` instance due to the higher complexity of the increased modularity

# Major Changes

* Slim requires PHP 7.1 or higher.
* Slim no longer ships with a PSR-7 Implementation.
* Slim no longer ships with Pimple.
* Slim no longer sets the `default_mimetype` to an empty string, so you need to set it yourself in php.ini or your app using `ini_set('default_mimetype', '')`.
* Slim `App::$settings` have been removed, multiple middleware have been implemented to replace the functionality from each individual settings.
* Routing is now done via the `Slim\Middleware\RoutingMiddleware`. By default routing will be performed last in the middleware queue. If you want to access the `route` and `routingResults` attributes from `$request` you will need to add this middleware last as it will get executed first within the queue when running the app. The middleware queue is still being executed in Last In First Out (LIFO) order. This replaces the `determineRouteBeforeAppMiddleware` setting.
* Output buffering is now done via `Slim\Middleware\OutputBufferingMiddleware`. This replaces the `outputBuffering` setting.
* Content length header calculation is now done via `Slim\Middleware\ContentLengthMiddleware`. This replaces the `addContentLengthHeader` setting.
* The `RouterInterface` component has been split into 4 interfaces `RouteCollectorInterface`, `RouteParserInterface`, `RouteResolverInterface` and `DispatcherInterface`.
* Double-Pass middleware has been deprecated. Middleware signature is now the PSR-15 `MiddlewareInterface` signature `process(Request $request, RequestHandler $handler)`. We no longer support the double-pass `function ($request, $response, $next)` signature. You can still use callables with the signature `function (Request $request, RequestHandler $handler) {}` to create middleware or use an invokable class with that signature.
* Slim `App` now implements the PSR-15 `RequestHandlerInterface`. Use `$app->handle($request)` instead of `$app($request)`.
* PSR-15 RequestHandler can now be used as route callables.
* Binding of `$app` to the `RouteGroup` callable has been removed. `RouteCollectorProxy` gets injected into the `RouteGroup`'s callable instead. `$app->group('/group', function (RouteCollectorProxy $group) { $group->get(...); }`
* The `App::subRequest()` method has been removed. You can perform sub-requests via `$app->handle($request)` from within a route callable.
* Removed `SlimException`. New `HttpException` have been implemented, namely `HttpBadRequestException`, `HttpForbiddenException`, `HttpInternalServerErrorException`, `HttpMethodNotAllowedException`, `HttpNotFoundException`, `HttpNotImplementedException` and `HttpUnauthorizedException`. You can also create your own by extending `HttpException` or `HttpSpecializedException`.
* Request method names are now case-sensitive when user `App::map()`.
* All traits have been removed. `CallableResolverTrait` and `MiddlewareAwareTrait` no longer exist.
* Two new factories have been introduced. `AppFactory` and `ServerRequestCreatorFactory` to facilitate `App` and `ServerRequest` creation. We currently support 4 PSR-7/ServerRequest creator combinations (Slim-Psr7, Nyholm PSR-7 & Nyholm PSR-7 Server, Guzzle PSR-7 and Guzzle HTTP Factory and Zend-Diactoros.

<br/>

# Changelog

## Added
- [#2642](https://github.com/slimphp/Slim/pull/2642) Added `AppFactory` to enable PSR-7 implementation and ServerRequest creator auto-detection.
- [#2641](https://github.com/slimphp/Slim/pull/2641) Added `RouteCollectorProxyInterface` which extracts all the route mapping functionality from app into its own interface.
- [#2640](https://github.com/slimphp/Slim/pull/2640) Added `RouteParserInterface` and decouple FastRoute route parser entirely from core. The methods `relativePathFor()`, `urlFor()` and `fullUrlFor()` are now located on this interface.
- [#2639](https://github.com/slimphp/Slim/pull/2639) Added `DispatcherInterface` and decouple FastRoute dispatcher entirely from core. This enables us to swap out our router implementation for any other router.
- [#2638](https://github.com/slimphp/Slim/pull/2638) Added `RouteCollector::fullUrlFor()` to give the ability to generate fully qualified URLs
- [#2634](https://github.com/slimphp/Slim/pull/2634) Added ability to set invocation strategy on a per-route basis. `$app->get(...)->setInvocationStrategy($strategy)`
- [#2555](https://github.com/slimphp/Slim/pull/2555) Added PSR-15 Middleware Support
- [#2529](https://github.com/slimphp/Slim/pull/2529) Slim no longer ships with a PSR-7 implementation. You need to provide a PSR-7 ServerRequest and a PSR-17 ResponseFactory to run Slim.
- [#2507](https://github.com/slimphp/Slim/pull/2507) Method names are now case-sensitive in `Router::map()`, and so, by extension, in App::map() 
- [#2497](https://github.com/slimphp/Slim/pull/2497) PSR-15 RequestHandlers can now be used as route callables
- [#2496](https://github.com/slimphp/Slim/pull/2496) A Slim App can now be used as PSR-15 Request Handler
- [#2405](https://github.com/slimphp/Slim/pull/2405) `RoutingMiddleware` now adds the `routingResults` request attribute to hold the results of routing
- [#2404](https://github.com/slimphp/Slim/pull/2404) Slim 4 requires PHP 7.1 or higher
- [#2425](https://github.com/slimphp/Slim/pull/2425) Added `$app->redirect()`
- [#2398](https://github.com/slimphp/Slim/pull/2398) Added `Middleware\ErrorMiddleware`
- [#2329](https://github.com/slimphp/Slim/pull/2329) Added `Middleware\MethodOverrideMiddleware`
- [#2288](https://github.com/slimphp/Slim/pull/2288) Separate routing from dispatching
- [#2254](https://github.com/slimphp/Slim/pull/2254) Added `Middleware\ContentLengthMiddleware`
- [#2166](https://github.com/slimphp/Slim/pull/2166) Added `Middleware\OutputBufferingMiddleware`

## Deprecated
- [#2654](https://github.com/slimphp/Slim/pull/2654) `RouteParser::pathFor()` and `RouteParser::relativePathFor()` are deprecated. Use `RouteParser::urlFor()` and `RouteParser::relativeUrlFor()`
- [#2641](https://github.com/slimphp/Slim/pull/2641) Deprecate `RouteCollector::pushGroup()`,`RouteCollector::popGroup()` which gets replaced by `RouteCollector::group()`
- [#2638](https://github.com/slimphp/Slim/pull/2638) Deprecate `RouteCollector::pathFor()` which gets replaced by `RouteCollector::urlFor()` preserving the orignal functionality
- [#2589](https://github.com/slimphp/Slim/pull/2589) Remove `App::$settings`
- [#2560](https://github.com/slimphp/Slim/pull/2560) Remove binding of `$this` to `RouteGroup` callable.
- [#2555](https://github.com/slimphp/Slim/pull/2555) Double-Pass Middleware Support has been deprecated

## Removed
- [#2612](https://github.com/slimphp/Slim/pull/2612) Remove Routable, refactored RouteGroup and Route interface
- [#2589](https://github.com/slimphp/Slim/pull/2589) Remove `App::$settings` altogether
- [#2587](https://github.com/slimphp/Slim/pull/2587) Remove Pimple as a dev-dependency
- [#2398](https://github.com/slimphp/Slim/pull/2398) Slim no longer has error handling built into App. Add `Slim\Middleware\ErrorMiddleware` as the outermost middleware.
- [#2375](https://github.com/slimphp/Slim/pull/2375) Slim no longer sets the `default_mimetype` to an empty string, so you need to set it yourself in php.ini or your app using `ini_set('default_mimetype', '');`.
- [#2288](https://github.com/slimphp/Slim/pull/2288) `determineRouteBeforeAppMiddleware` setting is removed. Add RoutingMiddleware() where you need it now.
- [#2254](https://github.com/slimphp/Slim/pull/2254) `addContentLengthHeader` setting is removed
- [#2221](https://github.com/slimphp/Slim/pull/2221) `Slim\Http` has been removed and Slim now depends on the separate Slim-Http component
- [#2166](https://github.com/slimphp/Slim/pull/2166) `outputBuffering` setting is removed
- [#2078](https://github.com/slimphp/Slim/pull/2078) Remove `App::subRequest()`
- [#2098](https://github.com/slimphp/Slim/pull/2098) Remove CallableResolverTrait
- [#2102](https://github.com/slimphp/Slim/pull/2102) Remove container from router
- [#2124](https://github.com/slimphp/Slim/pull/2124) Remove `Slim\Exception\SlimException`
- [#2174](https://github.com/slimphp/Slim/pull/2174) Switch from Container-Interop to PSR-11
- [#2290](https://github.com/slimphp/Slim/pull/2290) Removed container
- [#2560](https://github.com/slimphp/Slim/pull/2560) Remove binding of `$this` to `group()`

## Fixed
- [#2588](https://github.com/slimphp/Slim/pull/2588) Fix file/directory permission handling of `Router::setCacheFile()`
- [#2067](https://github.com/slimphp/Slim/pull/2067) Unit tests now pass on Windows systems
- [#2405](https://github.com/slimphp/Slim/pull/2405) We `rawurldecode()` the path before passing to FastRoute, so UTF-8 characters in paths should now work.

<br/>

# Step-By-Step Hello World

<br/>

## Step 1: Install Composer

Don't have Composer? It's easy to install by following the instructions on their [download](https://getcomposer.org/download/) page.

## Step 2: Install Slim

We recommend you install Slim with [Composer](https://getcomposer.org/).
Navigate into your project's root directory and execute the bash command
shown below. This command downloads the Slim Framework and its third-party
dependencies into your project's `vendor/` directory.

```bash
composer require slim/slim:4.0.0-alpha
```

## Step 3: Install a PSR-7 Implementation and ServerRequest Creator

Before you can get up and running with Slim you will need to choose a PSR-7 implementation that best fits your application.
In order for auto-detection to work and enable you to use `AppFactory::create()` and `App::run()` without having to manually create a `ServerRequest` you need to install one of the following implementations:

### [Slim PSR-7](https://github.com/slimphp/Slim-Psr7)
```bash
composer require slim/psr7:dev-master
```

### [Nyholm PSR-7](https://github.com/Nyholm/psr7) and [Nyholm PSR-7 Server](https://github.com/Nyholm/psr7-server)
```bash
composer require nyholm/psr7 nyholm/psr7-server
```

### [Guzzle PSR-7](https://github.com/guzzle/psr7) and [Guzzle HTTP Factory](https://github.com/http-interop/http-factory-guzzle)
```bash
composer require guzzlehttp/psr7 http-interop/http-factory-guzzle
```

### [Zend Diactoros](https://github.com/zendframework/zend-diactoros)
```bash
composer require zendframework/zend-diactoros
```

## Step 4: Hello World
```php
<?php
use Psr\Http\Message\ResponseInterface as Response;
use Psr\Http\Message\ServerRequestInterface as Request;
use Slim\Factory\AppFactory;

require __DIR__ . '/../vendor/autoload.php';

$app = AppFactory::create();

$app->get('/', function (Request $request, Response $response, $args) {
    $response->getBody()->write('Hello world!');
    return $response;
});

$app->run();
```

<br/>

# Slim 4 DDD Skeleton

[@l0gicgate](https://github.com/l0gicgate) created an app skeleton with a DDD style directory structure, example files and test coverage. It is a very opinionated and we're not sure yet if it is the right fit for a skeleton but we would like some feedback. You can clone the skeleton and try it out:

```bash
git clone https://github.com/l0gicgate/Slim-Skeleton.git
git checkout 4.x
```

<br/>