### PR TITLE
Adding RouteParser::getBasePath method (no changes to RouteParserInterface)

### DIFF
--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -125,4 +125,14 @@ class RouteParser implements RouteParserInterface
         $protocol = ($scheme ? $scheme . ':' : '') . ($authority ? '//' . $authority : '');
         return $protocol . $path;
     }
+
+    /**
+     * Get base path
+     *
+     * @return string
+     */
+    public function getBasePath(): string
+    {
+        return $this->routeCollector->getBasePath();
+    }
 }

--- a/tests/Routing/RouteParserTest.php
+++ b/tests/Routing/RouteParserTest.php
@@ -194,4 +194,17 @@ class RouteParserTest extends TestCase
         $expectedResult = 'http://example.com:8080/app/123';
         $this->assertEquals($expectedResult, $result);
     }
+
+    public function testGetBasePath()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
+        $routeCollector->setBasePath('/app');
+
+        $routeParser = $routeCollector->getRouteParser();
+
+        $this->assertEquals('/app', $routeParser->getBasePath());
+    }
 }


### PR DESCRIPTION
This superseeds #2852 and partially resolves #2837

Only difference is that there are no changes to `RouteParserInterface` to not break backward compatibility.