### PR TITLE
Emit non seekable streams

### DIFF
--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -133,7 +133,11 @@ class ResponseEmitter
         if (in_array($response->getStatusCode(), [204, 205, 304], true)) {
             return true;
         }
-        $contents = (string) $response->getBody();
-        return !strlen($contents);
+        $stream = $response->getBody();
+        $seekable = $stream->isSeekable();
+        if ($seekable) {
+            $stream->rewind();
+        }
+        return $seekable ? $stream->read(1) === '' : $stream->eof();
     }
 }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1564,6 +1564,7 @@ class AppTest extends TestCase
             $body .= $args[0];
             $this->__toString()->willReturn($body);
         });
+        $streamProphecy->read(1)->willReturn('_');
         $streamProphecy->read('11')->will(function () {
             $this->eof()->willReturn(true);
             return $this->reveal()->__toString();
@@ -1616,6 +1617,7 @@ class AppTest extends TestCase
             $body .= $args[0];
             $this->__toString()->willReturn($body);
         });
+        $streamProphecy->read(1)->willReturn('_');
         $streamProphecy->read('11')->will(function () {
             $this->eof()->willReturn(true);
             return $this->reveal()->__toString();


### PR DESCRIPTION
Every time when we emit any response we read all data from a stream twice.
- https://github.com/slimphp/Slim/blob/4.x/Slim/ResponseEmitter.php#L37
- https://github.com/slimphp/Slim/blob/4.x/Slim/ResponseEmitter.php#L49

There may be problems with slow streams or responses with too big body. In addition, with a such `ResponseEmitter` work, it is impossible to send a response with non seekable body.
