### PR TITLE
Optionally handle subclasses of exceptions in custom error handler

### DIFF
--- a/tests/Middleware/ErrorMiddlewareTest.php
+++ b/tests/Middleware/ErrorMiddlewareTest.php
@@ -99,24 +99,127 @@ class ErrorMiddlewareTest extends TestCase
         $this->assertInstanceOf(ErrorHandler::class, $handler);
     }
 
+    public function testSuperclassExceptionHandlerHandlesExceptionWithSubclassExactMatch()
+    {
+        $responseFactory = $this->getResponseFactory();
+        $app = new App($responseFactory);
+        $callableResolver = $app->getCallableResolver();
+        $mw = new ErrorMiddleware($callableResolver, $this->getResponseFactory(), false, false, false);
+        $app->add(function ($request, $handler) {
+            throw new \LogicException('This is a LogicException...');
+        });
+        $mw->setErrorHandler(\LogicException::class, (function (ServerRequestInterface $request, $exception) {
+            $response = $this->createResponse();
+            $response->getBody()->write($exception->getMessage());
+            return $response;
+        })->bindTo($this), true); // - true; handle subclass but also LogicException explicitly
+        $mw->setDefaultErrorHandler((function () {
+            $response = $this->createResponse();
+            $response->getBody()->write('Oops..');
+            return $response;
+        })->bindTo($this));
+        $app->add($mw);
+        $app->get('/foo', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('...');
+            return $response;
+        });
+        $request = $this->createServerRequest('/foo');
+        $app->run($request);
+        $this->expectOutputString('This is a LogicException...');
+    }
+
+    public function testSuperclassExceptionHandlerHandlesSubclassException()
+    {
+        $responseFactory = $this->getResponseFactory();
+        $app = new App($responseFactory);
+        $callableResolver = $app->getCallableResolver();
+
+        $mw = new ErrorMiddleware($callableResolver, $this->getResponseFactory(), false, false, false);
+
+        $app->add(function ($request, $handler) {
+            throw new \InvalidArgumentException('This is a subclass of LogicException...');
+        });
+
+        $mw->setErrorHandler(\LogicException::class, (function (ServerRequestInterface $request, $exception) {
+            $response = $this->createResponse();
+            $response->getBody()->write($exception->getMessage());
+            return $response;
+        })->bindTo($this), true); // - true; handle subclass
+
+        $mw->setDefaultErrorHandler((function () {
+            $response = $this->createResponse();
+            $response->getBody()->write('Oops..');
+            return $response;
+        })->bindTo($this));
+
+        $app->add($mw);
+
+        $app->get('/foo', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('...');
+            return $response;
+        });
+
+        $request = $this->createServerRequest('/foo');
+        $app->run($request);
+
+        $this->expectOutputString('This is a subclass of LogicException...');
+    }
+
+    public function testSuperclassExceptionHandlerDoesNotHandleSubclassException()
+    {
+        $responseFactory = $this->getResponseFactory();
+        $app = new App($responseFactory);
+        $callableResolver = $app->getCallableResolver();
+
+        $mw = new ErrorMiddleware($callableResolver, $this->getResponseFactory(), false, false, false);
+
+        $app->add(function ($request, $handler) {
+            throw new \InvalidArgumentException('This is a subclass of LogicException...');
+        });
+
+        $mw->setErrorHandler(\LogicException::class, (function (ServerRequestInterface $request, $exception) {
+            $response = $this->createResponse();
+            $response->getBody()->write($exception->getMessage());
+            return $response;
+        })->bindTo($this), false); // - false; don't handle subclass
+
+        $mw->setDefaultErrorHandler((function () {
+            $response = $this->createResponse();
+            $response->getBody()->write('Oops..');
+            return $response;
+        })->bindTo($this));
+
+        $app->add($mw);
+
+        $app->get('/foo', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('...');
+            return $response;
+        });
+
+        $request = $this->createServerRequest('/foo');
+        $app->run($request);
+
+        $this->expectOutputString('Oops..');
+    }
+
     public function testErrorHandlerHandlesThrowables()
     {
         $responseFactory = $this->getResponseFactory();
         $app = new App($responseFactory);
         $callableResolver = $app->getCallableResolver();
 
+        $mw = new ErrorMiddleware($callableResolver, $this->getResponseFactory(), false, false, false);
+
         $app->add(function ($request, $handler) {
             throw new Error('Oops..');
         });
 
-        $handler = (function (ServerRequestInterface $request, $exception) {
+        $mw->setDefaultErrorHandler((function (ServerRequestInterface $request, $exception) {
             $response = $this->createResponse();
             $response->getBody()->write($exception->getMessage());
             return $response;
-        })->bindTo($this);
+        })->bindTo($this));
 
-        $mw = new ErrorMiddleware($callableResolver, $this->getResponseFactory(), false, false, false);
-        $mw->setDefaultErrorHandler($handler);
         $app->add($mw);
 
         $app->get('/foo', function (ServerRequestInterface $request, ResponseInterface $response) {

--- a/tests/Middleware/ErrorMiddlewareTest.php
+++ b/tests/Middleware/ErrorMiddlewareTest.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Slim\Tests\Middleware;
 
 use Error;
+use InvalidArgumentException;
+use LogicException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\App;
@@ -106,9 +108,9 @@ class ErrorMiddlewareTest extends TestCase
         $callableResolver = $app->getCallableResolver();
         $mw = new ErrorMiddleware($callableResolver, $this->getResponseFactory(), false, false, false);
         $app->add(function ($request, $handler) {
-            throw new \LogicException('This is a LogicException...');
+            throw new LogicException('This is a LogicException...');
         });
-        $mw->setErrorHandler(\LogicException::class, (function (ServerRequestInterface $request, $exception) {
+        $mw->setErrorHandler(LogicException::class, (function (ServerRequestInterface $request, $exception) {
             $response = $this->createResponse();
             $response->getBody()->write($exception->getMessage());
             return $response;
@@ -137,10 +139,10 @@ class ErrorMiddlewareTest extends TestCase
         $mw = new ErrorMiddleware($callableResolver, $this->getResponseFactory(), false, false, false);
 
         $app->add(function ($request, $handler) {
-            throw new \InvalidArgumentException('This is a subclass of LogicException...');
+            throw new InvalidArgumentException('This is a subclass of LogicException...');
         });
 
-        $mw->setErrorHandler(\LogicException::class, (function (ServerRequestInterface $request, $exception) {
+        $mw->setErrorHandler(LogicException::class, (function (ServerRequestInterface $request, $exception) {
             $response = $this->createResponse();
             $response->getBody()->write($exception->getMessage());
             return $response;
@@ -174,10 +176,10 @@ class ErrorMiddlewareTest extends TestCase
         $mw = new ErrorMiddleware($callableResolver, $this->getResponseFactory(), false, false, false);
 
         $app->add(function ($request, $handler) {
-            throw new \InvalidArgumentException('This is a subclass of LogicException...');
+            throw new InvalidArgumentException('This is a subclass of LogicException...');
         });
 
-        $mw->setErrorHandler(\LogicException::class, (function (ServerRequestInterface $request, $exception) {
+        $mw->setErrorHandler(LogicException::class, (function (ServerRequestInterface $request, $exception) {
             $response = $this->createResponse();
             $response->getBody()->write($exception->getMessage());
             return $response;


### PR DESCRIPTION
Hello guys

I thought this could be a nice addition, so a particular app can decide to handle all subclasses of an exception with one handler. This is nice way to keep things separated.

I added this as an option that defaults to false so this *should* not be a breaking change, but I'm not 100% sure since `$handlers` is `protected` and not `private`.

What do you think?