### PR TITLE
[4.x] Fix argument type hint

### DIFF
--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -36,7 +36,7 @@ class MiddlewareDispatcher implements RequestHandlerInterface
      */
     public function __construct(
         RequestHandlerInterface $kernel,
-        ContainerInterface $container = null
+        ?ContainerInterface $container = null
     ) {
         $this->seedMiddlewareStack($kernel);
         $this->container = $container;


### PR DESCRIPTION
This PR simply fixes an argument type hint that could be `null`.