### PR TITLE
Update link to homepage in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "Slim is a PHP micro framework that helps you quickly write simple yet powerful web applications and APIs",
     "keywords": ["framework","micro","api","router"],
-    "homepage": "https://slimframework.com",
+    "homepage": "https://www.slimframework.com",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
This ensure that visitors from Packagist do not get an SSL certificate warning as GitHub Pages does not create an SSL certificate with both the apex domain and www subdomain registered.