### PR TITLE
Handle base path by routeCollector instead of RouteCollectorProxy

### DIFF
--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -38,8 +38,10 @@ class Dispatcher implements DispatcherInterface
         }
 
         $routeDefinitionCallback = function (RouteCollector $r) {
+            $basePath = $this->routeCollector->getBasePath();
+
             foreach ($this->routeCollector->getRoutes() as $route) {
-                $r->addRoute($route->getMethods(), $route->getPattern(), $route->getIdentifier());
+                $r->addRoute($route->getMethods(), $basePath . $route->getPattern(), $route->getIdentifier());
             }
         };
 

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -43,27 +43,27 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * @var string
      */
-    protected $basePath;
+    protected $groupPattern;
 
     /**
      * @param ResponseFactoryInterface     $responseFactory
      * @param CallableResolverInterface    $callableResolver
      * @param RouteCollectorInterface|null $routeCollector
      * @param ContainerInterface|null      $container
-     * @param string                       $basePath
+     * @param string                       $groupPattern
      */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
         CallableResolverInterface $callableResolver,
         ?ContainerInterface $container = null,
         ?RouteCollectorInterface $routeCollector = null,
-        string $basePath = ''
+        string $groupPattern = ''
     ) {
         $this->responseFactory = $responseFactory;
         $this->callableResolver = $callableResolver;
         $this->container = $container;
         $this->routeCollector = $routeCollector ?? new RouteCollector($responseFactory, $callableResolver, $container);
-        $this->basePath = $basePath;
+        $this->groupPattern = $groupPattern;
     }
 
     /**
@@ -103,7 +103,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
      */
     public function getBasePath(): string
     {
-        return $this->basePath;
+        return $this->routeCollector->getBasePath();
     }
 
     /**
@@ -111,7 +111,8 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
      */
     public function setBasePath(string $basePath): RouteCollectorProxyInterface
     {
-        $this->basePath = $basePath;
+        $this->routeCollector->setBasePath($basePath);
+
         return $this;
     }
 
@@ -176,7 +177,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
      */
     public function map(array $methods, string $pattern, $callable): RouteInterface
     {
-        $pattern = $this->basePath . $pattern;
+        $pattern = $this->groupPattern . $pattern;
 
         return $this->routeCollector->map($methods, $pattern, $callable);
     }
@@ -186,7 +187,8 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
      */
     public function group(string $pattern, $callable): RouteGroupInterface
     {
-        $pattern = $this->basePath . $pattern;
+        $pattern = $this->groupPattern . $pattern;
+
         return $this->routeCollector->group($pattern, $callable);
     }
 

--- a/tests/Routing/RouteCollectorProxyTest.php
+++ b/tests/Routing/RouteCollectorProxyTest.php
@@ -100,15 +100,14 @@ class RouteCollectorProxyTest extends TestCase
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
         $containerProphecy = $this->prophesize(ContainerInterface::class);
-        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
 
         $routeCollectorProxy = new RouteCollectorProxy(
             $responseFactoryProphecy->reveal(),
             $callableResolverProphecy->reveal(),
-            $containerProphecy->reveal(),
-            $routeCollectorProphecy->reveal(),
-            $basePath
+            $containerProphecy->reveal()
         );
+
+        $routeCollectorProxy->setBasePath($basePath);
 
         $this->assertEquals($basePath, $routeCollectorProxy->getBasePath());
 


### PR DESCRIPTION
At this moment, basePath is handled by both **RouteCollectorProxy** and **RouteCollector**.

This PR:
- [respects](https://github.com/slimphp/Slim/pull/2844/commits/017cb003316b732f250b567e908426264722fc6e#diff-37b87065bdf2692920fc31e79882d28eR41-R44) `RouteCollector::$basePath` when creating routes via Dispatcher
- [changes](https://github.com/slimphp/Slim/pull/2844/commits/017cb003316b732f250b567e908426264722fc6e#diff-f43987d6169165b72946d742f3062eb3R104-R117) `RouteCollectorProxy::setBasePath` and `RouteCollectorProxy::getBasePath` methods which now call RouteCollector methods
- renames `RouteCollectorProxy::$basePath` to `$groupPattern` as [that's what it is](https://github.com/slimphp/Slim/blob/017cb003316b732f250b567e908426264722fc6e/Slim/Routing/RouteCollector.php#L248)

There are no B/C changes.

Fixes https://github.com/slimphp/Slim/issues/2842 and possibly https://github.com/slimphp/Slim/issues/2512

For test case, see [Slim-4-basepath-issue](https://github.com/piotr-cz/Slim-4-basepath-issue)