### PR TITLE
Strategy handler response factory refactoring

### DIFF
--- a/Slim/Handlers/Strategies/RequestHandler.php
+++ b/Slim/Handlers/Strategies/RequestHandler.php
@@ -36,7 +36,6 @@ class RequestHandler implements RequestHandlerInvocationStrategyInterface
      *
      * @param callable               $callable
      * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
      * @param array                  $routeArguments
      *
      * @return ResponseInterface
@@ -44,7 +43,6 @@ class RequestHandler implements RequestHandlerInvocationStrategyInterface
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,
-        ResponseInterface $response,
         array $routeArguments
     ): ResponseInterface {
         if ($this->appendRouteArgumentsToRequestAttributes) {

--- a/Slim/Handlers/Strategies/RequestResponse.php
+++ b/Slim/Handlers/Strategies/RequestResponse.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Slim\Handlers\Strategies;
 
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Interfaces\InvocationStrategyInterface;
@@ -19,12 +20,24 @@ use Slim\Interfaces\InvocationStrategyInterface;
 class RequestResponse implements InvocationStrategyInterface
 {
     /**
+     * @var ResponseFactoryInterface
+     */
+    private $responseFactory;
+
+    /**
+     * @param ResponseFactoryInterface $responseFactory
+     */
+    public function __construct(ResponseFactoryInterface $responseFactory)
+    {
+        $this->responseFactory = $responseFactory;
+    }
+
+    /**
      * Invoke a route callable with request, response, and all route parameters
      * as an array of arguments.
      *
      * @param callable               $callable
      * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
      * @param array                  $routeArguments
      *
      * @return ResponseInterface
@@ -32,13 +45,12 @@ class RequestResponse implements InvocationStrategyInterface
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,
-        ResponseInterface $response,
         array $routeArguments
     ): ResponseInterface {
         foreach ($routeArguments as $k => $v) {
             $request = $request->withAttribute($k, $v);
         }
 
-        return $callable($request, $response, $routeArguments);
+        return $callable($request, $this->responseFactory->createResponse(), $routeArguments);
     }
 }

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Slim\Handlers\Strategies;
 
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Interfaces\InvocationStrategyInterface;
@@ -19,12 +20,24 @@ use Slim\Interfaces\InvocationStrategyInterface;
 class RequestResponseArgs implements InvocationStrategyInterface
 {
     /**
+     * @var ResponseFactoryInterface
+     */
+    private $responseFactory;
+
+    /**
+     * @param ResponseFactoryInterface $responseFactory
+     */
+    public function __construct(ResponseFactoryInterface $responseFactory)
+    {
+        $this->responseFactory = $responseFactory;
+    }
+
+    /**
      * Invoke a route callable with request, response and all route parameters
      * as individual arguments.
      *
      * @param callable               $callable
      * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
      * @param array                  $routeArguments
      *
      * @return ResponseInterface
@@ -32,9 +45,8 @@ class RequestResponseArgs implements InvocationStrategyInterface
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,
-        ResponseInterface $response,
         array $routeArguments
     ): ResponseInterface {
-        return $callable($request, $response, ...array_values($routeArguments));
+        return $callable($request, $this->responseFactory->createResponse(), ...array_values($routeArguments));
     }
 }

--- a/Slim/Interfaces/InvocationStrategyInterface.php
+++ b/Slim/Interfaces/InvocationStrategyInterface.php
@@ -22,7 +22,6 @@ interface InvocationStrategyInterface
      *
      * @param callable               $callable       The callable to invoke using the strategy.
      * @param ServerRequestInterface $request        The request object.
-     * @param ResponseInterface      $response       The response object.
      * @param array                  $routeArguments The route's placeholder arguments
      *
      * @return ResponseInterface The response from the callable.
@@ -30,7 +29,6 @@ interface InvocationStrategyInterface
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,
-        ResponseInterface $response,
         array $routeArguments
     ): ResponseInterface;
 }

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -143,7 +143,7 @@ class Route implements RouteInterface, RequestHandlerInterface
         $this->responseFactory = $responseFactory;
         $this->callableResolver = $callableResolver;
         $this->container = $container;
-        $this->invocationStrategy = $invocationStrategy ?? new RequestResponse();
+        $this->invocationStrategy = $invocationStrategy ?? new RequestResponse($responseFactory);
         $this->groups = $groups;
         $this->identifier = 'route' . $identifier;
         $this->middlewareDispatcher = new MiddlewareDispatcher($this, $callableResolver, $container);
@@ -368,7 +368,6 @@ class Route implements RouteInterface, RequestHandlerInterface
             $strategy = new RequestHandler();
         }
 
-        $response = $this->responseFactory->createResponse();
-        return $strategy($callable, $request, $response, $this->arguments);
+        return $strategy($callable, $request, $this->arguments);
     }
 }

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -105,7 +105,7 @@ class RouteCollector implements RouteCollectorInterface
         $this->responseFactory = $responseFactory;
         $this->callableResolver = $callableResolver;
         $this->container = $container;
-        $this->defaultInvocationStrategy = $defaultInvocationStrategy ?? new RequestResponse();
+        $this->defaultInvocationStrategy = $defaultInvocationStrategy ?? new RequestResponse($responseFactory);
         $this->routeParser = $routeParser ?? new RouteParser($this);
 
         if ($cacheFile) {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1269,7 +1269,9 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->getRouteCollector()->setDefaultInvocationStrategy(new RequestResponseArgs());
+        $app->getRouteCollector()->setDefaultInvocationStrategy(
+            new RequestResponseArgs($responseFactoryProphecy->reveal())
+        );
         $app->get('/Hello/{name}', function (ServerRequestInterface $request, ResponseInterface $response, $name) {
             $response->getBody()->write("Hello {$name}");
             return $response;
@@ -1583,7 +1585,9 @@ class AppTest extends TestCase
         $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
 
         $app = new App($responseFactoryProphecy->reveal());
-        $app->getRouteCollector()->setDefaultInvocationStrategy(new RequestResponseArgs());
+        $app->getRouteCollector()->setDefaultInvocationStrategy(
+            new RequestResponseArgs($responseFactoryProphecy->reveal())
+        );
         $app->get('/Hello/{name}', function (ServerRequestInterface $request, ResponseInterface $response, $name) {
             $response->getBody()->write($request->getAttribute('greeting') . ' ' . $name);
             return $response;

--- a/tests/Mocks/InvocationStrategyTest.php
+++ b/tests/Mocks/InvocationStrategyTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Mocks;
 
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Interfaces\InvocationStrategyInterface;
@@ -18,11 +19,23 @@ class InvocationStrategyTest implements InvocationStrategyInterface
     public static $LastCalledFor = null;
 
     /**
+     * @var ResponseFactoryInterface
+     */
+    private $responseFactory;
+
+    /**
+     * @param ResponseFactoryInterface $responseFactory
+     */
+    public function __construct(ResponseFactoryInterface $responseFactory)
+    {
+        $this->responseFactory = $responseFactory;
+    }
+
+    /**
      * Invoke a route callable.
      *
      * @param callable               $callable       The callable to invoke using the strategy.
      * @param ServerRequestInterface $request        The request object.
-     * @param ResponseInterface      $response       The response object.
      * @param array                  $routeArguments The route's placeholder arguments
      *
      * @return ResponseInterface The response from the callable.
@@ -30,10 +43,9 @@ class InvocationStrategyTest implements InvocationStrategyInterface
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,
-        ResponseInterface $response,
         array $routeArguments
     ): ResponseInterface {
         static::$LastCalledFor = $callable;
-        return $response;
+        return $this->responseFactory->createResponse();
     }
 }

--- a/tests/Mocks/MockCustomRequestHandlerInvocationStrategy.php
+++ b/tests/Mocks/MockCustomRequestHandlerInvocationStrategy.php
@@ -20,7 +20,6 @@ class MockCustomRequestHandlerInvocationStrategy implements RequestHandlerInvoca
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,
-        ResponseInterface $response,
         array $routeArguments
     ): ResponseInterface {
         self::$CalledCount += 1;

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -537,7 +537,7 @@ class RouteTest extends TestCase
             ->shouldBeCalledOnce();
 
         $callableResolver = new CallableResolver();
-        $invocationStrategy = new InvocationStrategyTest();
+        $invocationStrategy = new InvocationStrategyTest($responseFactoryProphecy->reveal());
 
         $deferred = '\Slim\Tests\Mocks\CallableTest:toCall';
         $route = new Route(
@@ -575,7 +575,7 @@ class RouteTest extends TestCase
         $containerProphecy->get('\Slim\Tests\Mocks\CallableTest')->willReturn(new CallableTest());
 
         $callableResolver = new CallableResolver($containerProphecy->reveal());
-        $strategy = new InvocationStrategyTest();
+        $strategy = new InvocationStrategyTest($responseFactoryProphecy->reveal());
 
         $deferred = '\Slim\Tests\Mocks\CallableTest:toCall';
         $route = new Route(
@@ -597,13 +597,10 @@ class RouteTest extends TestCase
 
     public function testInvokeUsesRequestHandlerStrategyForRequestHandlers()
     {
-        $responseProphecy = $this->prophesize(ResponseInterface::class);
-
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $responseFactoryProphecy
             ->createResponse()
-            ->willReturn($responseProphecy->reveal())
-            ->shouldBeCalledOnce();
+            ->shouldNotBeCalled();
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
         $containerProphecy->has(RequestHandlerTest::class)->willReturn(true);
@@ -634,13 +631,10 @@ class RouteTest extends TestCase
 
     public function testInvokeUsesUserSetStrategyForRequestHandlers()
     {
-        $responseProphecy = $this->prophesize(ResponseInterface::class);
-
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $responseFactoryProphecy
             ->createResponse()
-            ->willReturn($responseProphecy->reveal())
-            ->shouldBeCalledOnce();
+            ->shouldNotBeCalled();
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
         $containerProphecy->has(RequestHandlerTest::class)->willReturn(true);
@@ -676,8 +670,7 @@ class RouteTest extends TestCase
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $responseFactoryProphecy
             ->createResponse()
-            ->willReturn($responseProphecy->reveal())
-            ->shouldBeCalledOnce();
+            ->shouldNotBeCalled();
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
         $containerProphecy->has(RequestHandlerTest::class)->willReturn(true);
@@ -774,7 +767,7 @@ class RouteTest extends TestCase
         $containerProphecy->get('CallableTest2')->willReturn(new CallableTest());
 
         $callableResolver = new CallableResolver($containerProphecy->reveal());
-        $strategy = new InvocationStrategyTest();
+        $strategy = new InvocationStrategyTest($responseFactoryProphecy->reveal());
 
         $deferred = 'NonExistent:toCall';
         $route = new Route(
@@ -839,7 +832,7 @@ class RouteTest extends TestCase
         });
 
         $callableResolver = new CallableResolver($containerProphecy->reveal());
-        $strategy = new InvocationStrategyTest();
+        $strategy = new InvocationStrategyTest($responseFactoryProphecy->reveal());
 
         $deferred = 'CallableTest3';
         $route = new Route(

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -293,7 +293,7 @@ class RouteTest extends TestCase
             ->shouldBeCalledOnce();
 
         $routeCollectorProxyProphecy = $this->prophesize(RouteCollectorProxyInterface::class);
-        $strategy = new RequestResponse();
+        $strategy = new RequestResponse($responseFactoryProphecy->reveal());
 
         $called = 0;
         $mw = function (ServerRequestInterface $request, RequestHandlerInterface $handler) use (&$called) {


### PR DESCRIPTION
The response factory is used only in two of the three strategies, and it is passed as an argument in the interface. Perhaps it would be more logical to pass the response factory to the constructor as a dependency