### PR TITLE
Create class alias for FastRoute\RouteCollector

### DIFF
--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Slim\Routing;
 
-use FastRoute\RouteCollector;
+use FastRoute\RouteCollector as FastRouteCollector;
 use FastRoute\RouteParser\Std;
 use Slim\Interfaces\DispatcherInterface;
 use Slim\Interfaces\RouteCollectorInterface;
@@ -37,7 +37,7 @@ class Dispatcher implements DispatcherInterface
             return $this->dispatcher;
         }
 
-        $routeDefinitionCallback = function (RouteCollector $r) {
+        $routeDefinitionCallback = function (FastRouteCollector $r) {
             $basePath = $this->routeCollector->getBasePath();
 
             foreach ($this->routeCollector->getRoutes() as $route) {


### PR DESCRIPTION
So it doesn't confuse with [Slim\Routing\RouteCollector](https://github.com/slimphp/Slim/blob/4.2.0/Slim/Routing/RouteCollector.php) which resides in same namespace