### PR TITLE
Fix undefined property in tests

### DIFF
--- a/tests/Mocks/RequestHandlerTest.php
+++ b/tests/Mocks/RequestHandlerTest.php
@@ -43,6 +43,9 @@ class RequestHandlerTest implements RequestHandlerInterface
 
     public function custom(ServerRequestInterface $request): ResponseInterface
     {
+        $psr7ObjectProvider = new PSR7ObjectProvider();
+        $responseFactory = $psr7ObjectProvider->getResponseFactory();
+
         return $responseFactory->createResponse();
     }
 }


### PR DESCRIPTION
This seems like a dead code (tests don't complain) but I see no reason why not fix it.