### PR TITLE
Add list of allowed methods to HttpMethodNotAllowedException

### DIFF
--- a/Slim/Exception/HttpMethodNotAllowedException.php
+++ b/Slim/Exception/HttpMethodNotAllowedException.php
@@ -36,6 +36,7 @@ class HttpMethodNotAllowedException extends HttpSpecializedException
     public function setAllowedMethods(array $methods): HttpMethodNotAllowedException
     {
         $this->allowedMethods = $methods;
+        $this->message = 'Method not allowed. Must be one of: ' . implode(', ', $methods);
         return $this;
     }
 }

--- a/tests/Exception/HttpExceptionTest.php
+++ b/tests/Exception/HttpExceptionTest.php
@@ -43,8 +43,10 @@ class HttpExceptionTest extends TestCase
         $exception = new HttpMethodNotAllowedException($request);
         $exception->setAllowedMethods(['GET']);
         $this->assertEquals(['GET'], $exception->getAllowedMethods());
+        $this->assertEquals('Method not allowed. Must be one of: GET', $exception->getMessage());
 
         $exception = new HttpMethodNotAllowedException($request);
         $this->assertEquals([], $exception->getAllowedMethods());
+        $this->assertEquals('Method not allowed.', $exception->getMessage());
     }
 }


### PR DESCRIPTION
When we know the allowed methods, add them to the exception message so that it's easier to see what happened in error logs.
