### PR TITLE
4.x - Avoid that Travis-CI runs phpunit two times in analysis mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_script:
 
 script:
 - if [[ "$ANALYSIS" == 'true' ]]; then vendor/bin/phpunit --coverage-clover clover.xml ; fi
-- vendor/bin/phpunit
+- if [[ "$ANALYSIS" != 'true' ]]; then vendor/bin/phpunit ; fi
 - vendor/bin/phpcs
 - vendor/bin/phpstan analyse Slim
 


### PR DESCRIPTION
The Travis-CI job with analysis-mode (PHP 7.1) currently runs phpunit two times. One for the coverage report and then again without coverage.

This PR simply wraps the second phpunit into an if-statement.