### PR TITLE
4.x - Add test case for RoutingMiddleware::performRouting()

### DIFF
--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -96,6 +96,7 @@ class RoutingMiddlewareTest extends TestCase
 
     /**
      * @expectedException RuntimeException
+     * @expectedExceptionMessage An unexpected error occurred while performing routing.
      */
     public function testPerformRoutingThrowsExceptionOnInvalidRoutingResultsRouteStatus()
     {


### PR DESCRIPTION
Test case that checks whether the method `\Slim\Middleware\RoutingMiddleware::performRouting()` throws an exception in case the routing status of the routing results is invalid (unknown).