### PR TITLE
4.x - Add check for Slim callable notation if no resolver given

### DIFF
--- a/Slim/DeferredCallable.php
+++ b/Slim/DeferredCallable.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Slim;
 
+use RuntimeException;
 use Slim\Interfaces\CallableResolverInterface;
 
 class DeferredCallable
@@ -29,6 +30,13 @@ class DeferredCallable
      */
     public function __construct($callable, ?CallableResolverInterface $resolver = null)
     {
+        if ($resolver === null && is_string($callable) && preg_match(CallableResolver::$callablePattern, $callable)) {
+            throw new RuntimeException(sprintf(
+                'Slim callable notation %s is not allowed without callable resolver.',
+                $callable
+            ));
+        }
+
         $this->callable = $callable;
         $this->callableResolver = $resolver;
     }


### PR DESCRIPTION
PR for #2804 

The `\Slim\DeferredCallable` can be instantiated without callable resolver. If the callable is a `string`, then in many cases, this should work as expected. For example for function names, or `ClassName::MethodName` notation. But the Slim callable notation `ClassName:MethodName` would not work. This PR makes sure that we throw an exception if that is the case.