### PR TITLE
4.x - Optimize ResponseEmitter work

### DIFF
--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -34,8 +34,9 @@ class ResponseEmitter
      */
     public function emit(ResponseInterface $response): void
     {
+        $isEmpty = $this->isResponseEmpty($response);
         if (headers_sent() === false) {
-            if ($this->isResponseEmpty($response)) {
+            if ($isEmpty) {
                 $response = $response
                     ->withoutHeader('Content-Type')
                     ->withoutHeader('Content-Length');
@@ -44,7 +45,7 @@ class ResponseEmitter
             $this->emitStatusLine($response);
         }
 
-        if (!$this->isResponseEmpty($response)) {
+        if (!$isEmpty) {
             $this->emitBody($response);
         }
     }
@@ -129,8 +130,10 @@ class ResponseEmitter
      */
     public function isResponseEmpty(ResponseInterface $response): bool
     {
+        if (in_array($response->getStatusCode(), [204, 205, 304], true)) {
+            return true;
+        }
         $contents = (string) $response->getBody();
-
-        return !strlen($contents) || in_array($response->getStatusCode(), [204, 205, 304], true);
+        return !strlen($contents);
     }
 }

--- a/tests/Mocks/SlowPokeStream.php
+++ b/tests/Mocks/SlowPokeStream.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Mocks;
+
+use Exception;
+use Psr\Http\Message\StreamInterface;
+
+class SlowPokeStream implements StreamInterface
+{
+    const CHUNK_SIZE = 1;
+    const SIZE = 10000;
+
+    /**
+     * @var int
+     */
+    private $amountToRead;
+
+    public function __construct()
+    {
+        $this->amountToRead = self::SIZE;
+    }
+
+    public function __toString()
+    {
+        $content = '';
+        while (!$this->eof()) {
+            $content .= $this->read(self::CHUNK_SIZE);
+        }
+        return $content;
+    }
+
+    public function close()
+    {
+    }
+
+    public function detach()
+    {
+        throw new Exception('not implemented');
+    }
+
+    public function eof()
+    {
+        return $this->amountToRead === 0;
+    }
+
+    public function getContents()
+    {
+        throw new Exception('not implemented');
+    }
+
+    public function getMetadata($key = null)
+    {
+        throw new Exception('not implemented');
+    }
+
+    public function getSize()
+    {
+        return null;
+    }
+
+    public function isReadable()
+    {
+        return true;
+    }
+
+    public function isSeekable()
+    {
+        return false;
+    }
+
+    public function isWritable()
+    {
+        return false;
+    }
+
+    public function read($length)
+    {
+        \usleep(100);
+        $size = min($this->amountToRead, self::CHUNK_SIZE, $length);
+        $this->amountToRead -= $size;
+        return str_repeat('.', $size);
+    }
+
+    public function rewind()
+    {
+        throw new Exception('not implemented');
+    }
+
+    public function seek($offset, $whence = SEEK_SET)
+    {
+        throw new Exception('not implemented');
+    }
+
+    public function tell()
+    {
+        throw new Exception('not implemented');
+    }
+
+    public function write($string)
+    {
+        return $string;
+    }
+}

--- a/tests/Mocks/SlowPokeStream.php
+++ b/tests/Mocks/SlowPokeStream.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\StreamInterface;
 class SlowPokeStream implements StreamInterface
 {
     const CHUNK_SIZE = 1;
-    const SIZE = 100000;
+    const SIZE = 500;
 
     /**
      * @var int
@@ -82,7 +82,7 @@ class SlowPokeStream implements StreamInterface
 
     public function read($length)
     {
-        \usleep(100);
+        \usleep(1);
         $size = min($this->amountToRead, self::CHUNK_SIZE, $length);
         $this->amountToRead -= $size;
         return str_repeat('.', $size);

--- a/tests/Mocks/SlowPokeStream.php
+++ b/tests/Mocks/SlowPokeStream.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\StreamInterface;
 class SlowPokeStream implements StreamInterface
 {
     const CHUNK_SIZE = 1;
-    const SIZE = 10000;
+    const SIZE = 100000;
 
     /**
      * @var int

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -13,6 +13,7 @@ use Slim\ResponseEmitter;
 use Slim\Tests\Assets\HeaderStack;
 use Slim\Tests\Mocks\MockStream;
 use Slim\Tests\Mocks\SmallChunksStream;
+use Slim\Tests\Mocks\SlowPokeStream;
 
 class ResponseEmitterTest extends TestCase
 {
@@ -170,6 +171,19 @@ class ResponseEmitterTest extends TestCase
         $responseEmitter = new ResponseEmitter();
 
         $this->assertTrue($responseEmitter->isResponseEmpty($response));
+    }
+
+    public function testAvoidReadFromSlowStreamAccordingStatus()
+    {
+        $body = new SlowPokeStream();
+        $response = $this
+            ->createResponse(204, 'No content')
+            ->withBody($body);
+        
+        $responseEmitter = new ResponseEmitter();
+        $responseEmitter->emit($response);
+
+        $this->expectOutputString('');
     }
 
     public function testIsResponseEmptyWithEmptyBody()

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -183,6 +183,7 @@ class ResponseEmitterTest extends TestCase
         $responseEmitter = new ResponseEmitter();
         $responseEmitter->emit($response);
 
+        $this->assertFalse($body->eof());
         $this->expectOutputString('');
     }
 


### PR DESCRIPTION
Cheap validations should be first. This will help to avoid unnecessary loss of time.