### PR TITLE
Remove type-hint

### DIFF
--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -205,7 +205,6 @@ class RouteCollector implements RouteCollectorInterface
      */
     public function removeNamedRoute(string $name): RouteCollectorInterface
     {
-        /** @var Route $route */
         $route = $this->getNamedRoute($name);
         unset($this->routes[$route->getIdentifier()]);
         return $this;


### PR DESCRIPTION
The method `getNamedRoute()` returns a `RouteInterface` (type-hinted) which defines the method `getIdentifier()` used on the next line. So this explicit type-hint can be removed.