### PR TITLE
4.x - Add test case for MethodOverrideMiddleware::process() for eof body stream

### DIFF
--- a/tests/Middleware/MethodOverrideMiddlewareTest.php
+++ b/tests/Middleware/MethodOverrideMiddlewareTest.php
@@ -9,7 +9,8 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Middleware;
 
-use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
 use Slim\Middleware\MethodOverrideMiddleware;
 use Slim\MiddlewareDispatcher;
 use Slim\Tests\TestCase;
@@ -19,7 +20,7 @@ class MethodOverrideMiddlewareTest extends TestCase
     public function testHeader()
     {
         $responseFactory = $this->getResponseFactory();
-        $mw = (function ($request, $handler) use ($responseFactory) {
+        $mw = (function (Request $request, RequestHandler $handler) use ($responseFactory) {
             $this->assertEquals('PUT', $request->getMethod());
             return $responseFactory->createResponse();
         })->bindTo($this);
@@ -29,7 +30,7 @@ class MethodOverrideMiddlewareTest extends TestCase
             ->createServerRequest('/', 'POST')
             ->withHeader('X-Http-Method-Override', 'PUT');
 
-        $middlewareDispatcher = new MiddlewareDispatcher($this->createMock(RequestHandlerInterface::class));
+        $middlewareDispatcher = new MiddlewareDispatcher($this->createMock(RequestHandler::class));
         $middlewareDispatcher->addCallable($mw);
         $middlewareDispatcher->addMiddleware($mw2);
         $middlewareDispatcher->handle($request);
@@ -38,7 +39,7 @@ class MethodOverrideMiddlewareTest extends TestCase
     public function testBodyParam()
     {
         $responseFactory = $this->getResponseFactory();
-        $mw = (function ($request, $handler) use ($responseFactory) {
+        $mw = (function (Request $request, RequestHandler $handler) use ($responseFactory) {
             $this->assertEquals('PUT', $request->getMethod());
             return $responseFactory->createResponse();
         })->bindTo($this);
@@ -49,7 +50,7 @@ class MethodOverrideMiddlewareTest extends TestCase
             ->createServerRequest('/', 'POST')
             ->withParsedBody(['_METHOD' => 'PUT']);
 
-        $middlewareDispatcher = new MiddlewareDispatcher($this->createMock(RequestHandlerInterface::class));
+        $middlewareDispatcher = new MiddlewareDispatcher($this->createMock(RequestHandler::class));
         $middlewareDispatcher->addCallable($mw);
         $middlewareDispatcher->addMiddleware($mw2);
         $middlewareDispatcher->handle($request);
@@ -58,7 +59,7 @@ class MethodOverrideMiddlewareTest extends TestCase
     public function testHeaderPreferred()
     {
         $responseFactory = $this->getResponseFactory();
-        $mw = (function ($request, $handler) use ($responseFactory) {
+        $mw = (function (Request $request, RequestHandler $handler) use ($responseFactory) {
             $this->assertEquals('DELETE', $request->getMethod());
             return $responseFactory->createResponse();
         })->bindTo($this);
@@ -70,7 +71,7 @@ class MethodOverrideMiddlewareTest extends TestCase
             ->withHeader('X-Http-Method-Override', 'DELETE')
             ->withParsedBody((object) ['_METHOD' => 'PUT']);
 
-        $middlewareDispatcher = new MiddlewareDispatcher($this->createMock(RequestHandlerInterface::class));
+        $middlewareDispatcher = new MiddlewareDispatcher($this->createMock(RequestHandler::class));
         $middlewareDispatcher->addCallable($mw);
         $middlewareDispatcher->addMiddleware($mw2);
         $middlewareDispatcher->handle($request);
@@ -79,7 +80,7 @@ class MethodOverrideMiddlewareTest extends TestCase
     public function testNoOverride()
     {
         $responseFactory = $this->getResponseFactory();
-        $mw = (function ($request, $handler) use ($responseFactory) {
+        $mw = (function (Request $request, RequestHandler $handler) use ($responseFactory) {
             $this->assertEquals('POST', $request->getMethod());
             return $responseFactory->createResponse();
         })->bindTo($this);
@@ -88,7 +89,28 @@ class MethodOverrideMiddlewareTest extends TestCase
 
         $request = $this->createServerRequest('/', 'POST');
 
-        $middlewareDispatcher = new MiddlewareDispatcher($this->createMock(RequestHandlerInterface::class));
+        $middlewareDispatcher = new MiddlewareDispatcher($this->createMock(RequestHandler::class));
+        $middlewareDispatcher->addCallable($mw);
+        $middlewareDispatcher->addMiddleware($mw2);
+        $middlewareDispatcher->handle($request);
+    }
+
+    public function testNoOverrideRewindEofBodyStream()
+    {
+        $responseFactory = $this->getResponseFactory();
+        $mw = (function (Request $request, RequestHandler $handler) use ($responseFactory) {
+            $this->assertEquals('POST', $request->getMethod());
+            return $responseFactory->createResponse();
+        })->bindTo($this);
+
+        $mw2 = new MethodOverrideMiddleware();
+
+        $request = $this->createServerRequest('/', 'POST');
+
+        // Consume the body contents in order to get the stream to the end.
+        $request->getBody()->getContents();
+
+        $middlewareDispatcher = new MiddlewareDispatcher($this->createMock(RequestHandler::class));
         $middlewareDispatcher->addCallable($mw);
         $middlewareDispatcher->addMiddleware($mw2);
         $middlewareDispatcher->handle($request);


### PR DESCRIPTION
This PR adds a test case that prophesizes a body stream in order to be able to test whether or not the following lines of code would actually be called.
https://github.com/slimphp/Slim/blob/5cc55c6cc99faf18f74686cbe1fa7a23b087fff9/Slim/Middleware/MethodOverrideMiddleware.php#L37-L39

Not sure, if the test case is as desired. It is more or less a duplicate of the `\Slim\Tests\Middleware\MethodOverrideMiddlewareTest::testNoOverride()` test case. So instead of calling the `\Slim\Middleware\MethodOverrideMiddleware::process()` method directly, the test case uses a middleware dispatcher.

Additionally some type hints had been added to various closures in the class.