### PR TITLE
4.x - MiddlewareDispatcherInterface

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -72,11 +72,13 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
         $this->routeResolver = $routeResolver ?? new RouteResolver($this->routeCollector);
         $routeRunner = new RouteRunner($this->routeResolver, $this->routeCollector->getRouteParser());
 
-        if ($middlewareDispatcher) {
+        if (!$middlewareDispatcher) {
+            $middlewareDispatcher = new MiddlewareDispatcher($routeRunner, $this->callableResolver, $container);
+        } else {
             $middlewareDispatcher->seedMiddlewareStack($routeRunner);
         }
 
-        $this->middlewareDispatcher = $middlewareDispatcher ?? new MiddlewareDispatcher($routeRunner, $this->callableResolver, $container);
+        $this->middlewareDispatcher = $middlewareDispatcher;
     }
 
     /**

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -37,14 +37,14 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
     public const VERSION = '4.1.0';
 
     /**
-     * @var MiddlewareDispatcher
-     */
-    protected $middlewareDispatcher;
-
-    /**
      * @var RouteResolverInterface
      */
     protected $routeResolver;
+
+    /**
+     * @var MiddlewareDispatcherInterface
+     */
+    protected $middlewareDispatcher;
 
     /**
      * @param ResponseFactoryInterface              $responseFactory

--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -124,7 +124,14 @@ class AppFactory
             ? $container->get(MiddlewareDispatcherInterface::class)
             : null;
 
-        return new App($responseFactory, $container, $callableResolver, $routeCollector, $routeResolver, $middlewareDispatcher);
+        return new App(
+            $responseFactory,
+            $container,
+            $callableResolver,
+            $routeCollector,
+            $routeResolver,
+            $middlewareDispatcher
+        );
     }
 
     /**

--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -18,6 +18,7 @@ use Slim\Factory\Psr17\Psr17Factory;
 use Slim\Factory\Psr17\Psr17FactoryProvider;
 use Slim\Factory\Psr17\SlimHttpPsr17Factory;
 use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\MiddlewareDispatcherInterface;
 use Slim\Interfaces\Psr17FactoryProviderInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteResolverInterface;
@@ -60,16 +61,22 @@ class AppFactory
     protected static $routeResolver;
 
     /**
+     * @var MiddlewareDispatcherInterface|null
+     */
+    protected static $middlewareDispatcher;
+
+    /**
      * @var bool
      */
     protected static $slimHttpDecoratorsAutomaticDetectionEnabled = true;
 
     /**
-     * @param ResponseFactoryInterface|null  $responseFactory
-     * @param ContainerInterface|null        $container
-     * @param CallableResolverInterface|null $callableResolver
-     * @param RouteCollectorInterface|null   $routeCollector
-     * @param RouteResolverInterface|null    $routeResolver
+     * @param ResponseFactoryInterface|null         $responseFactory
+     * @param ContainerInterface|null               $container
+     * @param CallableResolverInterface|null        $callableResolver
+     * @param RouteCollectorInterface|null          $routeCollector
+     * @param RouteResolverInterface|null           $routeResolver
+     * @param MiddlewareDispatcherInterface|null    $middlewareDispatcher
      * @return App
      */
     public static function create(
@@ -77,7 +84,8 @@ class AppFactory
         ?ContainerInterface $container = null,
         ?CallableResolverInterface $callableResolver = null,
         ?RouteCollectorInterface $routeCollector = null,
-        ?RouteResolverInterface $routeResolver = null
+        ?RouteResolverInterface $routeResolver = null,
+        ?MiddlewareDispatcherInterface $middlewareDispatcher = null
     ): App {
         static::$responseFactory = $responseFactory ?? static::$responseFactory;
         return new App(
@@ -85,7 +93,8 @@ class AppFactory
             $container ?? static::$container,
             $callableResolver ?? static::$callableResolver,
             $routeCollector ?? static::$routeCollector,
-            $routeResolver ?? static::$routeResolver
+            $routeResolver ?? static::$routeResolver,
+            $middlewareDispatcher ?? static::$middlewareDispatcher
         );
     }
 
@@ -111,7 +120,11 @@ class AppFactory
             ? $container->get(RouteResolverInterface::class)
             : null;
 
