### PR TITLE
Add !is_numeric to empty condition

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -118,7 +118,7 @@ class Uri implements UriInterface
         $this->scheme = $this->filterScheme($scheme);
         $this->host = $host;
         $this->port = $this->filterPort($port);
-        $this->path = empty($path) ? '/' : $this->filterPath($path);
+        $this->path = empty($path) && !is_numeric($path) ? '/' : $this->filterPath($path);
         $this->query = $this->filterQuery($query);
         $this->fragment = $this->filterQuery($fragment);
         $this->user = $user;

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -708,4 +708,16 @@ class UriTest extends PHPUnit_Framework_TestCase
         $expected = 'https://0:0@0:1/0?0#0';
         $this->assertSame('https://0:0@0:1', (string) Uri::createFromString($expected)->getBaseUrl());
     }
+
+    public function testCreatorWithEmptyPath()
+    {
+        $uri = new Uri('https', 'example.com', null, '');
+        $this->assertSame('/', $uri->getPath());
+    }
+
+    public function testCreatorWithZeroAsPath()
+    {
+        $uri = new Uri('https', 'example.com', null, '0');
+        $this->assertSame('0', (string) $uri->getPath());
+    }
 }

--- a/tests/Http/UriTest.php
+++ b/tests/Http/UriTest.php
@@ -709,13 +709,13 @@ class UriTest extends PHPUnit_Framework_TestCase
         $this->assertSame('https://0:0@0:1', (string) Uri::createFromString($expected)->getBaseUrl());
     }
 
-    public function testCreatorWithEmptyPath()
+    public function testConstructorWithEmptyPath()
     {
         $uri = new Uri('https', 'example.com', null, '');
         $this->assertSame('/', $uri->getPath());
     }
 
-    public function testCreatorWithZeroAsPath()
+    public function testConstructorWithZeroAsPath()
     {
         $uri = new Uri('https', 'example.com', null, '0');
         $this->assertSame('0', (string) $uri->getPath());


### PR DESCRIPTION
This PR would patch `\Slim\Http\Uri::__construct()` in case the given `path` is a string like `"0"`. The php function `empty` would return `true` in that case, but we should treat that as being non-empty :-)