### PR TITLE
Replace abandoned `container-interop/container-interop` package with `psr/container`

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -11,7 +11,7 @@ use BadMethodCallException;
 use Closure;
 use Exception;
 use FastRoute\Dispatcher;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use InvalidArgumentException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\RequestInterface;

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -9,7 +9,7 @@ namespace Slim;
 
 use ArrayAccess;
 use Psr\Container\ContainerInterface;
-use Psr\Container\ContainerExceptionInterface as ContainerException;
+use Psr\Container\ContainerExceptionInterface;
 use InvalidArgumentException;
 use Pimple\Container as PimpleContainer;
 use Slim\Exception\ContainerException as SlimContainerException;
@@ -95,9 +95,10 @@ class Container extends PimpleContainer implements ContainerInterface
      * @return mixed
      *
      * @throws InvalidArgumentException         Thrown when an offset cannot be found in the Pimple container
-     * @throws SlimContainerException           Thrown when an exception is not an instance of ContainerException
+     * @throws SlimContainerException           Thrown when an exception is
+     *         not an instance of ContainerExceptionInterface
      * @throws ContainerValueNotFoundException  No entry was found for this identifier.
-     * @throws ContainerException               Error while retrieving the entry.
+     * @throws ContainerExceptionInterface      Error while retrieving the entry.
      */
     public function get($id)
     {
@@ -153,9 +154,10 @@ class Container extends PimpleContainer implements ContainerInterface
      * @return mixed
      *
      * @throws InvalidArgumentException         Thrown when an offset cannot be found in the Pimple container
-     * @throws SlimContainerException           Thrown when an exception is not an instance of ContainerException
+     * @throws SlimContainerException           Thrown when an exception is not
+     *         an instance of ContainerExceptionInterface
      * @throws ContainerValueNotFoundException  No entry was found for this identifier.
-     * @throws ContainerException               Error while retrieving the entry.
+     * @throws ContainerExceptionInterface      Error while retrieving the entry.
      */
     public function __get($name)
     {

--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -8,8 +8,8 @@
 namespace Slim;
 
 use ArrayAccess;
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\ContainerException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\ContainerExceptionInterface as ContainerException;
 use InvalidArgumentException;
 use Pimple\Container as PimpleContainer;
 use Slim\Exception\ContainerException as SlimContainerException;
@@ -120,7 +120,7 @@ class Container extends PimpleContainer implements ContainerInterface
     }
 
     /**
-     * Tests whether an exception needs to be recast for compliance with Container-Interop.  This will be if the
+     * Tests whether an exception needs to be recast for compliance with psr/container.  This will be if the
      * exception was thrown by Pimple.
      *
      * @param InvalidArgumentException $exception

--- a/Slim/DefaultServicesProvider.php
+++ b/Slim/DefaultServicesProvider.php
@@ -27,7 +27,7 @@ class DefaultServicesProvider
     /**
      * Register Slim's default services.
      *
-     * @param Container $container A DI container implementing ArrayAccess and container-interop.
+     * @param Container $container A DI container implementing ArrayAccess and psr/container.
      */
     public function register($container)
     {

--- a/Slim/Exception/ContainerException.php
+++ b/Slim/Exception/ContainerException.php
@@ -7,9 +7,9 @@
 
 namespace Slim\Exception;
 
-use Interop\Container\Exception\ContainerException as InteropContainerException;
+use Psr\Container\ContainerExceptionInterface;
 use InvalidArgumentException;
 
-class ContainerException extends InvalidArgumentException implements InteropContainerException
+class ContainerException extends InvalidArgumentException implements ContainerExceptionInterface
 {
 }

--- a/Slim/Exception/ContainerValueNotFoundException.php
+++ b/Slim/Exception/ContainerValueNotFoundException.php
@@ -7,9 +7,9 @@
 
 namespace Slim\Exception;
 
-use Interop\Container\Exception\NotFoundException as InteropNotFoundException;
+use Psr\Container\NotFoundExceptionInterface;
 use RuntimeException;
 
-class ContainerValueNotFoundException extends RuntimeException implements InteropNotFoundException
+class ContainerValueNotFoundException extends RuntimeException implements NotFoundExceptionInterface
 {
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "pimple/pimple": "^3.0",
         "psr/http-message": "^1.0",
         "nikic/fast-route": "^1.0",
-        "container-interop/container-interop": "^1.2",
         "psr/container": "^1.0"
     },
     "require-dev": {

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -55,7 +55,7 @@ class ContainerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test `get()` recasts InvalidArgumentException as ContainerInterop-compliant exceptions when an error is present
+     * Test `get()` recasts InvalidArgumentException as psr/container exceptions when an error is present
      * in the DI config
      *
      * @expectedException \Slim\Exception\ContainerException


### PR DESCRIPTION
PSR-11 `container-interop/container-interop` package is replaced by `psr/container`, but Slim v3 branch still uses it.

There were just a few uses of interfaces internally used by Slim, and this PR replaces them with the `psr/container` counterparts. 

Quoting from `container-interop/container-interop` project page:

> ## Deprecation warning!
> 
> Starting Feb. 13th 2017, container-interop is officially deprecated in favor of [PSR-11](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-11-container.md).
> Container-interop has been the test-bed of PSR-11. From v1.2, container-interop directly extends PSR-11 interfaces.
> Therefore, all containers implementing container-interop are now *de-facto* compatible with PSR-11.
> 
> - Projects implementing container-interop interfaces are encouraged to directly implement PSR-11 interfaces instead.
> - Projects consuming container-interop interfaces are very strongly encouraged to directly type-hint on PSR-11 interfaces, in order to be compatible with PSR-11 containers that are not compatible with container-interop.
> 
> Regarding the delegate lookup feature, that is present in container-interop and not in PSR-11, the feature is actually a design pattern. It is therefore not deprecated. Documentation regarding this design pattern will be migrated from this repository into a separate website in the future.

I do not think this will be a BC break (in semantic versioning sense) because the `container-interop` package implements `psr/container` internally.

Travis CI tests: https://travis-ci.org/Ayesh/Slim/builds/617400679

Thank you.