### PR TITLE
Change empty to empty and !is_numeric

### DIFF
--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -129,7 +129,7 @@ class ResponseEmitter
      */
     public function isResponseEmpty(ResponseInterface $response): bool
     {
-        $contents = (string)$response->getBody();
+        $contents = (string) $response->getBody();
         return (empty($contents) && !is_numeric($contents))
             || in_array($response->getStatusCode(), [204, 205, 304], true);
     }

--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -129,7 +129,8 @@ class ResponseEmitter
      */
     public function isResponseEmpty(ResponseInterface $response): bool
     {
-        $contents = (string) $response->getBody();
-        return empty($contents) || in_array($response->getStatusCode(), [204, 205, 304], true);
+        $contents = (string)$response->getBody();
+        return (empty($contents) && !is_numeric($contents))
+            || in_array($response->getStatusCode(), [204, 205, 304], true);
     }
 }

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -180,6 +180,17 @@ class ResponseEmitterTest extends TestCase
         $this->assertTrue($responseEmitter->isResponseEmpty($response));
     }
 
+    public function testIsResponseEmptyWithZeroAsBody()
+    {
+        $body = $this->createStream('0');
+        $response = $this
+            ->createResponse(200)
+            ->withBody($body);
+        $responseEmitter = new ResponseEmitter();
+
+        $this->assertFalse($responseEmitter->isResponseEmpty($response));
+    }
+
     public function testWillHandleInvalidConnectionStatusWithADeterminateBody()
     {
         $body = $this->getStreamFactory()->createStreamFromResource(fopen('php://temp', 'r+'));


### PR DESCRIPTION
If the body is '0' for example, the php method `empty()` would return `true`. But `\Slim\ResponseEmitter::isResponseEmpty` should return `false` in this case. So this PR adds a second condition, `!is_numeric()` to assure this.