### PR TITLE
Add BodyParsingMiddleware

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -101,7 +101,7 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
     }
 
     /**
-     * Add the slim built-in routing middleware to the app middleware stack
+     * Add the Slim built-in routing middleware to the app middleware stack
      *
      * @return RoutingMiddleware
      */
@@ -116,7 +116,7 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
     }
 
     /**
-     * Add the slim built-in error middleware to the app middleware stack
+     * Add the Slim built-in error middleware to the app middleware stack
      *
      * @param bool $displayErrorDetails
      * @param bool $logErrors

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -19,6 +19,7 @@ use Slim\Factory\ServerRequestCreatorFactory;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteResolverInterface;
+use Slim\Middleware\BodyParsingMiddleware;
 use Slim\Middleware\ErrorMiddleware;
 use Slim\Middleware\RoutingMiddleware;
 use Slim\Routing\RouteCollectorProxy;
@@ -137,6 +138,20 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
         );
         $this->add($errorMiddleware);
         return $errorMiddleware;
+    }
+
+    /**
+     * Add the Slim body parsing middleware to the app middleware stack
+     *
+     * @param callable[] $bodyParsers
+     *
+     * @return BodyParsingMiddleware
+     */
+    public function addBodyParsingMiddleware(array $bodyParsers = []): BodyParsingMiddleware
+    {
+        $bodyParsingMiddleware = new BodyParsingMiddleware($bodyParsers);
+        $this->add($bodyParsingMiddleware);
+        return $bodyParsingMiddleware;
     }
 
     /**

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -23,8 +23,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
     protected $bodyParsers;
 
     /**
-     * Constructor.
-     *
      * @param callable[] $bodyParsers list of body parsers as an associative array of mediaType => callable
      */
     public function __construct(array $bodyParsers = [])
@@ -53,8 +51,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Register media type parser.
-     *
      * @param string   $mediaType A HTTP media type (excluding content-type params).
      * @param callable $callable  A callable that returns parsed contents for media type.
      * @return self
@@ -66,8 +62,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Is a body parser registered for this media type?
-     *
      * @param string   $mediaType A HTTP media type (excluding content-type params).
      * @return boolean
      */
@@ -77,10 +71,9 @@ class BodyParsingMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Retrieve media type parser.
-     *
      * @param string    $mediaType A HTTP media type (excluding content-type params).
      * @return callable
+     * @throws RuntimeException
      */
     public function getBodyParser(string $mediaType): callable
     {
@@ -91,9 +84,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
     }
 
 