-        return new App($responseFactory, $container, $callableResolver, $routeCollector, $routeResolver);
+        $middlewareDispatcher = $container->has(MiddlewareDispatcherInterface::class)
+            ? $container->get(MiddlewareDispatcherInterface::class)
+            : null;
+
+        return new App($responseFactory, $container, $callableResolver, $routeCollector, $routeResolver, $middlewareDispatcher);
     }
 
     /**
@@ -222,6 +235,14 @@ class AppFactory
     public static function setRouteResolver(RouteResolverInterface $routeResolver): void
     {
         static::$routeResolver = $routeResolver;
+    }
+
+    /**
+     * @param MiddlewareDispatcherInterface $middlewareDispatcher
+     */
+    public static function setMiddlewareDispatcher(MiddlewareDispatcherInterface $middlewareDispatcher): void
+    {
+        static::$middlewareDispatcher = $middlewareDispatcher;
     }
 
     /**

--- a/Slim/Interfaces/MiddlewareDispatcherInterface.php
+++ b/Slim/Interfaces/MiddlewareDispatcherInterface.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Interfaces;
+
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+interface MiddlewareDispatcherInterface extends RequestHandlerInterface
+{
+    /**
+     * Add a new middleware to the stack
+     *
+     * Middleware are organized as a stack. That means middleware
+     * that have been added before will be executed after the newly
+     * added one (last in, first out).
+     *
+     * @param MiddlewareInterface|string|callable $middleware
+     * @return self
+     */
+    public function add($middleware): self;
+
+    /**
+     * Add a new middleware to the stack
+     *
+     * Middleware are organized as a stack. That means middleware
+     * that have been added before will be executed after the newly
+     * added one (last in, first out).
+     *
+     * @param MiddlewareInterface $middleware
+     * @return self
+     */
+    public function addMiddleware(MiddlewareInterface $middleware): self;
+
+    /**
+     * Seed the middleware stack with the inner request handler
+     *
+     * @param RequestHandlerInterface $kernel
+     * @return void
+     */
+    public function seedMiddlewareStack(RequestHandlerInterface $kernel): void;
+}

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -18,8 +18,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 use Slim\Interfaces\AdvancedCallableResolverInterface;
 use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\MiddlewareDispatcherInterface;
 
-class MiddlewareDispatcher implements RequestHandlerInterface
+class MiddlewareDispatcher implements MiddlewareDispatcherInterface
 {
     /**
      * Tip of the middleware call stack
@@ -29,7 +30,7 @@ class MiddlewareDispatcher implements RequestHandlerInterface
     protected $tip;
 
     /**
-     * @var CallableResolverInterface
+     * @var CallableResolverInterface|null
      */
     protected $callableResolver;
 
@@ -54,12 +55,9 @@ class MiddlewareDispatcher implements RequestHandlerInterface
     }
 
     /**
-     * Seed the middleware stack with the inner request handler
-     *
-     * @param RequestHandlerInterface $kernel
-     * @return void
+     * {@inheritdoc}
      */
-    protected function seedMiddlewareStack(RequestHandlerInterface $kernel): void
+    public function seedMiddlewareStack(RequestHandlerInterface $kernel): void
     {
         $this->tip = $kernel;
     }
@@ -83,9 +81,9 @@ class MiddlewareDispatcher implements RequestHandlerInterface
      * added one (last in, first out).
      *
      * @param MiddlewareInterface|string|callable $middleware
-     * @return self
+     * @return MiddlewareDispatcherInterface
      */
