### PR TITLE
4.x - Fix RouteCollectorProxy::redirect() Bug

### DIFF
--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -195,8 +195,10 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
      */
     public function redirect(string $from, $to, int $status = 302): RouteInterface
     {
-        $handler = function () use ($to, $status) {
-            $response = $this->responseFactory->createResponse($status);
+        $responseFactory = $this->responseFactory;
+
+        $handler = function () use ($to, $status, $responseFactory) {
+            $response = $responseFactory->createResponse($status);
             return $response->withHeader('Location', (string) $to);
         };
 


### PR DESCRIPTION
Fix for #2815

When a container is present the callable gets bound to the container when it's resolved. So the `$this` context becomes the container and not `RouteCollectorProxy` anymore.

```php
$handler = function () use ($to, $status) {
    $response = $this->responseFactory->createResponse($status);
    return $response->withHeader('Location', (string) $to);
};
```

We're using `$this->responseFactory()` when we should just pass it in via `use()`