### PR TITLE
non-buffered responses fixes

### DIFF
--- a/Slim/Http/Message.php
+++ b/Slim/Http/Message.php
@@ -230,6 +230,10 @@ abstract class Message implements MessageInterface
         $clone = clone $this;
         $clone->headers->add($name, $value);
 
+        if ($this instanceof Response && $this->body instanceof NonBufferedBody) {
+            header(sprintf('%s: %s', $name, $this->getHeaderLine($name)));
+        }
+
         return $clone;
     }
 
@@ -250,6 +254,10 @@ abstract class Message implements MessageInterface
     {
         $clone = clone $this;
         $clone->headers->remove($name);
+
+        if ($this instanceof Response && $this->body instanceof NonBufferedBody) {
+            header_remove($name);
+        }
 
         return $clone;
     }

--- a/Slim/Http/Message.php
+++ b/Slim/Http/Message.php
@@ -231,7 +231,7 @@ abstract class Message implements MessageInterface
         $clone->headers->add($name, $value);
 
         if ($this instanceof Response && $this->body instanceof NonBufferedBody) {
-            header(sprintf('%s: %s', $name, $this->getHeaderLine($name)));
+            header(sprintf('%s: %s', $name, $clone->getHeaderLine($name)));
         }
 
         return $clone;

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -274,7 +274,7 @@ class Response extends Message implements ResponseInterface
         $clone->headers->set($name, $value);
 
         if ($this->body instanceof NonBufferedBody) {
-            header(sprintf('%s: %s', $name, $this->getHeaderLine($name)));
+            header(sprintf('%s: %s', $name, $clone->getHeaderLine($name)));
         }
 
         if ($clone->getStatusCode() === StatusCode::HTTP_OK && strtolower($name) === 'location') {

--- a/Slim/Http/Response.php
+++ b/Slim/Http/Response.php
@@ -270,12 +270,12 @@ class Response extends Message implements ResponseInterface
      */
     public function withHeader($name, $value)
     {
-        if ($this->body instanceof NonBufferedBody) {
-            header("$name: $value");
-        }
-
         $clone = clone $this;
         $clone->headers->set($name, $value);
+
+        if ($this->body instanceof NonBufferedBody) {
+            header(sprintf('%s: %s', $name, $this->getHeaderLine($name)));
+        }
 
         if ($clone->getStatusCode() === StatusCode::HTTP_OK && strtolower($name) === 'location') {
             $clone = $clone->withStatus(StatusCode::HTTP_FOUND);

--- a/composer.json
+++ b/composer.json
@@ -51,10 +51,9 @@
         }
     },
     "autoload-dev": {
-        "files": [
-          "tests/Assets/PhpFunctionOverrides.php",
-          "tests/Assets/PhpHttpFunctionOverrides.php"
-        ]
+        "psr-4": {
+            "Slim\\Tests\\": "tests"
+        }
     },
     "scripts": {
         "test": [

--- a/tests/Assets/HeaderStack.php
+++ b/tests/Assets/HeaderStack.php
@@ -78,4 +78,18 @@ class HeaderStack
 
         return false;
     }
+
+    /**
+     * Remove occurrences of $header
+     *
+     * @param string $header
+     */
+    public static function remove($header)
+    {
+        foreach (self::$data as $key => $item) {
+            if (false !== strpos($item['header'], "$header:")) {
+                unset(self::$data[$key]);
+            }
+        }
+    }
 }

--- a/tests/Assets/PhpHttpFunctionOverrides.php
+++ b/tests/Assets/PhpHttpFunctionOverrides.php
@@ -7,6 +7,8 @@
 
 namespace Slim\Http;
 
+use Slim\Tests\Assets\HeaderStack;
+
 /**
  * Return the value of the global variable $GLOBALS['getallheaders_return'] if it exists. Otherwise the
  * function override calls the default php built-in function.
@@ -20,4 +22,27 @@ function getallheaders()
     }
 
     return \getallheaders();
+}
+
+/**
+ * Emit a header, without creating actual output artifacts
+ *
+ * @param string   $string
+ * @param bool     $replace
+ * @param int|null $statusCode
+ */
+function header($string, $replace = true, $statusCode = null)
+{
+    HeaderStack::push(
+        [
+            'header'      => $string,
+            'replace'     => $replace,
+            'status_code' => $statusCode,
+        ]
+    );
+}
+
+function header_remove($name = null)
+{
+    HeaderStack::remove($name);
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,16 +5,13 @@
  * @license https://github.com/slimphp/Slim/blob/3.x/LICENSE.md (MIT License)
  */
 
-use Composer\Autoload\ClassLoader;
-
 // Set timezone
 date_default_timezone_set('America/New_York');
 
 // Prevent session cookies
 ini_set('session.use_cookies', 0);
 
-/** @var ClassLoader $autoloader */
-$autoloader = require dirname(__DIR__) . '/vendor/autoload.php';
-$autoloader->addPsr4('Slim\Tests\\', __DIR__);
-
-require dirname(__FILE__) . '/getallheaders.php';
+require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/getallheaders.php';
+require __DIR__ . '/Assets/PhpFunctionOverrides.php';
+require __DIR__ . '/Assets/PhpHttpFunctionOverrides.php';


### PR DESCRIPTION
- Fix potential casting from array to string in Response::withHeader()
- Fix non buffered responses when calling Response::withAddedHeader() and Response::withoutHeader()

Reference: https://github.com/slimphp/Slim-Psr7/pull/39#issuecomment-487278458