### PR TITLE
[4.x] Display previous exception(s) only if displayErrorDetails is enabled

### DIFF
--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -27,10 +27,10 @@ class PlainTextErrorRenderer extends AbstractErrorRenderer
         $text = "Slim Application Error:\n";
         $text .= $this->formatExceptionFragment($exception);
 
-        do {
+        while ($displayErrorDetails && $exception = $exception->getPrevious()) {
             $text .= "\nPrevious Error:\n";
             $text .= $this->formatExceptionFragment($exception);
-        } while ($exception = $exception->getPrevious());
+        }
 
         return $text;
     }


### PR DESCRIPTION
This PR addresses #2739.

The do-while-loop would be changed into a while-loop to ensure that the block only will be executed, if there is actually a previous exception.