### PR TITLE
 4.x - Improve AppFactory & ServerRequestCreatorFactory Automatic Decoration

### DIFF
--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -130,8 +130,10 @@ class AppFactory
      * @param StreamFactoryInterface   $streamFactory
      * @return ResponseFactoryInterface
      */
-    protected static function attemptResponseFactoryDecoration(ResponseFactoryInterface $responseFactory, StreamFactoryInterface $streamFactory): ResponseFactoryInterface
-    {
+    protected static function attemptResponseFactoryDecoration(
+        ResponseFactoryInterface $responseFactory,
+        StreamFactoryInterface $streamFactory
+    ): ResponseFactoryInterface {
         if (static::$slimHttpDecoratorsAutomaticDetectionEnabled
             && SlimHttpPsr17Factory::isResponseFactoryAvailable()
         ) {

--- a/Slim/Factory/ServerRequestCreatorFactory.php
+++ b/Slim/Factory/ServerRequestCreatorFactory.php
@@ -73,8 +73,9 @@ class ServerRequestCreatorFactory
      * @param ServerRequestCreatorInterface $serverRequestCreator
      * @return ServerRequestCreatorInterface
      */
-    protected static function attemptServerRequestCreatorDecoration(ServerRequestCreatorInterface $serverRequestCreator): ServerRequestCreatorInterface
-    {
+    protected static function attemptServerRequestCreatorDecoration(
+        ServerRequestCreatorInterface $serverRequestCreator
+    ): ServerRequestCreatorInterface {
         if (static::$slimHttpDecoratorsAutomaticDetectionEnabled
             && SlimHttpServerRequestCreator::isServerRequestDecoratorAvailable()
         ) {

--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -11,6 +11,7 @@ namespace Slim\Tests\Factory;
 
 use GuzzleHttp\Psr7\ServerRequest as GuzzleServerRequest;
 use Nyholm\Psr7\ServerRequest as NyholmServerRequest;
+use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use Slim\Factory\Psr17\GuzzlePsr17Factory;
 use Slim\Factory\Psr17\NyholmPsr17Factory;
@@ -20,6 +21,8 @@ use Slim\Factory\Psr17\SlimPsr17Factory;
 use Slim\Factory\Psr17\ZendDiactorosPsr17Factory;
 use Slim\Factory\ServerRequestCreatorFactory;
 use Slim\Http\ServerRequest;
+use Slim\Interfaces\ServerRequestCreatorInterface;
+use Slim\Psr7\Factory\ServerRequestFactory;
 use Slim\Psr7\Request as SlimServerRequest;
 use Slim\Tests\TestCase;
 use Zend\Diactoros\ServerRequest as ZendServerRequest;
@@ -83,5 +86,22 @@ class ServerRequestCreatorFactoryTest extends TestCase
         $serverRequestCreator = ServerRequestCreatorFactory::create();
 
         $this->assertInstanceOf(SlimServerRequest::class, $serverRequestCreator->createServerRequestFromGlobals());
+    }
+
+    public function testSetServerRequestCreator()
+    {
+        $serverRequestProphecy = $this->prophesize(ServerRequestInterface::class);
+
+        $serverRequestCreatorProphecy = $this->prophesize(ServerRequestCreatorInterface::class);
+        $serverRequestCreatorProphecy
+            ->createServerRequestFromGlobals()
+            ->willReturn($serverRequestProphecy->reveal())
+            ->shouldBeCalledOnce();
+
+        ServerRequestCreatorFactory::setServerRequestCreator($serverRequestCreatorProphecy->reveal());
+
+        $serverRequestCreator = ServerRequestCreatorFactory::create();
+
+        $this->assertSame($serverRequestProphecy->reveal(), $serverRequestCreator->createServerRequestFromGlobals());
     }
 }

--- a/tests/Mocks/MockPsr17FactoryWithoutStreamFactory.php
+++ b/tests/Mocks/MockPsr17FactoryWithoutStreamFactory.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Mocks;
+
+use Slim\Factory\Psr17\Psr17Factory;
+
+class MockPsr17FactoryWithoutStreamFactory extends Psr17Factory
+{
+    protected static $responseFactoryClass = 'Slim\Psr7\Factory\ResponseFactory';
+    protected static $streamFactoryClass = '';
+    protected static $serverRequestCreatorClass = '';
+    protected static $serverRequestCreatorMethod = '';
+}


### PR DESCRIPTION
**AppFactory's New Behavior**
`AppFactory` will attempt to decorate `ResponseFactory` instances passed via `AppFactory::create()` or set via `AppFactory::setResponseFactory()` given that a `StreamFactoryInterface` has been set via `AppFactory::setStreamFactory()` given that `Slim\Http` is present.

Note that the `AppFactory` setters will override any of the PSR-17 factory provider automatically detected implementations.

```php
<?php
use Slim\Factory\AppFactory;
use Your\Psr7\CustomResponseFactory;
use Your\Psr7\CustomStreamFactory;

// Set your custom StreamFactory first
$myStreamFactory = new CustomStreamFactory();
AppFactory::setStreamFactory($myStreamFactory);

// You can use a setter for your ResponseFactory
$myCustomResponseFactory = new CustomResponseFactory();
AppFactory::setResponseFactory($myCustomResponseFactory);
$app = AppFactory::create();

// Or you can use the AppFactory::create() constructor parameter
$app = AppFactory::create($myCustomResponseFactory);
```

**ServerRequestCreatorFactory's New Behavior**
Similarly to `AppFactory` you can set a default `ServerRequestCreator` which implements `ServerRequestCreatorInterface` that will override the automatically detected server request creators present in the PSR-17 factory provider.

```php
<?php
use Slim\Factory\AppFactory;
use Slim\Factory\ServerRequestCreatorFactory;
use Your\Psr7\CustomServerRequestCreator;

$myCustomServerRequestCreator = new CustomServerRequestCreator();
ServerRequestCreatorFactory::setServerRequestCreator($myCustomServerRequestCreator);

$app = AppFactory::create();
$app->run();
```

This PR effectively closes #2709, #2710, #2712  and #2713