-    public function add($middleware): self
+    public function add($middleware): MiddlewareDispatcherInterface
     {
         if ($middleware instanceof MiddlewareInterface) {
             return $this->addMiddleware($middleware);
@@ -113,9 +111,9 @@ class MiddlewareDispatcher implements RequestHandlerInterface
      * added one (last in, first out).
      *
      * @param MiddlewareInterface $middleware
-     * @return self
+     * @return MiddlewareDispatcherInterface
      */
-    public function addMiddleware(MiddlewareInterface $middleware): self
+    public function addMiddleware(MiddlewareInterface $middleware): MiddlewareDispatcherInterface
     {
         $next = $this->tip;
         $this->tip = new class($middleware, $next) implements RequestHandlerInterface

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -40,13 +40,13 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
     protected $container;
 
     /**
-     * @param RequestHandlerInterface   $kernel
-     * @param CallableResolverInterface $callableResolver
-     * @param ContainerInterface|null   $container
+     * @param RequestHandlerInterface        $kernel
+     * @param CallableResolverInterface|null $callableResolver
+     * @param ContainerInterface|null        $container
      */
     public function __construct(
         RequestHandlerInterface $kernel,
-        CallableResolverInterface $callableResolver,
+        ?CallableResolverInterface $callableResolver = null,
         ?ContainerInterface $container = null
     ) {
         $this->seedMiddlewareStack($kernel);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -119,24 +119,7 @@ class AppTest extends TestCase
         $this->assertEquals($routeCollector, $app->getRouteCollector());
     }
 
-    public function testGetMiddlewareDispatcherReturnsInjectedInstance()
-    {
-        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
-        $middlewareDispatcherProphecy = $this->prophesize(MiddlewareDispatcherInterface::class);
-
-        $app = new App(
-            $responseFactoryProphecy->reveal(),
-            null,
-            null,
-            null,
-            null,
-            $middlewareDispatcherProphecy->reveal()
-        );
-
-        $this->assertSame($middlewareDispatcherProphecy->reveal(), $app->getMiddlewareDispatcher());
-    }
-
-    public function testMiddlewareDispatcherGetsSeededWithInjectedInstance()
+    public function testGetMiddlewareDispatcherGetsSeededAndReturnsInjectedInstance()
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -25,6 +25,7 @@ use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
 use Slim\Handlers\Strategies\RequestResponseArgs;
 use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\MiddlewareDispatcherInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteCollectorProxyInterface;
 use Slim\Interfaces\RouteParserInterface;
@@ -116,6 +117,30 @@ class AppTest extends TestCase
         );
 
         $this->assertEquals($routeCollector, $app->getRouteCollector());
+    }
+
+    public function testGetMiddlewareDispatcherReturnsInjectedInstance()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $middlewareDispatcherProphecy = $this->prophesize(MiddlewareDispatcherInterface::class);
+
+        $app = new App($responseFactoryProphecy->reveal(), null, null, null, null, $middlewareDispatcherProphecy->reveal());
+
+        $this->assertSame($middlewareDispatcherProphecy->reveal(), $app->getMiddlewareDispatcher());
+    }
+
+    public function testMiddlewareDispatcherGetsSeededWithInjectedInstance()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+
+        $middlewareDispatcherProphecy = $this->prophesize(MiddlewareDispatcherInterface::class);
+        $middlewareDispatcherProphecy
+            ->seedMiddlewareStack(Argument::any())
+            ->shouldBeCalledOnce();
+
+        $app = new App($responseFactoryProphecy->reveal(), null, null, null, null, $middlewareDispatcherProphecy->reveal());
+
+        $this->assertSame($middlewareDispatcherProphecy->reveal(), $app->getMiddlewareDispatcher());
     }
 
     public function lowerCaseRequestMethodsProvider()

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -124,7 +124,14 @@ class AppTest extends TestCase
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $middlewareDispatcherProphecy = $this->prophesize(MiddlewareDispatcherInterface::class);
 
-        $app = new App($responseFactoryProphecy->reveal(), null, null, null, null, $middlewareDispatcherProphecy->reveal());
+        $app = new App(
+            $responseFactoryProphecy->reveal(),
+            null,
+            null,
+            null,
+            null,
+            $middlewareDispatcherProphecy->reveal()
+        );
 
         $this->assertSame($middlewareDispatcherProphecy->reveal(), $app->getMiddlewareDispatcher());
     }
@@ -138,7 +145,14 @@ class AppTest extends TestCase
             ->seedMiddlewareStack(Argument::any())
             ->shouldBeCalledOnce();
 
-        $app = new App($responseFactoryProphecy->reveal(), null, null, null, null, $middlewareDispatcherProphecy->reveal());
+        $app = new App(
+            $responseFactoryProphecy->reveal(),
+            null,
+            null,
+            null,
+            null,
+            $middlewareDispatcherProphecy->reveal()
+        );
 
         $this->assertSame($middlewareDispatcherProphecy->reveal(), $app->getMiddlewareDispatcher());
     }

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -26,6 +26,7 @@ use Slim\Factory\Psr17\ZendDiactorosPsr17Factory;
 use Slim\Http\Factory\DecoratedResponseFactory;
 use Slim\Http\Response as DecoratedResponse;
 use Slim\Interfaces\CallableResolverInterface;