-    /**
-     * Register the default body parsers
-     */
     protected function registerDefaultBodyParsers(): void
     {
         $this->registerBodyParser('application/json', function ($input) {
@@ -168,8 +158,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Get the request's media type, if known.
-     *
      * @param ServerRequestInterface $request
      * @return string|null The serverRequest media type, minus content-type params
      */

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -170,8 +170,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
     /**
      * Get the request's media type, if known.
      *
-     * Note: This method is not part of the PSR-7 standard.
-     *
      * @param ServerRequestInterface $request
      * @return string|null The serverRequest media type, minus content-type params
      */

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -18,14 +18,14 @@ use RuntimeException;
 class BodyParsingMiddleware implements MiddlewareInterface
 {
     /**
-     * @var array
+     * @var callable[]
      */
     protected $bodyParsers;
 
     /**
      * Constructor.
      *
-     * @param array $bodyParsers list of body parsers as an associative array of mediaType => callable
+     * @param callable[] $bodyParsers list of body parsers as an associative array of mediaType => callable
      */
     public function __construct(array $bodyParsers = [])
     {
@@ -94,7 +94,7 @@ class BodyParsingMiddleware implements MiddlewareInterface
     /**
      * Register the default body parsers
      */
-    protected function registerDefaultBodyParsers()
+    protected function registerDefaultBodyParsers(): void
     {
         $this->registerBodyParser('application/json', function ($input) {
             $result = json_decode($input, true);

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -106,42 +106,29 @@ class BodyParsingMiddleware implements MiddlewareInterface
             return $result;
         });
 
-        $this->registerBodyParser('application/xml', function ($input) {
-            $backup = libxml_disable_entity_loader(true);
-            $backup_errors = libxml_use_internal_errors(true);
-            $result = simplexml_load_string($input);
-
-            libxml_disable_entity_loader($backup);
-            libxml_clear_errors();
-            libxml_use_internal_errors($backup_errors);
-
-            if ($result === false) {
-                return null;
-            }
-
-            return $result;
-        });
-
-        $this->registerBodyParser('text/xml', function ($input) {
-            $backup = libxml_disable_entity_loader(true);
-            $backup_errors = libxml_use_internal_errors(true);
-            $result = simplexml_load_string($input);
-
-            libxml_disable_entity_loader($backup);
-            libxml_clear_errors();
-            libxml_use_internal_errors($backup_errors);
-
-            if ($result === false) {
-                return null;
-            }
-
-            return $result;
-        });
-
         $this->registerBodyParser('application/x-www-form-urlencoded', function ($input) {
             parse_str($input, $data);
             return $data;
         });
+
+        $xmlCallable = function ($input) {
+            $backup = libxml_disable_entity_loader(true);
+            $backup_errors = libxml_use_internal_errors(true);
+            $result = simplexml_load_string($input);
+
+            libxml_disable_entity_loader($backup);
+            libxml_clear_errors();
+            libxml_use_internal_errors($backup_errors);
+
+            if ($result === false) {
+                return null;
+            }
+
+            return $result;
+        };
+
+        $this->registerBodyParser('application/xml', $xmlCallable);
+        $this->registerBodyParser('text/xml', $xmlCallable);
     }
 
     /**

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -77,7 +77,7 @@ class BodyParsingMiddleware implements MiddlewareInterface
     }
 
     /**
-     * Retreive media type parser.
+     * Retrieve media type parser.
      *
      * @param string    $mediaType A HTTP media type (excluding content-type params).
      * @return callable

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace Slim\Middleware;
 
-use RuntimeException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
 
 class BodyParsingMiddleware implements MiddlewareInterface
 {

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Middleware;
+
+use RuntimeException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+class BodyParsingMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var array
+     */
+    protected $bodyParsers;
+
+    /**
+     * Constructor.
+     *
+     * @param array $bodyParsers list of body parsers as an associative array of mediaType => callable
+     */
+    public function __construct(array $bodyParsers = [])
+    {
+        $this->registerDefaultBodyParsers();
+
+        foreach ($bodyParsers as $mediaType => $parser) {
+            $this->registerBodyParser($mediaType, $parser);
+        }
+    }
+
+    /**
+     * @param ServerRequestInterface  $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $parsedBody = $request->getParsedBody();
+        if ($parsedBody === null || empty($parsedBody)) {
+            $parsedBody = $this->parseBody($request);
+            $request = $request->withParsedBody($parsedBody);
+        }
+
+        return $handler->handle($request);
+    }
+
+    /**
+     * Register media type parser.
+     *
+     * @param string   $mediaType A HTTP media type (excluding content-type params).
+     * @param callable $callable  A callable that returns parsed contents for media type.
+     * @return self
+     */
+    public function registerBodyParser(string $mediaType, callable $callable): self
+    {
+        $this->bodyParsers[$mediaType] = $callable;
+        return $this;
+    }
+
+    /**
+     * Is a body parser registered for this media type?
+     *
+     * @param string   $mediaType A HTTP media type (excluding content-type params).
+     * @return boolean
+     */
+    public function hasBodyParser(string $mediaType): bool
+    {
+        return isset($this->bodyParsers[$mediaType]);
+    }
+
+    /**
+     * Retreive media type parser.
+     *
+     * @param string    $mediaType A HTTP media type (excluding content-type params).
+     * @return callable
+     */
+    public function getBodyParser(string $mediaType): callable
+    {
+        if (!isset($this->bodyParsers[$mediaType])) {
+            throw new RuntimeException('No parser for type ' . $mediaType);
+        }
+        return $this->bodyParsers[$mediaType];
+    }
+
+
+    /**
+     * Register the default body parsers
+     */
+    protected function registerDefaultBodyParsers()
+    {
+        $this->registerBodyParser('application/json', function ($input) {
+            $result = json_decode($input, true);
+
+            if (!is_array($result)) {
+                return null;
+            }
+
+            return $result;
+        });
+
+        $this->registerBodyParser('application/xml', function ($input) {
+            $backup = libxml_disable_entity_loader(true);
+            $backup_errors = libxml_use_internal_errors(true);
+            $result = simplexml_load_string($input);
+
+            libxml_disable_entity_loader($backup);
+            libxml_clear_errors();
+            libxml_use_internal_errors($backup_errors);
+
+            if ($result === false) {
+                return null;
+            }
+
+            return $result;
+        });
+
+        $this->registerBodyParser('text/xml', function ($input) {
+            $backup = libxml_disable_entity_loader(true);
+            $backup_errors = libxml_use_internal_errors(true);
+            $result = simplexml_load_string($input);
+
+            libxml_disable_entity_loader($backup);
+            libxml_clear_errors();
+            libxml_use_internal_errors($backup_errors);
+
+            if ($result === false) {
+                return null;
+            }
+
+            return $result;
+        });
+
+        $this->registerBodyParser('application/x-www-form-urlencoded', function ($input) {
+            parse_str($input, $data);
+            return $data;
+        });
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @return null|array|object
+     */
+    protected function parseBody(ServerRequestInterface $request)
+    {
+        $mediaType = $this->getMediaType($request);
+        if ($mediaType === null) {
+            return null;
+        }
+
+        // Check if this specific media type has a parser registered first
+        if (!isset($this->bodyParsers[$mediaType])) {
+            // If not, look for a media type with a structured syntax suffix (RFC 6839)
+            $parts = explode('+', $mediaType);
+            if (count($parts) >= 2) {
+                $mediaType = 'application/' . $parts[count($parts) - 1];
+            }
+        }
+
+        if (isset($this->bodyParsers[$mediaType])) {
+            $body = (string)$request->getBody();
+            $parsed = $this->bodyParsers[$mediaType]($body);
+
+            if (!is_null($parsed) && !is_object($parsed) && !is_array($parsed)) {
+                throw new RuntimeException(
+                    'Request body media type parser return value must be an array, an object, or null'
+                );
+            }
+
+            return $parsed;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get the request's media type, if known.
+     *
+     * Note: This method is not part of the PSR-7 standard.
+     *
+     * @param ServerRequestInterface $request
+     * @return string|null The serverRequest media type, minus content-type params
+     */
+    protected function getMediaType(ServerRequestInterface $request): ?string
+    {
+        $contentType = $request->getHeader('Content-Type')[0] ?? null;
+
+        if (is_string($contentType) && trim($contentType) != '') {
+            $contentTypeParts = explode(';', $contentType);
+            return strtolower(trim($contentTypeParts[0]));
+        }
+
+        return null;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,8 @@
         "phpstan": "php -d memory_limit=-1 vendor/bin/phpstan analyse Slim"
     },
     "suggest": {
+        "ext-simplexml": "Needed to support XML format in BodyParsingMiddleware",
+        "ext-xml": "Needed to support XML format in BodyParsingMiddleware",
         "slim/psr7": "Slim PSR-7 implementation. See http://www.slimframework.com/docs/v4/start/installation.html for more information."
     }
 }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -28,6 +28,7 @@ use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteCollectorProxyInterface;
 use Slim\Interfaces\RouteParserInterface;
+use Slim\Middleware\BodyParsingMiddleware;
 use Slim\Middleware\ErrorMiddleware;
 use Slim\Middleware\RoutingMiddleware;
 use Slim\MiddlewareDispatcher;
@@ -712,6 +713,36 @@ class AppTest extends TestCase
 
         $this->assertSame($errorMiddleware, $middlewareProperty->getValue($tip));
         $this->assertInstanceOf(ErrorMiddleware::class, $errorMiddleware);
+    }
+
+    public function testAddBodyParsingMiddleware()
+    {
+        /** @var ResponseFactoryInterface $responseFactory */
+        $responseFactory = $this->prophesize(ResponseFactoryInterface::class)->reveal();
+
+        // Create the app.
+        $app = new App($responseFactory);
+
+        // Add the error middleware.
+        $bodyParsingMiddleware = $app->addBodyParsingMiddleware();
+
+        // Check that the body parsing middleware really has been added to the tip of the app middleware stack.
+        $middlewareDispatcherProperty = new \ReflectionProperty(App::class, 'middlewareDispatcher');
+        $middlewareDispatcherProperty->setAccessible(true);
+        /** @var MiddlewareDispatcher $middlewareDispatcher */
+        $middlewareDispatcher = $middlewareDispatcherProperty->getValue($app);
+
+        $tipProperty = new \ReflectionProperty(MiddlewareDispatcher::class, 'tip');
+        $tipProperty->setAccessible(true);
+        /** @var RequestHandlerInterface $tip */
+        $tip = $tipProperty->getValue($middlewareDispatcher);
+
+        $reflection = new \ReflectionClass($tip);
+        $middlewareProperty = $reflection->getProperty('middleware');
+        $middlewareProperty->setAccessible(true);
+
+        $this->assertSame($bodyParsingMiddleware, $middlewareProperty->getValue($tip));
+        $this->assertInstanceOf(BodyParsingMiddleware::class, $bodyParsingMiddleware);
     }
 
     public function testAddMiddlewareOnRoute()

--- a/tests/Middleware/BodyParsingMiddlewareTest.php
+++ b/tests/Middleware/BodyParsingMiddlewareTest.php
@@ -185,7 +185,7 @@ class BodyParsingMiddlewareTest extends TestCase
         $middleware->process($request, $this->createRequestHandler());
     }
 
-    public function testSettingAndGetttingAParser()
+    public function testSettingAndGettingAParser()
     {
         $middleware = new BodyParsingMiddleware();
         $parser = function ($input) {

--- a/tests/Middleware/BodyParsingMiddlewareTest.php
+++ b/tests/Middleware/BodyParsingMiddlewareTest.php
@@ -42,8 +42,6 @@ class BodyParsingMiddlewareTest extends TestCase
     }
 
     /**
-     * Helper function to create a ServerRequest with a body and a content-type header
-     *
      * @param string $contentType
      * @param string $body
      * @return ServerRequestInterface

--- a/tests/Middleware/BodyParsingMiddlewareTest.php
+++ b/tests/Middleware/BodyParsingMiddlewareTest.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
+use Slim\Middleware\BodyParsingMiddleware;
+use Slim\Tests\TestCase;
+
+class BodyParsingMiddlewareTest extends TestCase
+{
+    /**
+     * Create a request handler that simply assigns the $request that it receives to a public property
+     * of the returned response, so that we can then inspect that request.
+     */
+    protected function createRequestHandler() : RequestHandlerInterface
+    {
+        $response = $this->createResponse();
+        return new class($response) implements RequestHandlerInterface {
+            private $response;
+
+            public function __construct(ResponseInterface $response)
+            {
+                $this->response = $response;
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->response->request = $request;
+                return $this->response;
+            }
+        };
+    }
+
+    /**
+     * Helper function to create a ServerRequest with a body and a content-type header
+     *
+     * @param string $contentType
+     * @param string $body
+     * @return ServerRequestInterface
+     */
+    protected function createRequestWithBody($contentType, $body)
+    {
+        $request = $this->createServerRequest('/', 'POST');
+        if (is_string($contentType)) {
+            $request = $request->withHeader('Content-Type', $contentType);
+        }
+        if (is_string($body)) {
+            $request = $request->withBody($this->createStream($body));
+        }
+        return $request;
+    }
+
+
+    public function parsingProvider()
+    {
+        return [
+            'form' => [
+                'application/x-www-form-urlencoded;charset=utf8',
+                'foo=bar',
+                ['foo' => 'bar'],
+            ],
+            'json' => [
+                "application/json",
+                '{"foo":"bar"}',
+                ['foo' => 'bar'],
+            ],
+            'json-with-charset' => [
+                "application/json\t ; charset=utf8",
+                '{"foo":"bar"}',
+                ['foo' => 'bar'],
+            ],
+            'json-suffix' => [
+                'application/vnd.api+json;charset=utf8',
+                '{"foo":"bar"}',
+                ['foo' => 'bar'],
+            ],
+            'xml' => [
+                'application/xml',
+                '<person><name>John</name></person>',
+                simplexml_load_string('<person><name>John</name></person>'),
+            ],
+            'xml-suffix' => [
+                'application/hal+xml;charset=utf8',
+                '<person><name>John</name></person>',
+                simplexml_load_string('<person><name>John</name></person>'),
+            ],
+            'text-xml' => [
+                'text/xml',
+                '<person><name>John</name></person>',
+                simplexml_load_string('<person><name>John</name></person>'),
+            ],
+            'invalid-json' => [
+                'application/json;charset=utf8',
+                '{"foo"}/bar',
+                null,
+            ],
+            'valid-json-but-not-an-array' => [
+                'application/json;charset=utf8',
+                '"foo bar"',
+                null,
+            ],
+            'unknown-contenttype' => [
+                'text/foo+bar',
+                '"foo bar"',
+                null,
+            ],
+            'empty-contenttype' => [
+                '',
+                '"foo bar"',
+                null,
+            ],
+            'no-contenttype' => [
+                null,
+                '"foo bar"',
+                null,
+            ],
+            'invalid-contenttype' => [
+                'foo',
+                '"foo bar"',
+                null,
+            ],
+            'invalid-xml' => [
+                'application/xml',
+                '<person><name>John</name></invalid>',
+                null,
+            ],
+            'invalid-textxml' => [
+                'text/xml',
+                '<person><name>John</name></invalid>',
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider parsingProvider
+     */
+    public function testParsing($contentType, $body, $expected)
+    {
+        $request = $this->createRequestWithBody($contentType, $body);
+
+        $middleware = new BodyParsingMiddleware();
+        $response = $middleware->process($request, $this->createRequestHandler());
+
+        $this->assertEquals($expected, $response->request->getParsedBody());
+    }
+
+    public function testParsingWithARegisteredParser()
+    {
+        $request = $this->createRequestWithBody('application/vnd.api+json', '{"foo":"bar"}');
+
+        $parsers = [
+            'application/vnd.api+json' => function ($input) {
+                return ['data' => $input];
+            },
+        ];
+        $middleware = new BodyParsingMiddleware($parsers);
+        $response = $middleware->process($request, $this->createRequestHandler());
+
+        $this->assertEquals(['data' => '{"foo":"bar"}'], $response->request->getParsedBody());
+    }
+
+    public function testParsingFailsWhenAnInvalidTypeIsReturned()
+    {
+        $request = $this->createRequestWithBody('application/json;charset=utf8', '{"foo":"bar"}');
+
+        $parsers = [
+            'application/json' => function ($input) {
+                return 10; // invalid - should return null, array or object
+            },
+        ];
+        $middleware = new BodyParsingMiddleware($parsers);
+
+        $this->expectException(RuntimeException::class);
+        $middleware->process($request, $this->createRequestHandler());
+    }
+
+    public function testSettingAndGetttingAParser()
+    {
+        $middleware = new BodyParsingMiddleware();
+        $parser = function ($input) {
+            return ['data' => $input];
+        };
+
+        $this->assertFalse($middleware->hasBodyParser('text/foo'));
+
+        $middleware->registerBodyParser('text/foo', $parser);
+        $this->assertTrue($middleware->hasBodyParser('text/foo'));
+
+        $this->assertSame($parser, $middleware->getBodyParser('text/foo'));
+    }
+
+    public function testGettingUnknownParser()
+    {
+        $middleware = new BodyParsingMiddleware();
+
+        $this->expectException(RuntimeException::class);
+        $middleware->getBodyParser('text/foo');
+    }
+}


### PR DESCRIPTION
This middleware will parse the body of a PSR-7 ServerRequest and if the content-type is known and a parser is registered, it will add the parsed data to the request object before passing to the next middleware. 

Usage:

```php
use Psr\Http\Message\ResponseInterface;
use Psr\Http\Message\ServerRequestInterface;
use Slim\Factory\AppFactory;
use Slim\Middleware\BodyParsingMiddleware;
use Slim\Psr7\Response;

$app = AppFactory::create();
$app->addBodyParsingMiddleware();

$app->post('/foo', function (ServerRequestInterface $request): ResponseInterface {
    $data = $request->getParsedBody();

    $response = new Response();
    $response->getBody()->write(
        print_r($data, true)
    );
    return new Response();
});

$app->run();
```