### PR TITLE
4.x - Allow uris with leading multi-slashes

### DIFF
--- a/Slim/Routing/RouteResolver.php
+++ b/Slim/Routing/RouteResolver.php
@@ -48,7 +48,10 @@ class RouteResolver implements RouteResolverInterface
      */
     public function computeRoutingResults(string $uri, string $method): RoutingResults
     {
-        $uri = '/' . ltrim(rawurldecode($uri), '/');
+        $uri = rawurldecode($uri);
+        if ($uri[0] !== '/') {
+            $uri = '/' . $uri;
+        }
         return $this->dispatcher->dispatch($method, $uri);
     }
 

--- a/Slim/Routing/RouteResolver.php
+++ b/Slim/Routing/RouteResolver.php
@@ -49,7 +49,7 @@ class RouteResolver implements RouteResolverInterface
     public function computeRoutingResults(string $uri, string $method): RoutingResults
     {
         $uri = rawurldecode($uri);
-        if ($uri[0] !== '/') {
+        if ($uri === '' || $uri[0] !== '/') {
             $uri = '/' . $uri;
         }
         return $this->dispatcher->dispatch($method, $uri);


### PR DESCRIPTION
This PR closes #2822.

The test case `\Slim\Tests\Routing\RouteResolverTest::testComputeRoutingResults()` had been modified such that the error message would be understandable if the test fails.