### PR TITLE
Fix trailing question mark when query values are null

### DIFF
--- a/Slim/Router.php
+++ b/Slim/Router.php
@@ -382,7 +382,11 @@ class Router implements RouterInterface
         }
         $url = implode('', $segments);
 
-        if ($queryParams) {
+        $hasQueryParams = array_filter($queryParams, function ($value) {
+            return $value !== null;
+        }) !== [];
+
+        if ($hasQueryParams) {
             $url .= '?' . http_build_query($queryParams);
         }
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -180,6 +180,22 @@ class RouterTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testPathForWithNullQueryParameters()
+    {
+        $methods = ['GET'];
+        $pattern = '/hello/{name}';
+        $callable = function ($request, $response, $args) {
+            echo sprintf('Hello %s', $args['name']);
+        };
+        $route = $this->router->map($methods, $pattern, $callable);
+        $route->setName('foo');
+
+        $this->assertEquals(
+            '/hello/josh',
+            $this->router->pathFor('foo', ['name' => 'josh'], ['a' => null])
+        );
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */


### PR DESCRIPTION
`http_build_query` ignores values that are null, so URLs where all the query data is null leaves a trailing question mark. This PR resolves this.