### PR TITLE
4.x - Support For Slim Callables in MiddlewareDispatcher & Container Closure Autobinding

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -22,6 +22,11 @@ use Slim\Interfaces\CallableResolverInterface;
 final class CallableResolver implements CallableResolverInterface
 {
     /**
+     * @var string
+     */
+    public static $callablePattern = '!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!';
+
+    /**
      * @var ContainerInterface|null
      */
     private $container;
@@ -55,14 +60,13 @@ final class CallableResolver implements CallableResolverInterface
             $instance = null;
             $method = null;
 
-            // check for slim callable as "class:method"
-            $callablePattern = '!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!';
-            if (preg_match($callablePattern, $toResolve, $matches)) {
+            // Check for Slim callable as `class:method`
+            if (preg_match(self::$callablePattern, $toResolve, $matches)) {
                 $class = $matches[1];
                 $method = $matches[2];
             }
 
-            if ($this->container instanceof ContainerInterface && $this->container->has($class)) {
+            if ($this->container && $this->container->has($class)) {
                 $instance = $this->container->get($class);
             } else {
                 if (!class_exists($class)) {
@@ -91,7 +95,7 @@ final class CallableResolver implements CallableResolverInterface
             ));
         }
 
-        if ($this->container instanceof ContainerInterface && $resolved instanceof Closure) {
+        if ($this->container && $resolved instanceof Closure) {
             $resolved = $resolved->bindTo($this->container);
         }
 

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -174,7 +174,7 @@ class MiddlewareDispatcher implements RequestHandlerInterface
                     if ($instance instanceof MiddlewareInterface) {
                         return $instance->process($request, $this->next);
                     }
-                } else if (!function_exists($resolved)) {
+                } elseif (!function_exists($resolved)) {
                     if (!class_exists($resolved)) {
                         throw new RuntimeException(sprintf('Middleware %s does not exist', $resolved));
                     }

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -92,7 +92,13 @@ class MiddlewareDispatcherTest extends TestCase
         $containerProphecy = $this->prophesize(ContainerInterface::class);
 
         $self = $this;
-        $callable = function (ServerRequestInterface $request, RequestHandlerInterface $handler) use ($self, $containerProphecy) {
+        $callable = function (
+            ServerRequestInterface $request,
+            RequestHandlerInterface $handler
+        ) use (
+            $self,
+            $containerProphecy
+        ) {
             $self->assertSame($containerProphecy->reveal(), $this);
             return $handler->handle($request);
         };
@@ -113,7 +119,13 @@ class MiddlewareDispatcherTest extends TestCase
         $containerProphecy = $this->prophesize(ContainerInterface::class);
 
         $self = $this;
-        $callable = function (ServerRequestInterface $request, RequestHandlerInterface $handler) use ($self, $containerProphecy) {
+        $callable = function (
+            ServerRequestInterface $request,
+            RequestHandlerInterface $handler
+        ) use (
+            $self,
+            $containerProphecy
+        ) {
             $self->assertSame($containerProphecy->reveal(), $this);
             return $handler->handle($request);
         };

--- a/tests/Mocks/MockMiddlewareSlimCallable.php
+++ b/tests/Mocks/MockMiddlewareSlimCallable.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Mocks;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class MockMiddlewareSlimCallable
+{
+    /**
+     * @param ServerRequestInterface  $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function custom(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/tests/Mocks/MockMiddlewareWithConstructor.php
+++ b/tests/Mocks/MockMiddlewareWithConstructor.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
 declare(strict_types=1);
 
 namespace Slim\Tests\Mocks;


### PR DESCRIPTION
This PR adds support for Slim callables when adding deferred style middleware:
```php
$app->add('MyClass:customMethod`);
```
Fix for: https://github.com/slimphp/Slim/issues/2770#issuecomment-518101050

This PR also adds support for middleware callable Closure container auto-binding. Now callables are automatically bound to the container as they were in Slim 3.
Fix for: https://github.com/slimphp/Slim/issues/2770#issuecomment-517581778
