### PR TITLE
[3.x] Change empty() and !is_numeric() to !strlen()

### DIFF
--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -118,7 +118,7 @@ class Uri implements UriInterface
         $this->scheme = $this->filterScheme($scheme);
         $this->host = $host;
         $this->port = $this->filterPort($port);
-        $this->path = empty($path) && !is_numeric($path) ? '/' : $this->filterPath($path);
+        $this->path = ($path === null || !strlen($path)) ? '/' : $this->filterPath($path);
         $this->query = $this->filterQuery($query);
         $this->fragment = $this->filterQuery($fragment);
         $this->user = $user;


### PR DESCRIPTION
This PR would replace #2720. It changes the `empty()` and `!is_numeric()` condition on the path to `=== null` and `!strlen()`.

Not sure if the `null` condition is really required, what do you think?