+use Slim\Interfaces\MiddlewareDispatcherInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteParserInterface;
 use Slim\Interfaces\RouteResolverInterface;
@@ -117,6 +118,7 @@ class AppFactoryTest extends TestCase
         $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
         $routeParserProphecy = $this->prophesize(RouteParserInterface::class);
         $routeResolverProphecy = $this->prophesize(RouteResolverInterface::class);
+        $middlewareDispatcherProphecy = $this->prophesize(MiddlewareDispatcherInterface::class);
 
         $routeCollectorProphecy->getRouteParser()->willReturn($routeParserProphecy);
 
@@ -126,6 +128,7 @@ class AppFactoryTest extends TestCase
         AppFactory::setCallableResolver($callableResolverProphecy->reveal());
         AppFactory::setRouteCollector($routeCollectorProphecy->reveal());
         AppFactory::setRouteResolver($routeResolverProphecy->reveal());
+        AppFactory::setMiddlewareDispatcher($middlewareDispatcherProphecy->reveal());
 
         $app = AppFactory::create();
 
@@ -152,6 +155,11 @@ class AppFactoryTest extends TestCase
         $this->assertSame(
             $routeResolverProphecy->reveal(),
             $app->getRouteResolver()
+        );
+
+        $this->assertSame(
+            $middlewareDispatcherProphecy->reveal(),
+            $app->getMiddlewareDispatcher()
         );
     }
 
@@ -242,6 +250,8 @@ class AppFactoryTest extends TestCase
             ->willReturn($routeParserProphecy->reveal())
             ->shouldBeCalledOnce();
 
+        $middlewareDispatcherProphecy = $this->prophesize(MiddlewareDispatcherInterface::class);
+
         $containerProphecy = $this->prophesize(ContainerInterface::class);
 
         $containerProphecy
@@ -284,6 +294,16 @@ class AppFactoryTest extends TestCase
             ->willReturn($routeResolverProphecy->reveal())
             ->shouldBeCalledOnce();
 
+        $containerProphecy
+            ->has(MiddlewareDispatcherInterface::class)
+            ->willReturn(true)
+            ->shouldBeCalledOnce();
+
+        $containerProphecy
+            ->get(MiddlewareDispatcherInterface::class)
+            ->willReturn($middlewareDispatcherProphecy->reveal())
+            ->shouldBeCalledOnce();
+
         AppFactory::setSlimHttpDecoratorsAutomaticDetection(false);
         $app = AppFactory::createFromContainer($containerProphecy->reveal());
 
@@ -292,5 +312,6 @@ class AppFactoryTest extends TestCase
         $this->assertSame($app->getCallableResolver(), $callableResolverProphecy->reveal());
         $this->assertSame($app->getRouteCollector(), $routeCollectorProphecy->reveal());
         $this->assertSame($app->getRouteResolver(), $routeResolverProphecy->reveal());
+        $this->assertSame($app->getMiddlewareDispatcher(), $middlewareDispatcherProphecy->reveal());
     }
 }


### PR DESCRIPTION
Closes #2785 

This PR enables users to inject their own `MiddlewareDispatcher` into the `App` component.

The new proposed interface:
```php
<?php
declare(strict_types=1);

namespace Slim\Interfaces;

use Psr\Http\Server\MiddlewareInterface;
use Psr\Http\Server\RequestHandlerInterface;

interface MiddlewareDispatcherInterface extends RequestHandlerInterface
{
    /**
     * Add a new middleware to the stack
     *
     * Middleware are organized as a stack. That means middleware
     * that have been added before will be executed after the newly
     * added one (last in, first out).
     *
     * @param MiddlewareInterface|string|callable $middleware
     * @return self
     */
    public function add($middleware): self;

    /**
     * Add a new middleware to the stack
     *
     * Middleware are organized as a stack. That means middleware
     * that have been added before will be executed after the newly
     * added one (last in, first out).
     *
     * @param MiddlewareInterface $middleware
     * @return self
     */
    public function addMiddleware(MiddlewareInterface $middleware): self;

    /**
     * Seed the middleware stack with the inner request handler
     *
     * @param RequestHandlerInterface $kernel
     * @return void
     */
    public function seedMiddlewareStack(RequestHandlerInterface $kernel): void;
}
```