### PR TITLE
[4.x] Fix argument type hint

### DIFF
--- a/Slim/DeferredCallable.php
+++ b/Slim/DeferredCallable.php
@@ -27,7 +27,7 @@ class DeferredCallable
      * @param callable|string                $callable
      * @param CallableResolverInterface|null $resolver
      */
-    public function __construct($callable, CallableResolverInterface $resolver = null)
+    public function __construct($callable, ?CallableResolverInterface $resolver = null)
     {
         $this->callable = $callable;
         $this->callableResolver = $resolver;


### PR DESCRIPTION
This PR fixes an argument type-hint that could be `null`.