### PR TITLE
Cookie-header detection must be case insensitive

### DIFF
--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -58,7 +58,7 @@ class ResponseEmitter
     private function emitHeaders(ResponseInterface $response): void
     {
         foreach ($response->getHeaders() as $name => $values) {
-            $first = $name !== 'Set-Cookie';
+            $first = strtolower($name) !== 'set-cookie';
             foreach ($values as $value) {
                 $header = sprintf('%s: %s', $name, $value);
                 header($header, $first);

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -148,14 +148,14 @@ class ResponseEmitterTest extends TestCase
     {
         $response = $this
             ->createResponse(200, 'OK')
-            ->withHeader('Set-Cookie', 'foo=bar')
+            ->withHeader('set-cOOkie', 'foo=bar')
             ->withAddedHeader('Set-Cookie', 'bar=baz');
         $responseEmitter = new ResponseEmitter();
         $responseEmitter->emit($response);
 
         $expectedStack = [
-            ['header' => 'Set-Cookie: foo=bar', 'replace' => false, 'status_code' => null],
-            ['header' => 'Set-Cookie: bar=baz', 'replace' => false, 'status_code' => null],
+            ['header' => 'set-cOOkie: foo=bar', 'replace' => false, 'status_code' => null],
+            ['header' => 'set-cOOkie: bar=baz', 'replace' => false, 'status_code' => null],
             ['header' => 'HTTP/1.1 200 OK', 'replace' => true, 'status_code' => 200],
         ];
 
@@ -179,7 +179,7 @@ class ResponseEmitterTest extends TestCase
         $response = $this
             ->createResponse(204, 'No content')
             ->withBody($body);
-        
+
         $responseEmitter = new ResponseEmitter();
         $responseEmitter->emit($response);
 


### PR DESCRIPTION
Follow the [official guide](http://www.slimframework.com/docs/v4/start/installation.html) to create a simple application and reproduce the bug.
```php
// imports
$app->get('/', function (Request $request, Response $response, $args) {
    header('Set-Cookie: name=foo');
    $response = $response->withHeader('Set-Cookie', 'name=bar');
    $response->getBody()->write("Hello world!");
    return $response;
});
$app->run();
```
While everything is fine, the browser receives two headers with the same fields but different values.
```sh
Set-Cookie: name=foo
Set-Cookie: name=bar
```
However, when we start using case insensitive names, the behavior changes.
```php
// imports
$app->get('/', function (Request $request, Response $response, $args) {
    header('Set-Cookie: name=foo');
    $response = $response->withHeader('set-cOOkie', 'name=bar');
    $response->getBody()->write("Hello world!");
    return $response;
});
$app->run();
```
```sh
set-cOOkie: name=bar
```