### PR TITLE
Add `null` to param type-hints

### DIFF
--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -87,12 +87,12 @@ class RouteCollector implements RouteCollectorInterface
     protected $responseFactory;
 
     /**
-     * @param ResponseFactoryInterface    $responseFactory
-     * @param CallableResolverInterface   $callableResolver
-     * @param ContainerInterface|null     $container
-     * @param InvocationStrategyInterface $defaultInvocationStrategy
-     * @param RouteParserInterface        $routeParser
-     * @param string                      $cacheFile
+     * @param ResponseFactoryInterface         $responseFactory
+     * @param CallableResolverInterface        $callableResolver
+     * @param ContainerInterface|null          $container
+     * @param InvocationStrategyInterface|null $defaultInvocationStrategy
+     * @param RouteParserInterface|null        $routeParser
+     * @param string|null                      $cacheFile
      */
     public function __construct(
         ResponseFactoryInterface $responseFactory,


### PR DESCRIPTION
The last three parameters of the `\Slim\Routing\RouteCollector` constructor can be `null`. So this PR would update the docblock type-hints accordingly.

https://github.com/slimphp/Slim/blob/7f36c9e3ec0e002a915e6ef85677499d1cd0c728/Slim/Routing/RouteCollector.php#L97-L104