### PR TITLE
[4.x] Wrap error message into CDATA section in XML Error Renderer

### DIFF
--- a/Slim/Error/Renderers/XmlErrorRenderer.php
+++ b/Slim/Error/Renderers/XmlErrorRenderer.php
@@ -24,7 +24,7 @@ class XmlErrorRenderer extends AbstractErrorRenderer
      */
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
-        $xml = "<error>\n  <message>{$exception->getMessage()}</message>\n";
+        $xml = "<error>\n  <message>".$this->createCdataSection($exception->getMessage())."</message>\n";
 
         if ($displayErrorDetails) {
             do {


### PR DESCRIPTION
This PR wraps the message of the first error into a CDATA-section.