### PR TITLE
3.12.3 Release

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -41,7 +41,7 @@ class App
      *
      * @var string
      */
-    const VERSION = '3.12.2';
+    const VERSION = '3.12.3';
 
     /**
      * @var ContainerInterface


### PR DESCRIPTION
Total issues resolved: **2**
- [2880: &#91;3.x&#92; Remove phpdoc inheritdoc override](https://github.com/slimphp/Slim/pull/2880) thanks to @adriansuter
- [2885: Replace abandoned `container-interop/container-interop` package with `psr/container`](https://github.com/slimphp/Slim/pull/2885) thanks to @Ayesh