### PR TITLE
Add test case for \Slim\Routing\RouteGroup::getPattern

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -530,6 +530,19 @@ class AppTest extends TestCase
         $this->assertEquals($expectedPath, $route->getPattern());
     }
 
+    public function testRouteGroupPattern()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+
+        /** @var ResponseFactoryInterface $responseFactoryInterface */
+        $responseFactoryInterface = $responseFactoryProphecy->reveal();
+        $app = new App($responseFactoryInterface);
+        $group = $app->group('/foo', function () {
+        });
+
+        $this->assertEquals('/foo', $group->getPattern());
+    }
+
     /********************************************************************************
      * Middleware
      *******************************************************************************/


### PR DESCRIPTION
This PR adds a simple test case for
https://github.com/slimphp/Slim/blob/28691fafd51593764eed3ddeb9c069b258e06369/Slim/Routing/RouteGroup.php#L106-L109

Note that the test case would not use any data provider. It simply asserts that the pattern returned by the `getPattern()` method is the same as the one given to the `$app->group()` method.