### PR TITLE
add member variable  for AbstractError classes

### DIFF
--- a/Slim/Handlers/AbstractError.php
+++ b/Slim/Handlers/AbstractError.php
@@ -18,6 +18,11 @@ abstract class AbstractError extends AbstractHandler
     protected $displayErrorDetails;
 
     /**
+     * @var string
+     */
+    protected $title = 'Slim Application Error';
+
+    /**
      * @param bool $displayErrorDetails Set to true to display full details
      */
     public function __construct($displayErrorDetails = false)
@@ -38,7 +43,7 @@ abstract class AbstractError extends AbstractHandler
             return;
         }
 
-        $message = 'Slim Application Error:' . PHP_EOL;
+        $message = $this->title . ':' . PHP_EOL;
         $message .= $this->renderThrowableAsText($throwable);
         while ($throwable = $throwable->getPrevious()) {
             $message .= PHP_EOL . 'Previous error:' . PHP_EOL;

--- a/Slim/Handlers/Error.php
+++ b/Slim/Handlers/Error.php
@@ -66,8 +66,6 @@ class Error extends AbstractError
      */
     protected function renderHtmlErrorMessage(Exception $exception)
     {
-        $title = 'Slim Application Error';
-
         if ($this->displayErrorDetails) {
             $html = '<p>The application could not run because of the following error:</p>';
             $html .= '<h2>Details</h2>';
@@ -86,8 +84,8 @@ class Error extends AbstractError
             "<title>%s</title><style>body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana," .
             "sans-serif;}h1{margin:0;font-size:48px;font-weight:normal;line-height:48px;}strong{" .
             "display:inline-block;width:65px;}</style></head><body><h1>%s</h1>%s</body></html>",
-            $title,
-            $title,
+            $this->title,
+            $this->title,
             $html
         );
 
@@ -159,7 +157,7 @@ class Error extends AbstractError
     protected function renderJsonErrorMessage(Exception $exception)
     {
         $error = [
-            'message' => 'Slim Application Error',
+            'message' => $this->title,
         ];
 
         if ($this->displayErrorDetails) {
@@ -189,7 +187,7 @@ class Error extends AbstractError
      */
     protected function renderXmlErrorMessage(Exception $exception)
     {
-        $xml = "<error>\n  <message>Slim Application Error</message>\n";
+        $xml = "<error>\n  <message>" . $this->title . "</message>\n";
         if ($this->displayErrorDetails) {
             do {
                 $xml .= "  <exception>\n";

--- a/Slim/Handlers/PhpError.php
+++ b/Slim/Handlers/PhpError.php
@@ -64,8 +64,6 @@ class PhpError extends AbstractError
      */
     protected function renderHtmlErrorMessage(Throwable $error)
     {
-        $title = 'Slim Application Error';
-
         if ($this->displayErrorDetails) {
             $html = '<p>The application could not run because of the following error:</p>';
             $html .= '<h2>Details</h2>';
@@ -84,8 +82,8 @@ class PhpError extends AbstractError
             "<title>%s</title><style>body{margin:0;padding:30px;font:12px/1.5 Helvetica,Arial,Verdana," .
             "sans-serif;}h1{margin:0;font-size:48px;font-weight:normal;line-height:48px;}strong{" .
             "display:inline-block;width:65px;}</style></head><body><h1>%s</h1>%s</body></html>",
-            $title,
-            $title,
+            $this->title,
+            $this->title,
             $html
         );
 
@@ -137,7 +135,7 @@ class PhpError extends AbstractError
     protected function renderJsonErrorMessage(Throwable $error)
     {
         $json = [
-            'message' => 'Slim Application Error',
+            'message' => $this->title,
         ];
 
         if ($this->displayErrorDetails) {
@@ -167,7 +165,7 @@ class PhpError extends AbstractError
      */
     protected function renderXmlErrorMessage(Throwable $error)
     {
-        $xml = "<error>\n  <message>Slim Application Error</message>\n";
+        $xml = "<error>\n  <message>" . $this->title . "</message>\n";
         if ($this->displayErrorDetails) {
             do {
                 $xml .= "  <error>\n";


### PR DESCRIPTION
For errors I want to use the Slim error handlers. Because I'm using Twig, I have derived my own classes and overwrote the html output methods. The only bad thing was the fixed title 'Slim Application Error'. It was quite deep in the code so that I would have had to do a slow string replace afterwards or double the entire functions. Instead I decided to move this string into a member variable.