### PR TITLE
Fix composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,9 +68,9 @@
             "@phpcs",
             "@phpstan"
         ],
-        "phpunit": "php vendor/bin/phpunit",
-        "phpcs": "php vendor/bin/phpcs",
-        "phpstan": "php -d memory_limit=-1 vendor/bin/phpstan analyse Slim"
+        "phpunit": "phpunit",
+        "phpcs": "phpcs",
+        "phpstan": "phpstan analyse Slim --memory-limit=-1"
     },
     "suggest": {
         "ext-simplexml": "Needed to support XML format in BodyParsingMiddleware",


### PR DESCRIPTION
When trying to run composer scripts, instead of executing their file is printed on screen.
For example
```sh
composer phpunit
> php vendor/bin/phpunit

dir=$(cd "${0%[/\\]*}" > /dev/null; cd "../phpunit/phpunit" && pwd)

if [ -d /proc/cygdrive ]; then
    case $(which php) in
        $(readlink -n /proc/cygdrive)/*)
            # We are in Cygwin using Windows php, so the path must be translated
            dir=$(cygpath -m "$dir");
            ;;
    esac
fi

"${dir}/phpunit" "$@"
```

Fixed by adjusting to suggestions: 
- Composer > Scripts > [Writing custom commands](https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands)
- changed phpstan arguments to suggested [here](https://github.com/phpstan/phpstan/issues/1148#issuecomment-402065524)