### PR TITLE
4.x - Add route context helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 4.0.0 - 2019-07-03
 
 ### Added
+- [#2759](https://github.com/slimphp/Slim/pull/2759) Add `RouteContext` to enable access to the current route, route parser, and routing results.
 - [#2654](https://github.com/slimphp/Slim/pull/2654) `RouteParser::pathFor()` and `RouteParser::relativePathFor()` are deprecated. Use `RouteParser::urlFor()` and `RouteParser::relativeUrlFor()`
 - [#2642](https://github.com/slimphp/Slim/pull/2642) Add `AppFactory` to enable PSR-7 implementation and ServerRequest creator auto-detection.
 - [#2641](https://github.com/slimphp/Slim/pull/2641) Add `RouteCollectorProxyInterface` which extracts all the route mapping functionality from app into its own interface.

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -68,7 +68,7 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
         );
 
         $this->routeResolver = $routeResolver ?? new RouteResolver($this->routeCollector);
-        $routeRunner = new RouteRunner($this->routeResolver);
+        $routeRunner = new RouteRunner($this->routeResolver, $this->routeCollector->getRouteParser());
 
         $this->middlewareDispatcher = new MiddlewareDispatcher($routeRunner, $container);
     }

--- a/Slim/Routing/RouteContext.php
+++ b/Slim/Routing/RouteContext.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Routing;
+
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+use Slim\Interfaces\RouteInterface;
+use Slim\Interfaces\RouteParserInterface;
+
+final class RouteContext
+{
+    /**
+     * @param ServerRequestInterface $serverRequest
+     * @return RouteContext
+     */
+    public static function fromRequest(ServerRequestInterface $serverRequest): self
+    {
+        $route = $serverRequest->getAttribute('route');
+        $routeParser = $serverRequest->getAttribute('routeParser');
+        $routingResults = $serverRequest->getAttribute('routingResults');
+
+        if ($routeParser === null || $routingResults === null) {
+            throw new RuntimeException('Cannot create RouteContext before routing has been completed');
+        }
+
+        return new self($route, $routeParser, $routingResults);
+    }
+
+    /**
+     * @var RouteInterface|null
+     */
+    private $route;
+
+    /**
+     * @var RouteParserInterface
+     */
+    private $routeParser;
+
+    /**
+     * @var RoutingResults
+     */
+    private $routingResults;
+
+    /**
+     * @param RouteInterface|null  $route
+     * @param RouteParserInterface $routeParser
+     * @param RoutingResults       $routingResults
+     */
+    private function __construct(
+        ?RouteInterface $route,
+        RouteParserInterface $routeParser,
+        RoutingResults $routingResults
+    ) {
+        $this->route = $route;
+        $this->routeParser = $routeParser;
+        $this->routingResults = $routingResults;
+    }
+
+    /**
+     * @return RouteInterface|null
+     */
+    public function getRoute(): ?RouteInterface
+    {
+        return $this->route;
+    }
+
+    /**
+     * @return RouteParserInterface
+     */
+    public function getRouteParser(): RouteParserInterface
+    {
+        return $this->routeParser;
+    }
+
+    /**
+     * @return RoutingResults
+     */
+    public function getRoutingResults(): RoutingResults
+    {
+        return $this->routingResults;
+    }
+}

--- a/Slim/Routing/RouteRunner.php
+++ b/Slim/Routing/RouteRunner.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
+use Slim\Interfaces\RouteParserInterface;
 use Slim\Interfaces\RouteResolverInterface;
 use Slim\Middleware\RoutingMiddleware;
 
@@ -25,11 +26,18 @@ class RouteRunner implements RequestHandlerInterface
     private $routeResolver;
 
     /**
-     * @param RouteResolverInterface $routeResolver
+     * @var RouteParserInterface
      */
-    public function __construct(RouteResolverInterface $routeResolver)
+    private $routeParser;
+
+    /**
+     * @param RouteResolverInterface $routeResolver
+     * @param RouteParserInterface   $routeParser
+     */
+    public function __construct(RouteResolverInterface $routeResolver, RouteParserInterface $routeParser)
     {
         $this->routeResolver = $routeResolver;
+        $this->routeParser = $routeParser;
     }
 
     /**
@@ -48,7 +56,7 @@ class RouteRunner implements RequestHandlerInterface
     {
         // If routing hasn't been done, then do it now so we can dispatch
         if ($request->getAttribute('routingResults') === null) {
-            $routingMiddleware = new RoutingMiddleware($this->routeResolver);
+            $routingMiddleware = new RoutingMiddleware($this->routeResolver, $this->routeParser);
             $request = $routingMiddleware->performRouting($request);
         }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -27,6 +27,7 @@ use Slim\Handlers\Strategies\RequestResponseArgs;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteCollectorProxyInterface;
+use Slim\Interfaces\RouteParserInterface;
 use Slim\Routing\RouteCollector;
 use Slim\Routing\RouteCollectorProxy;
 use Slim\Tests\Mocks\MockAction;
@@ -85,6 +86,10 @@ class AppTest extends TestCase
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+        $routeParserProphecy = $this->prophesize(RouteParserInterface::class);
+
+        $routeCollectorProphecy->getRouteParser()->willReturn($routeParserProphecy->reveal());
+
         $app = new App($responseFactoryProphecy->reveal(), null, null, $routeCollectorProphecy->reveal());
 
         $this->assertSame($routeCollectorProphecy->reveal(), $app->getRouteCollector());

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -27,6 +27,7 @@ use Slim\Http\Factory\DecoratedResponseFactory;
 use Slim\Http\Response as DecoratedResponse;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteCollectorInterface;
+use Slim\Interfaces\RouteParserInterface;
 use Slim\Interfaces\RouteResolverInterface;
 use Slim\Psr7\Factory\ResponseFactory as SlimResponseFactory;
 use Slim\Routing\RouteCollector;
@@ -114,7 +115,10 @@ class AppFactoryTest extends TestCase
         $containerProphecy = $this->prophesize(ContainerInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
         $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+        $routeParserProphecy = $this->prophesize(RouteParserInterface::class);
         $routeResolverProphecy = $this->prophesize(RouteResolverInterface::class);
+
+        $routeCollectorProphecy->getRouteParser()->willReturn($routeParserProphecy);
 
         AppFactory::setSlimHttpDecoratorsAutomaticDetection(false);
         AppFactory::setResponseFactory($responseFactoryProphecy->reveal());
@@ -157,7 +161,10 @@ class AppFactoryTest extends TestCase
         $containerProphecy = $this->prophesize(ContainerInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
         $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+        $routeParserProphecy = $this->prophesize(RouteParserInterface::class);
         $routeResolverProphecy = $this->prophesize(RouteResolverInterface::class);
+
+        $routeCollectorProphecy->getRouteParser()->willReturn($routeParserProphecy->reveal());
 
         AppFactory::setSlimHttpDecoratorsAutomaticDetection(false);
 

--- a/tests/Middleware/ErrorMiddlewareTest.php
+++ b/tests/Middleware/ErrorMiddlewareTest.php
@@ -28,7 +28,7 @@ class ErrorMiddlewareTest extends TestCase
         $app = new App($responseFactory);
         $callableResolver = $app->getCallableResolver();
 
-        $mw = new RoutingMiddleware($app->getRouteResolver());
+        $mw = new RoutingMiddleware($app->getRouteResolver(), $app->getRouteCollector()->getRouteParser());
         $app->add($mw);
 
         $exception = HttpNotFoundException::class;
@@ -54,7 +54,7 @@ class ErrorMiddlewareTest extends TestCase
         $app = new App($responseFactory);
         $callableResolver = $app->getCallableResolver();
 
-        $mw = new RoutingMiddleware($app->getRouteResolver());
+        $mw = new RoutingMiddleware($app->getRouteResolver(), $app->getRouteCollector()->getRouteParser());
         $app->add($mw);
 
         $handler = (function () {

--- a/tests/Routing/RouteContextTest.php
+++ b/tests/Routing/RouteContextTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Routing;
+
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+use Slim\Interfaces\RouteInterface;
+use Slim\Interfaces\RouteParserInterface;
+use Slim\Routing\RouteContext;
+use Slim\Routing\RoutingResults;
+use Slim\Tests\TestCase;
+
+class RouteContextTest extends TestCase
+{
+    public function testCanCreateInstanceFromServerRequest(): void
+    {
+        $route = $this->createMock(RouteInterface::class);
+        $routeParser = $this->createMock(RouteParserInterface::class);
+        $routingResults = $this->createMock(RoutingResults::class);
+
+        $serverRequest = $this->createServerRequest('/')
+                              ->withAttribute('route', $route)
+                              ->withAttribute('routeParser', $routeParser)
+                              ->withAttribute('routingResults', $routingResults);
+
+        $routeContext = RouteContext::fromRequest($serverRequest);
+
+        $this->assertSame($route, $routeContext->getRoute());
+        $this->assertSame($routeParser, $routeContext->getRouteParser());
+        $this->assertSame($routingResults, $routeContext->getRoutingResults());
+    }
+
+    public function testCanCreateInstanceWithoutRoute(): void
+    {
+        $serverRequest = $this->createServerRequestWithRouteAttributes();
+
+        // Route attribute is not required
+        $serverRequest = $serverRequest->withoutAttribute('route');
+
+        $routeContext = RouteContext::fromRequest($serverRequest);
+        $this->assertNull($routeContext->getRoute());
+        $this->assertNotNull($routeContext->getRouteParser());
+        $this->assertNotNull($routeContext->getRoutingResults());
+    }
+
+    public function requiredRouteContextRequestAttributes(): array
+    {
+        return [
+            ['routeParser'],
+            ['routingResults'],
+        ];
+    }
+
+    /**
+     * @dataProvider requiredRouteContextRequestAttributes
+     * @expectedException RuntimeException
+     * @param string $attribute
+     */
+    public function testCannotCreateInstanceIfRequestIsMissingAttributes(string $attribute): void
+    {
+        $serverRequest = $this->createServerRequestWithRouteAttributes()->withoutAttribute($attribute);
+
+        RouteContext::fromRequest($serverRequest);
+    }
+
+    private function createServerRequestWithRouteAttributes(): ServerRequestInterface
+    {
+        $route = $this->createMock(RouteInterface::class);
+        $routeParser = $this->createMock(RouteParserInterface::class);
+        $routingResults = $this->createMock(RoutingResults::class);
+
+        return $this->createServerRequest('/')
+                    ->withAttribute('route', $route)
+                    ->withAttribute('routeParser', $routeParser)
+                    ->withAttribute('routingResults', $routingResults);
+    }
+}

--- a/tests/Routing/RouteRunnerTest.php
+++ b/tests/Routing/RouteRunnerTest.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Slim\CallableResolver;
 use Slim\MiddlewareDispatcher;
 use Slim\Routing\RouteCollector;
+use Slim\Routing\RouteParser;
 use Slim\Routing\RouteResolver;
 use Slim\Routing\RouteRunner;
 use Slim\Routing\RoutingResults;
@@ -35,10 +36,11 @@ class RouteRunnerTest extends TestCase
         $routeCollector = new RouteCollector($responseFactory, $callableResolver);
         $routeCollector->map(['GET'], '/hello/{name}', $handler);
 
+        $routeParser = new RouteParser($routeCollector);
         $routeResolver = new RouteResolver($routeCollector);
 
         $request = $this->createServerRequest('https://example.com:443/hello/foo', 'GET');
-        $dispatcher = new RouteRunner($routeResolver);
+        $dispatcher = new RouteRunner($routeResolver, $routeParser);
 
         $middlewareDispatcher = new MiddlewareDispatcher($dispatcher);
         $middlewareDispatcher->handle($request);


### PR DESCRIPTION
Creates a new `RouteContext` class that can be used to gain access to the current request route, route parser, and routing results.

Fixes #2758 
Fixes #2761