### PR TITLE
Group method was missing string typehint for callable

### DIFF
--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -139,8 +139,8 @@ interface RouteCollectorProxyInterface
      * declarations in the callback will be prepended by the group(s)
      * that it is in.
      *
-     * @param string   $pattern
-     * @param callable $callable
+     * @param string          $pattern
+     * @param string|callable $callable
      *
      * @return RouteGroupInterface
      */


### PR DESCRIPTION
Now it's consistent with RouteCollectorInterface

PHPStan complained when I did `$app->group('/pattern', InvokableClassThatDefinesRoutes::class)`, which does work.