### PR TITLE
[4.x] Make Slim routing as extensible as possible

### DIFF
--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -13,12 +13,12 @@ class Dispatcher implements DispatcherInterface
     /**
      * @var RouteCollectorInterface
      */
-    private $routeCollector;
+    protected $routeCollector;
 
     /**
      * @var FastRouteDispatcher|null
      */
-    private $dispatcher;
+    protected $dispatcher;
 
     /**
      * @param RouteCollectorInterface $routeCollector

--- a/Slim/Routing/FastRouteDispatcher.php
+++ b/Slim/Routing/FastRouteDispatcher.php
@@ -16,7 +16,7 @@ class FastRouteDispatcher extends GroupCountBased
     /**
      * @var array
      */
-    private $allowedMethods = [];
+    protected $allowedMethods = [];
 
     /**
      * @param string $httpMethod

--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -20,12 +20,12 @@ class RouteParser implements RouteParserInterface
     /**
      * @var RouteCollectorInterface
      */
-    private $routeCollector;
+    protected $routeCollector;
 
     /**
      * @var Std
      */
-    private $routeParser;
+    protected $routeParser;
 
     /**
      * @param RouteCollectorInterface $routeCollector

--- a/Slim/Routing/RouteResolver.php
+++ b/Slim/Routing/RouteResolver.php
@@ -29,7 +29,7 @@ class RouteResolver implements RouteResolverInterface
     /**
      * @var DispatcherInterface
      */
-    private $dispatcher;
+    protected $dispatcher;
 
     /**
      * @param RouteCollectorInterface  $routeCollector

--- a/Slim/Routing/RouteRunner.php
+++ b/Slim/Routing/RouteRunner.php
@@ -22,7 +22,7 @@ class RouteRunner implements RequestHandlerInterface
     /**
      * @var RouteResolverInterface
      */
-    private $routeResolver;
+    protected $routeResolver;
 
     /**
      * @param RouteResolverInterface $routeResolver


### PR DESCRIPTION
This PR would change some properties from `private` to `protected` in order to make the classes extensible.