### PR TITLE
4.x - Psr17Factory Provider & Slim-Http Auto-Detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
   - php: 7.2
   - php: 7.3
   - php: nightly
+
   allow_failures:
   - php: nightly
 

--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -95,8 +95,7 @@ class AppFactory
             if ($psr17factory::isResponseFactoryAvailable()) {
                 $responseFactory = $psr17factory::getResponseFactory();
 
-                if (
-                    static::$slimHttpDecoratorsAutomaticDetectionEnabled
+                if (static::$slimHttpDecoratorsAutomaticDetectionEnabled
                     && SlimHttpPsr17Factory::isResponseFactoryAvailable()
                     && $psr17factory::isStreamFactoryAvailable()
                 ) {

--- a/Slim/Factory/Psr17/GuzzlePsr17Factory.php
+++ b/Slim/Factory/Psr17/GuzzlePsr17Factory.php
@@ -12,6 +12,7 @@ namespace Slim\Factory\Psr17;
 class GuzzlePsr17Factory extends Psr17Factory
 {
     protected static $responseFactoryClass = 'Http\Factory\Guzzle\ResponseFactory';
+    protected static $streamFactoryClass = 'Http\Factory\Guzzle\StreamFactory';
     protected static $serverRequestCreatorClass = 'GuzzleHttp\Psr7\ServerRequest';
     protected static $serverRequestCreatorMethod = 'fromGlobals';
 }

--- a/Slim/Factory/Psr17/NyholmPsr17Factory.php
+++ b/Slim/Factory/Psr17/NyholmPsr17Factory.php
@@ -8,6 +8,7 @@ use Slim\Interfaces\ServerRequestCreatorInterface;
 class NyholmPsr17Factory extends Psr17Factory
 {
     protected static $responseFactoryClass = 'Nyholm\Psr7\Factory\Psr17Factory';
+    protected static $streamFactoryClass = 'Nyholm\Psr7\Factory\Psr17Factory';
     protected static $serverRequestCreatorClass = 'Nyholm\Psr7Server\ServerRequestCreator';
     protected static $serverRequestCreatorMethod = 'fromGlobals';
 

--- a/Slim/Factory/Psr17/Psr17Factory.php
+++ b/Slim/Factory/Psr17/Psr17Factory.php
@@ -43,7 +43,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
     public static function getResponseFactory(): ResponseFactoryInterface
     {
         if (!static::isResponseFactoryAvailable()) {
-            throw new RuntimeException(__METHOD__ . ' could not instantiate response factory.');
+            throw new RuntimeException(get_called_class() . ' could not instantiate a response factory.');
         }
 
         return new static::$responseFactoryClass;
@@ -55,7 +55,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
     public static function getStreamFactory(): StreamFactoryInterface
     {
         if (!static::isStreamFactoryAvailable()) {
-            throw new RuntimeException(__METHOD__ . ' could not instantiate stream factory.');
+            throw new RuntimeException(get_called_class() . ' could not instantiate a stream factory.');
         }
 
         return new static::$streamFactoryClass;
@@ -67,7 +67,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
     public static function getServerRequestCreator(): ServerRequestCreatorInterface
     {
         if (!static::isServerRequestCreatorAvailable()) {
-            throw new RuntimeException(__METHOD__ . ' could not instantiate server request creator.');
+            throw new RuntimeException(get_called_class() . ' could not instantiate a server request creator.');
         }
 
         return new ServerRequestCreator(static::$serverRequestCreatorClass, static::$serverRequestCreatorMethod);

--- a/Slim/Factory/Psr17/Psr17Factory.php
+++ b/Slim/Factory/Psr17/Psr17Factory.php
@@ -18,22 +18,22 @@ use Slim\Interfaces\ServerRequestCreatorInterface;
 abstract class Psr17Factory implements Psr17FactoryInterface
 {
     /**
-     * @var string|null
+     * @var string
      */
     protected static $responseFactoryClass;
 
     /**
-     * @var string|null
+     * @var string
      */
     protected static $streamFactoryClass;
 
     /**
-     * @var string|null
+     * @var string
      */
     protected static $serverRequestCreatorClass;
 
     /**
-     * @var string|null
+     * @var string
      */
     protected static $serverRequestCreatorMethod;
 

--- a/Slim/Factory/Psr17/Psr17Factory.php
+++ b/Slim/Factory/Psr17/Psr17Factory.php
@@ -10,23 +10,30 @@ declare(strict_types=1);
 namespace Slim\Factory\Psr17;
 
 use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use RuntimeException;
 use Slim\Interfaces\Psr17FactoryInterface;
 use Slim\Interfaces\ServerRequestCreatorInterface;
 
 abstract class Psr17Factory implements Psr17FactoryInterface
 {
     /**
-     * @var string
+     * @var string|null
      */
     protected static $responseFactoryClass;
 
     /**
-     * @var string
+     * @var string|null
+     */
+    protected static $streamFactoryClass;
+
+    /**
+     * @var string|null
      */
     protected static $serverRequestCreatorClass;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected static $serverRequestCreatorMethod;
 
@@ -35,7 +42,23 @@ abstract class Psr17Factory implements Psr17FactoryInterface
      */
     public static function getResponseFactory(): ResponseFactoryInterface
     {
+        if (!static::isResponseFactoryAvailable()) {
+            throw new RuntimeException(__METHOD__ . ' could not instantiate response factory.');
+        }
+
         return new static::$responseFactoryClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getStreamFactory(): StreamFactoryInterface
+    {
+        if (!static::isStreamFactoryAvailable()) {
+            throw new RuntimeException(__METHOD__ . ' could not instantiate stream factory.');
+        }
+
+        return new static::$streamFactoryClass;
     }
 
     /**
@@ -43,6 +66,10 @@ abstract class Psr17Factory implements Psr17FactoryInterface
      */
     public static function getServerRequestCreator(): ServerRequestCreatorInterface
     {
+        if (!static::isServerRequestCreatorAvailable()) {
+            throw new RuntimeException(__METHOD__ . ' could not instantiate server request creator.');
+        }
+
         return new ServerRequestCreator(static::$serverRequestCreatorClass, static::$serverRequestCreatorMethod);
     }
 
@@ -51,7 +78,15 @@ abstract class Psr17Factory implements Psr17FactoryInterface
      */
     public static function isResponseFactoryAvailable(): bool
     {
-        return class_exists(static::$responseFactoryClass);
+        return static::$responseFactoryClass && class_exists(static::$responseFactoryClass);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function isStreamFactoryAvailable(): bool
+    {
+        return static::$streamFactoryClass && class_exists(static::$streamFactoryClass);
     }
 
     /**
@@ -59,6 +94,10 @@ abstract class Psr17Factory implements Psr17FactoryInterface
      */
     public static function isServerRequestCreatorAvailable(): bool
     {
-        return class_exists(static::$serverRequestCreatorClass);
+        return (
+            static::$serverRequestCreatorClass
+            && static::$serverRequestCreatorMethod
+            && class_exists(static::$serverRequestCreatorClass)
+        );
     }
 }

--- a/Slim/Factory/Psr17/Psr17FactoryProvider.php
+++ b/Slim/Factory/Psr17/Psr17FactoryProvider.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Slim\Factory\Psr17;
+
+use Slim\Interfaces\Psr17FactoryProviderInterface;
+
+class Psr17FactoryProvider implements Psr17FactoryProviderInterface
+{
+    /**
+     * @var array
+     */
+    protected static $factories = [
+        SlimPsr17Factory::class,
+        NyholmPsr17Factory::class,
+        ZendDiactorosPsr17Factory::class,
+        GuzzlePsr17Factory::class,
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getFactories(): array
+    {
+        return static::$factories;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setFactories(array $factories): void
+    {
+        static::$factories = $factories;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function addFactory(string $factory): void
+    {
+        array_unshift(static::$factories, $factory);
+    }
+}

--- a/Slim/Factory/Psr17/SlimHttpPsr17Factory.php
+++ b/Slim/Factory/Psr17/SlimHttpPsr17Factory.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Factory\Psr17;
+
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+
+class SlimHttpPsr17Factory extends Psr17Factory
+{
+    protected static $responseFactoryClass = 'Slim\Http\Factory\DecoratedResponseFactory';
+
+    /**
+     * @param ResponseFactoryInterface $responseFactory
+     * @param StreamFactoryInterface   $streamFactory
+     * @return ResponseFactoryInterface
+     */
+    public static function createDecoratedResponseFactory(
+        ResponseFactoryInterface $responseFactory,
+        StreamFactoryInterface $streamFactory
+    ): ResponseFactoryInterface {
+        return new static::$responseFactoryClass($responseFactory, $streamFactory);
+    }
+}

--- a/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
+++ b/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Factory\Psr17;
+
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+use Slim\Interfaces\ServerRequestCreatorInterface;
+
+class SlimHttpServerRequestCreator implements ServerRequestCreatorInterface
+{
+    /**
+     * @var ServerRequestCreatorInterface
+     */
+    protected $serverRequestCreator;
+
+    /**
+     * @var string
+     */
+    protected static $serverRequestDecoratorClass = 'Slim\Http\ServerRequest';
+
+    /**
+     * @param ServerRequestCreatorInterface $serverRequestCreator
+     */
+    public function __construct(ServerRequestCreatorInterface $serverRequestCreator)
+    {
+        $this->serverRequestCreator = $serverRequestCreator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createServerRequestFromGlobals(): ServerRequestInterface
+    {
+        if (!static::isServerRequestDecoratorAvailable()) {
+            throw new RuntimeException('The Slim-Http ServerRequest decorator is not available.');
+        }
+
+        $request = $this->serverRequestCreator->createServerRequestFromGlobals();
+
+        return new static::$serverRequestDecoratorClass($request);
+    }
+
+    /**
+     * @return bool
+     */
+    public static function isServerRequestDecoratorAvailable(): bool
+    {
+        return class_exists(static::$serverRequestDecoratorClass);
+    }
+}

--- a/Slim/Factory/Psr17/SlimPsr17Factory.php
+++ b/Slim/Factory/Psr17/SlimPsr17Factory.php
@@ -12,6 +12,7 @@ namespace Slim\Factory\Psr17;
 class SlimPsr17Factory extends Psr17Factory
 {
     protected static $responseFactoryClass = 'Slim\Psr7\Factory\ResponseFactory';
+    protected static $streamFactoryClass = 'Slim\Psr7\Factory\StreamFactory';
     protected static $serverRequestCreatorClass = 'Slim\Psr7\Factory\ServerRequestFactory';
     protected static $serverRequestCreatorMethod = 'createFromGlobals';
 }

--- a/Slim/Factory/Psr17/ZendDiactorosPsr17Factory.php
+++ b/Slim/Factory/Psr17/ZendDiactorosPsr17Factory.php
@@ -12,6 +12,7 @@ namespace Slim\Factory\Psr17;
 class ZendDiactorosPsr17Factory extends Psr17Factory
 {
     protected static $responseFactoryClass = 'Zend\Diactoros\ResponseFactory';
+    protected static $streamFactoryClass = 'Zend\Diactoros\StreamFactory';
     protected static $serverRequestCreatorClass = 'Zend\Diactoros\ServerRequestFactory';
     protected static $serverRequestCreatorMethod = 'fromGlobals';
 }

--- a/Slim/Factory/ServerRequestCreatorFactory.php
+++ b/Slim/Factory/ServerRequestCreatorFactory.php
@@ -49,8 +49,7 @@ class ServerRequestCreatorFactory
             if ($psr17Factory::isServerRequestCreatorAvailable()) {
                 $serverRequestCreator = $psr17Factory::getServerRequestCreator();
 
-                if (
-                    static::$slimHttpDecoratorsAutomaticDetectionEnabled
+                if (static::$slimHttpDecoratorsAutomaticDetectionEnabled
                     && SlimHttpServerRequestCreator::isServerRequestDecoratorAvailable()
                 ) {
                     return new SlimHttpServerRequestCreator($serverRequestCreator);

--- a/Slim/Interfaces/Psr17FactoryInterface.php
+++ b/Slim/Interfaces/Psr17FactoryInterface.php
@@ -10,16 +10,29 @@ declare(strict_types=1);
 namespace Slim\Interfaces;
 
 use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use RuntimeException;
 
 interface Psr17FactoryInterface
 {
     /**
      * @return ResponseFactoryInterface
+     *
+     * @throws RuntimeException when the factory could not be instantiated
      */
     public static function getResponseFactory(): ResponseFactoryInterface;
 
     /**
+     * @return StreamFactoryInterface
+     *
+     * @throws RuntimeException when the factory could not be instantiated
+     */
+    public static function getStreamFactory(): StreamFactoryInterface;
+
+    /**
      * @return ServerRequestCreatorInterface
+     *
+     * @throws RuntimeException when the factory could not be instantiated
      */
     public static function getServerRequestCreator(): ServerRequestCreatorInterface;
 
@@ -29,6 +42,13 @@ interface Psr17FactoryInterface
      * @return bool
      */
     public static function isResponseFactoryAvailable(): bool;
+
+    /**
+     * Is the PSR-17 StreamFactory available
+     *
+     * @return bool
+     */
+    public static function isStreamFactoryAvailable(): bool;
 
     /**
      * Is the ServerRequest creator available

--- a/Slim/Interfaces/Psr17FactoryProviderInterface.php
+++ b/Slim/Interfaces/Psr17FactoryProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Interfaces;
+
+interface Psr17FactoryProviderInterface
+{
+    /**
+     * @return array
+     */
+    public static function getFactories(): array;
+
+    /**
+     * @var array
+     */
+    public static function setFactories(array $factories): void;
+
+    /**
+     * @param string $factory
+     * @return void
+     */
+    public static function addFactory(string $factory): void;
+}

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "phpunit/phpunit": "^7.5",
         "phpspec/prophecy": "^1.8",
         "phpstan/phpstan": "^0.11.5",
-        "slim/psr7": "dev-master",
+        "slim/http": "^0.7",
+        "slim/psr7": "^0.3",
         "squizlabs/php_codesniffer": "^3.4.2",
         "zendframework/zend-diactoros": "^2.1"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.1/phpunit.xsd"
          backupGlobals="false"
@@ -20,13 +19,11 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory>./Slim/</directory>
         </whitelist>
     </filter>
-
     <logging>
         <log
             type="coverage-html"

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -14,11 +14,14 @@ use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use ReflectionProperty;
+use RuntimeException;
 use Slim\Factory\AppFactory;
 use Slim\Factory\Psr17\GuzzlePsr17Factory;
 use Slim\Factory\Psr17\NyholmPsr17Factory;
+use Slim\Factory\Psr17\Psr17FactoryProvider;
 use Slim\Factory\Psr17\SlimPsr17Factory;
 use Slim\Factory\Psr17\ZendDiactorosPsr17Factory;
+use Slim\Http\Factory\DecoratedResponseFactory;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteResolverInterface;
@@ -46,9 +49,8 @@ class AppFactoryTest extends TestCase
      */
     public function testCreateAppWithAllImplementations(string $psr17factory, string $expectedResponseFactoryClass)
     {
-        $psr17FactoriesProperty = new ReflectionProperty(AppFactory::class, 'psr17Factories');
-        $psr17FactoriesProperty->setAccessible(true);
-        $psr17FactoriesProperty->setValue([$psr17factory]);
+        Psr17FactoryProvider::setFactories([$psr17factory]);
+        AppFactory::setSlimHttpDecoratorsAutomaticDetection(false);
 
         $app = AppFactory::create();
 
@@ -62,15 +64,22 @@ class AppFactoryTest extends TestCase
         $this->assertInstanceOf($expectedResponseFactoryClass, $responseFactory);
     }
 
+    public function testDetermineResponseFactoryReturnsDecoratedFactory()
+    {
+        Psr17FactoryProvider::setFactories([SlimPsr17Factory::class]);
+        AppFactory::setSlimHttpDecoratorsAutomaticDetection(true);
+
+        $app = AppFactory::create();
+
+        $this->assertInstanceOf(DecoratedResponseFactory::class, $app->getResponseFactory());
+    }
+
     /**
-     * @expectedException \RuntimeException
+     * @expectedException RuntimeException
      */
     public function testDetermineResponseFactoryThrowsRuntimeException()
     {
-        $psr17FactoriesProperty = new ReflectionProperty(AppFactory::class, 'psr17Factories');
-        $psr17FactoriesProperty->setAccessible(true);
-        $psr17FactoriesProperty->setValue([]);
-
+        Psr17FactoryProvider::setFactories([]);
         AppFactory::create();
     }
 
@@ -82,6 +91,7 @@ class AppFactoryTest extends TestCase
         $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
         $routeResolverProphecy = $this->prophesize(RouteResolverInterface::class);
 
+        AppFactory::setSlimHttpDecoratorsAutomaticDetection(false);
         AppFactory::setResponseFactory($responseFactoryProphecy->reveal());
         AppFactory::setContainer($containerProphecy->reveal());
         AppFactory::setCallableResolver($callableResolverProphecy->reveal());
@@ -123,6 +133,8 @@ class AppFactoryTest extends TestCase
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
         $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
         $routeResolverProphecy = $this->prophesize(RouteResolverInterface::class);
+
+        AppFactory::setSlimHttpDecoratorsAutomaticDetection(false);
 
         $app = AppFactory::create(
             $responseFactoryProphecy->reveal(),

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -169,4 +169,15 @@ class AppFactoryTest extends TestCase
             $app->getRouteResolver()
         );
     }
+
+    public function testSetPsr17FactoryProvider()
+    {
+        $psr17FactoryProvider = new Psr17FactoryProvider();
+        $psr17FactoryProvider::setFactories([SlimPsr17Factory::class]);
+
+        AppFactory::setPsr17FactoryProvider($psr17FactoryProvider);
+        AppFactory::setSlimHttpDecoratorsAutomaticDetection(false);
+
+        $this->assertInstanceOf(SlimResponseFactory::class, AppFactory::determineResponseFactory());
+    }
 }

--- a/tests/Factory/Psr17/Psr17FactoryProviderTest.php
+++ b/tests/Factory/Psr17/Psr17FactoryProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Factory\Psr17;
+
+use Slim\Factory\Psr17\Psr17FactoryProvider;
+use Slim\Tests\TestCase;
+
+class Psr17FactoryProviderTest extends TestCase
+{
+    public function testGetSetFactories()
+    {
+        Psr17FactoryProvider::setFactories([]);
+
+        $this->assertEquals([], Psr17FactoryProvider::getFactories());
+    }
+
+
+    public function testAddFactory()
+    {
+        Psr17FactoryProvider::setFactories(['Factory 1']);
+        Psr17FactoryProvider::addFactory('Factory 2');
+
+        $this->assertEquals(['Factory 2', 'Factory 1'], Psr17FactoryProvider::getFactories());
+    }
+}

--- a/tests/Factory/Psr17/Psr17FactoryTest.php
+++ b/tests/Factory/Psr17/Psr17FactoryTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Factory\Psr17;
+
+use RuntimeException;
+use Slim\Tests\Mocks\MockPsr17Factory;
+use Slim\Tests\TestCase;
+
+class Psr17FactoryTest extends TestCase
+{
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Slim\Tests\Mocks\MockPsr17Factory could not instantiate a response factory.
+     */
+    public function testGetResponseFactoryThrowsRuntimeException()
+    {
+        MockPsr17Factory::getResponseFactory();
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Slim\Tests\Mocks\MockPsr17Factory could not instantiate a stream factory.
+     */
+    public function testGetStreamFactoryThrowsRuntimeException()
+    {
+        MockPsr17Factory::getStreamFactory();
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Slim\Tests\Mocks\MockPsr17Factory could not instantiate a server request creator.
+     */
+    public function testGetServerRequestCreatorThrowsRuntimeException()
+    {
+        MockPsr17Factory::getServerRequestCreator();
+    }
+}

--- a/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
+++ b/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Factory\Psr17;
+
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionProperty;
+use RuntimeException;
+use Slim\Factory\Psr17\SlimHttpServerRequestCreator;
+use Slim\Http\ServerRequest;
+use Slim\Interfaces\ServerRequestCreatorInterface;
+use Slim\Tests\TestCase;
+
+class SlimHttpServerRequestCreatorTest extends TestCase
+{
+    /**
+     * We need to reset the static property of SlimHttpServerRequestCreator back to its original value
+     * Otherwise other tests will fail
+     */
+    public function tearDown()
+    {
+        $serverRequestCreatorProphecy = $this->prophesize(ServerRequestCreatorInterface::class);
+
+        $slimHttpServerRequestCreator = new SlimHttpServerRequestCreator($serverRequestCreatorProphecy->reveal());
+
+        $serverRequestDecoratorClassProperty = new ReflectionProperty(
+            SlimHttpServerRequestCreator::class,
+            'serverRequestDecoratorClass'
+        );
+        $serverRequestDecoratorClassProperty->setAccessible(true);
+        $serverRequestDecoratorClassProperty->setValue($slimHttpServerRequestCreator, ServerRequest::class);
+    }
+
+    public function testCreateServerRequestFromGlobals()
+    {
+        $serverRequestProphecy = $this->prophesize(ServerRequestInterface::class);
+
+        $serverRequestCreatorProphecy = $this->prophesize(ServerRequestCreatorInterface::class);
+
+        $serverRequestCreatorProphecy
+            ->createServerRequestFromGlobals()
+            ->willReturn($serverRequestProphecy->reveal())
+            ->shouldBeCalledOnce();
+
+        $slimHttpServerRequestCreator = new SlimHttpServerRequestCreator($serverRequestCreatorProphecy->reveal());
+
+        $this->assertInstanceOf(ServerRequest::class, $slimHttpServerRequestCreator->createServerRequestFromGlobals());
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The Slim-Http ServerRequest decorator is not available.
+     */
+    public function testCreateServerRequestFromGlobalsThrowsRuntimeException()
+    {
+        $serverRequestCreatorProphecy = $this->prophesize(ServerRequestCreatorInterface::class);
+
+        $slimHttpServerRequestCreator = new SlimHttpServerRequestCreator($serverRequestCreatorProphecy->reveal());
+
+        $serverRequestDecoratorClassProperty = new ReflectionProperty(
+            SlimHttpServerRequestCreator::class,
+            'serverRequestDecoratorClass'
+        );
+        $serverRequestDecoratorClassProperty->setAccessible(true);
+        $serverRequestDecoratorClassProperty->setValue($slimHttpServerRequestCreator, '');
+
+        $slimHttpServerRequestCreator->createServerRequestFromGlobals();
+    }
+}

--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -11,12 +11,15 @@ namespace Slim\Tests\Factory;
 
 use GuzzleHttp\Psr7\ServerRequest as GuzzleServerRequest;
 use Nyholm\Psr7\ServerRequest as NyholmServerRequest;
-use ReflectionProperty;
+use RuntimeException;
 use Slim\Factory\Psr17\GuzzlePsr17Factory;
 use Slim\Factory\Psr17\NyholmPsr17Factory;
+use Slim\Factory\Psr17\Psr17FactoryProvider;
+use Slim\Factory\Psr17\SlimHttpServerRequestCreator;
 use Slim\Factory\Psr17\SlimPsr17Factory;
 use Slim\Factory\Psr17\ZendDiactorosPsr17Factory;
 use Slim\Factory\ServerRequestCreatorFactory;
+use Slim\Http\ServerRequest;
 use Slim\Psr7\Request as SlimServerRequest;
 use Slim\Tests\TestCase;
 use Zend\Diactoros\ServerRequest as ZendServerRequest;
@@ -40,9 +43,8 @@ class ServerRequestCreatorFactoryTest extends TestCase
      */
     public function testCreateAppWithAllImplementations(string $psr17factory, string $expectedServerRequestClass)
     {
-        $psr17FactoriesProperty = new ReflectionProperty(ServerRequestCreatorFactory::class, 'psr17Factories');
-        $psr17FactoriesProperty->setAccessible(true);
-        $psr17FactoriesProperty->setValue([$psr17factory]);
+        Psr17FactoryProvider::setFactories([$psr17factory]);
+        ServerRequestCreatorFactory::setSlimHttpDecoratorsAutomaticDetection(false);
 
         $serverRequestCreator = ServerRequestCreatorFactory::create();
         $serverRequest = $serverRequestCreator->createServerRequestFromGlobals();
@@ -50,15 +52,23 @@ class ServerRequestCreatorFactoryTest extends TestCase
         $this->assertInstanceOf($expectedServerRequestClass, $serverRequest);
     }
 
+    public function testDetermineServerRequestCreatorReturnsDecoratedServerRequestCreator()
+    {
+        Psr17FactoryProvider::setFactories([SlimPsr17Factory::class]);
+        ServerRequestCreatorFactory::setSlimHttpDecoratorsAutomaticDetection(true);
+
+        $serverRequestCreator = ServerRequestCreatorFactory::create();
+
+        $this->assertInstanceOf(SlimHttpServerRequestCreator::class, $serverRequestCreator);
+        $this->assertInstanceOf(ServerRequest::class, $serverRequestCreator->createServerRequestFromGlobals());
+    }
+
     /**
-     * @expectedException \RuntimeException
+     * @expectedException RuntimeException
      */
     public function testDetermineServerRequestCreatorThrowsRuntimeException()
     {
-        $psr17FactoriesProperty = new ReflectionProperty(ServerRequestCreatorFactory::class, 'psr17Factories');
-        $psr17FactoriesProperty->setAccessible(true);
-        $psr17FactoriesProperty->setValue([]);
-
+        Psr17FactoryProvider::setFactories([]);
         ServerRequestCreatorFactory::create();
     }
 }

--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -71,4 +71,17 @@ class ServerRequestCreatorFactoryTest extends TestCase
         Psr17FactoryProvider::setFactories([]);
         ServerRequestCreatorFactory::create();
     }
+
+    public function testSetPsr17FactoryProvider()
+    {
+        $psr17FactoryProvider = new Psr17FactoryProvider();
+        $psr17FactoryProvider::setFactories([SlimPsr17Factory::class]);
+
+        ServerRequestCreatorFactory::setPsr17FactoryProvider($psr17FactoryProvider);
+        ServerRequestCreatorFactory::setSlimHttpDecoratorsAutomaticDetection(false);
+
+        $serverRequestCreator = ServerRequestCreatorFactory::create();
+
+        $this->assertInstanceOf(SlimServerRequest::class, $serverRequestCreator->createServerRequestFromGlobals());
+    }
 }

--- a/tests/Mocks/MockPsr17Factory.php
+++ b/tests/Mocks/MockPsr17Factory.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Slim\Tests\Mocks;
+
+use Slim\Factory\Psr17\Psr17Factory;
+
+class MockPsr17Factory extends Psr17Factory
+{
+    protected static $responseFactoryClass = '';
+    protected static $streamFactoryClass = '';
+    protected static $serverRequestCreatorClass = '';
+    protected static $serverRequestCreatorMethod = '';
+}


### PR DESCRIPTION
This PR is to enable users to provide their own set of PSR-17 factories to the `AppFactory` component.

It also adds `Slim-Http` auto-detection which automatically instantiates the `DecoratedResponseFactory` and automatically decorates the `ServerRequest` object incoming from the `ServerRequestCreator` that has been detected by `ServerRequestCreatorFactory`.

**Note that automatic decoration can be disabled via these methods:**
- AppFactory::setSlimHttpDecoratorsAutomaticDetection()
- ServerRequestCreatorFactory::setSlimHttpDecoratorsAutomaticDetection()

**In order for Slim-Http auto-detection to work you have to ensure it is installed:**
```bash
composer require slim/http
```