### PR TITLE
4.x - Add Possibility For Custom RequestHandler Invocation Strategies

### DIFF
--- a/Slim/Handlers/Strategies/RequestHandler.php
+++ b/Slim/Handlers/Strategies/RequestHandler.php
@@ -11,13 +11,26 @@ namespace Slim\Handlers\Strategies;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Slim\Interfaces\InvocationStrategyInterface;
+use Slim\Interfaces\RequestHandlerInvocationStrategyInterface;
 
 /**
- * Default route callback strategy with route parameters as an array of arguments.
+ * PSR-15 RequestHandler invocation strategy
  */
-class RequestHandler implements InvocationStrategyInterface
+class RequestHandler implements RequestHandlerInvocationStrategyInterface
 {
+    /**
+     * @var bool
+     */
+    protected $appendRouteArgumentsToRequestAttributes;
+
+    /**
+     * @param bool $appendRouteArgumentsToRequestAttributes
+     */
+    public function __construct(bool $appendRouteArgumentsToRequestAttributes = false)
+    {
+        $this->appendRouteArgumentsToRequestAttributes = $appendRouteArgumentsToRequestAttributes;
+    }
+
     /**
      * Invoke a route callable that implements RequestHandlerInterface
      *
@@ -34,6 +47,12 @@ class RequestHandler implements InvocationStrategyInterface
         ResponseInterface $response,
         array $routeArguments
     ): ResponseInterface {
+        if ($this->appendRouteArgumentsToRequestAttributes) {
+            foreach ($routeArguments as $k => $v) {
+                $request = $request->withAttribute($k, $v);
+            }
+        }
+
         return $callable($request);
     }
 }

--- a/Slim/Interfaces/RequestHandlerInvocationStrategyInterface.php
+++ b/Slim/Interfaces/RequestHandlerInvocationStrategyInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Interfaces;
+
+interface RequestHandlerInvocationStrategyInterface extends InvocationStrategyInterface
+{
+}

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -19,6 +19,7 @@ use Slim\Handlers\Strategies\RequestHandler;
 use Slim\Handlers\Strategies\RequestResponse;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\InvocationStrategyInterface;
+use Slim\Interfaces\RequestHandlerInvocationStrategyInterface;
 use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;
 use Slim\MiddlewareDispatcher;
@@ -360,9 +361,12 @@ class Route implements RouteInterface, RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $callable = $this->callableResolver->resolve($this->callable);
-
         $strategy = $this->invocationStrategy;
-        if (is_array($callable) && $callable[0] instanceof RequestHandlerInterface) {
+
+        if (is_array($callable)
+            && $callable[0] instanceof RequestHandlerInterface
+            && !in_array(RequestHandlerInvocationStrategyInterface::class, class_implements($strategy))
+        ) {
             $strategy = new RequestHandler();
         }
 

--- a/tests/Mocks/MockCustomRequestHandlerInvocationStrategy.php
+++ b/tests/Mocks/MockCustomRequestHandlerInvocationStrategy.php
@@ -17,10 +17,13 @@ class MockCustomRequestHandlerInvocationStrategy implements RequestHandlerInvoca
 {
     public static $CalledCount = 0;
 
-    public function __invoke(callable $callable, ServerRequestInterface $request, ResponseInterface $response, array $routeArguments): ResponseInterface
-    {
+    public function __invoke(
+        callable $callable,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        array $routeArguments
+    ): ResponseInterface {
         self::$CalledCount += 1;
-
         return $callable($request);
     }
 }

--- a/tests/Mocks/MockCustomRequestHandlerInvocationStrategy.php
+++ b/tests/Mocks/MockCustomRequestHandlerInvocationStrategy.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Mocks;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Interfaces\RequestHandlerInvocationStrategyInterface;
+
+class MockCustomRequestHandlerInvocationStrategy implements RequestHandlerInvocationStrategyInterface
+{
+    public static $CalledCount = 0;
+
+    public function __invoke(callable $callable, ServerRequestInterface $request, ResponseInterface $response, array $routeArguments): ResponseInterface
+    {
+        self::$CalledCount += 1;
+
+        return $callable($request);
+    }
+}


### PR DESCRIPTION
This effectively closes #2772 and #2773

Added a new interface for invocation strategies that can handle request handlers:
- RequestHandlerInvocationStrategyInterface

The current `RequestHandler` strategy now implements that interface which enables to check within the `Route::run()` method that the user set strategy can handle request handlers. In the event that it doesn't, a new `RequestHandler` strategy is instantiated.

Also added feature to the existing `RequestHandler` strategy (requested in #2772/#2773) to append route arguments as attributes to the incoming request object. By default it is set to `false`. If you want to enable this feature:

**To enable the feature for all the routes:**
```php
use Slim\Factory\AppFactory;
use Slim\Handlers\Strategies\RequestHandler;

$app = AppFactory::create();

/**
  * The RequestHandler constructor now takes an argument
  * Setting it to true will enable appending the route arguments as attributes to the request
  * @param bool $appendRouteArgumentsToRequestAttributes
 */
$strategy = new RequestHandler(true);
$app->getRouteCollectorProxy()->setDefaultInvocationStrategy($strategy);
```

**To enable the feature on a per route basis:**
```php
use Slim\Factory\AppFactory;
use Slim\Handlers\Strategies\RequestHandler;

$app = AppFactory::create();

/**
  * The RequestHandler constructor now takes an argument
  * Setting it to true will enable appending the route arguments as attributes to the request
  * @param bool $appendRouteArgumentsToRequestAttributes
 */
$strategy = new RequestHandler(true);

$route = $app->get(...);
$route->setInvocationStrategy($strategy);