### PR TITLE
[4.x] Add content-type for the default error renderer

### DIFF
--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -69,7 +69,7 @@ class ErrorHandler implements ErrorHandlerInterface
     protected $logErrorDetails;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $contentType;
 

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -215,7 +215,7 @@ class ErrorHandler implements ErrorHandlerInterface
      */
     protected function determineRenderer(): callable
     {
-        if (array_key_exists($this->contentType, $this->errorRenderers)) {
+        if (!is_null($this->contentType) && array_key_exists($this->contentType, $this->errorRenderers)) {
             $renderer = $this->errorRenderers[$this->contentType];
         } else {
             $renderer = $this->defaultErrorRenderer;
@@ -277,7 +277,7 @@ class ErrorHandler implements ErrorHandlerInterface
     protected function respond(): ResponseInterface
     {
         $response = $this->responseFactory->createResponse($this->statusCode);
-        if (array_key_exists($this->contentType, $this->errorRenderers)) {
+        if (!is_null($this->contentType) && array_key_exists($this->contentType, $this->errorRenderers)) {
             $response = $response->withHeader('Content-type', $this->contentType);
         } else {
             $response = $response->withHeader('Content-type', $this->defaultErrorRendererContentType);

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -138,13 +138,25 @@ class ErrorHandler implements ErrorHandlerInterface
         $this->exception = $exception;
         $this->method = $request->getMethod();
         $this->statusCode = $this->determineStatusCode();
-        $this->contentType = $this->determineContentType($request);
+        if (is_null($this->contentType)) {
+            $this->contentType = $this->determineContentType($request);
+        }
 
         if ($logErrors) {
             $this->writeToErrorLog();
         }
 
         return $this->respond();
+    }
+
+    /**
+     * Force the content type for all error handler responses.
+     *
+     * @param string|null $contentType The content type
+     */
+    public function forceContentType(?string $contentType): void
+    {
+        $this->contentType = $contentType;
     }
 
     /**

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -203,7 +203,7 @@ class ErrorHandlerTest extends TestCase
     {
         $request = $this
             ->createServerRequest('/', 'GET')
-            ->withHeader('Content-Type', 'text/plain,text/html');
+            ->withHeader('Accept', 'text/plain,text/html');
 
         // provide access to the determineContentType() as it's a protected method
         $class = new ReflectionClass(ErrorHandler::class);

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -92,6 +92,26 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals($statusCode, 500);
     }
 
+    /**
+     * Test if we can force the content type of all error handler responses.
+     */
+    public function testForceContentType()
+    {
+        $request = $this
+            ->createServerRequest('/not-defined', 'GET')
+            ->withHeader('Accept', 'text/plain,text/xml');
+
+        $handler = new ErrorHandler($this->getCallableResolver(), $this->getResponseFactory());
+        $handler->forceContentType('application/json');
+
+        $exception = new HttpNotFoundException($request);
+
+        /** @var ResponseInterface $response */
+        $response = $handler->__invoke($request, $exception, false, false, false);
+
+        $this->assertSame(['application/json'], $response->getHeader('Content-Type'));
+    }
+
     public function testHalfValidContentType()
     {
         $request = $this


### PR DESCRIPTION
This PR addresses #2749.

There is one commit https://github.com/slimphp/Slim/commit/419f9bd91fc3f78b2395bb9b1d524ac45e3d3803 that is actually a fix (independent of the issue).
