### PR TITLE
Added description to addRoutingMiddleware()

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -120,6 +120,8 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
     /**
      * Add the Slim built-in routing middleware to the app middleware stack
      *
+     * This method can be used to control middleware order and is not required for default routing operation.
+     *
      * @return RoutingMiddleware
      */
     public function addRoutingMiddleware(): RoutingMiddleware


### PR DESCRIPTION
Clarifies what method can be used for and that it's optional for default operation.

I was a little confused by this method, upgrading from Slim v3, and think it could use a description clarifying the purpose (context https://twitter.com/akrabat/status/1164163782136012800 ).