### PR TITLE
Remove explicit type-hint

### DIFF
--- a/Slim/Middleware/ContentLengthMiddleware.php
+++ b/Slim/Middleware/ContentLengthMiddleware.php
@@ -23,7 +23,6 @@ class ContentLengthMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        /** @var ResponseInterface $response */
         $response = $handler->handle($request);
 
         // Add Content-Length header if not already added

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -56,7 +56,6 @@ class OutputBufferingMiddleware implements MiddlewareInterface
     {
         try {
             ob_start();
-            /** @var ResponseInterface $response */
             $response = $handler->handle($request);
             $output = ob_get_clean();
         } catch (Throwable $e) {


### PR DESCRIPTION
The explicit type-hint can be removed as it can be inferred from `\Psr\Http\Server\RequestHandlerInterface::handle()`.