### PR TITLE
[4.x] Change empty() and !is_numeric() to !strlen()

### DIFF
--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -130,7 +130,7 @@ class ResponseEmitter
     public function isResponseEmpty(ResponseInterface $response): bool
     {
         $contents = (string) $response->getBody();
-        return (empty($contents) && !is_numeric($contents))
-            || in_array($response->getStatusCode(), [204, 205, 304], true);
+
+        return !strlen($contents) || in_array($response->getStatusCode(), [204, 205, 304], true);
     }
 }


### PR DESCRIPTION
This PR would replace PR https://github.com/slimphp/Slim/pull/2719.

Instead of `empty()` and `!is_numeric()`, we simply use `!strlen()` to check if the body is empty in `\Slim\ResponseEmitter::isResponseEmpty()`.