### PR TITLE
Adding RouteParser::getBasePath method

### DIFF
--- a/Slim/Interfaces/RouteParserInterface.php
+++ b/Slim/Interfaces/RouteParserInterface.php
@@ -61,5 +61,5 @@ interface RouteParserInterface
      *
      * @return string
      */
-    public function basePath(): string;
+    public function getBasePath(): string;
 }

--- a/Slim/Interfaces/RouteParserInterface.php
+++ b/Slim/Interfaces/RouteParserInterface.php
@@ -55,4 +55,11 @@ interface RouteParserInterface
      * @return string
      */
     public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string;
+
+    /**
+     * Get base path
+     *
+     * @return string
+     */
+    public function basePath(): string;
 }

--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -129,7 +129,7 @@ class RouteParser implements RouteParserInterface
     /**
      * {@inheritdoc}
      */
-    public function basePath(): string
+    public function getBasePath(): string
     {
         return $this->routeCollector->getBasePath();
     }

--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -125,4 +125,12 @@ class RouteParser implements RouteParserInterface
         $protocol = ($scheme ? $scheme . ':' : '') . ($authority ? '//' . $authority : '');
         return $protocol . $path;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function basePath(): string
+    {
+        return $this->routeCollector->getBasePath();
+    }
 }

--- a/tests/Routing/RouteParserTest.php
+++ b/tests/Routing/RouteParserTest.php
@@ -194,4 +194,17 @@ class RouteParserTest extends TestCase
         $expectedResult = 'http://example.com:8080/app/123';
         $this->assertEquals($expectedResult, $result);
     }
+
+    public function testBasePath()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $routeCollector->setBasePath('/app');
+
+        $routeParser = $routeCollector->getRouteParser();
+
+        $this->assertEquals('/app', $routeParser->basePath());
+    }
 }

--- a/tests/Routing/RouteParserTest.php
+++ b/tests/Routing/RouteParserTest.php
@@ -195,7 +195,7 @@ class RouteParserTest extends TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function testBasePath()
+    public function testGetBasePath()
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
@@ -205,6 +205,6 @@ class RouteParserTest extends TestCase
 
         $routeParser = $routeCollector->getRouteParser();
 
-        $this->assertEquals('/app', $routeParser->basePath());
+        $this->assertEquals('/app', $routeParser->getBasePath());
     }
 }


### PR DESCRIPTION
See #2837

At this moment it's not trivial to retrieve `basePath` from code that doesn't have access to App or RouteCollector instances (and in my opinion code responsible for rendering responses shouldn't have).

RouteParser class seems like good place for it as

- it contains other related methods (`relativeUrlFor`, `urlFor`, `fullUrlFor`)
- it can be available as a route attribute (and indirectly in middleware) when using `App::addRoutingMiddleware`

I haven't implemented in this PR other methods that could be helpful like baseUrl by purpose as I'm not sure if it should be implemented in Slim or view classes.
