### PR TITLE
Change route context attribute names

### DIFF
--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -54,7 +54,7 @@ class RoutingMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $request = RouteContext::attachRouteParser($request, $this->routeParser);
+        $request = $request->withAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME, $this->routeParser);
         $request = $this->performRouting($request);
         return $handler->handle($request);
     }
@@ -77,7 +77,7 @@ class RoutingMiddleware implements MiddlewareInterface
         );
         $routeStatus = $routingResults->getRouteStatus();
 
-        $request = RouteContext::attachRoutingResults($request, $routingResults);
+        $request = $request->withAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME, $routingResults);
 
         switch ($routeStatus) {
             case RoutingResults::FOUND:
@@ -86,7 +86,7 @@ class RoutingMiddleware implements MiddlewareInterface
                 $route = $this->routeResolver
                     ->resolveRoute($routeIdentifier)
                     ->prepare($routeArguments);
-                return RouteContext::attachRoute($request, $route);
+                return $request->withAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME, $route);
 
             case RoutingResults::NOT_FOUND:
                 throw new HttpNotFoundException($request);

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -54,7 +54,7 @@ class RoutingMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $request = $request->withAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME, $this->routeParser);
+        $request = $request->withAttribute(RouteContext::ROUTE_PARSER, $this->routeParser);
         $request = $this->performRouting($request);
         return $handler->handle($request);
     }
@@ -77,7 +77,7 @@ class RoutingMiddleware implements MiddlewareInterface
         );
         $routeStatus = $routingResults->getRouteStatus();
 
-        $request = $request->withAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME, $routingResults);
+        $request = $request->withAttribute(RouteContext::ROUTING_RESULTS, $routingResults);
 
         switch ($routeStatus) {
             case RoutingResults::FOUND:
@@ -86,7 +86,7 @@ class RoutingMiddleware implements MiddlewareInterface
                 $route = $this->routeResolver
                     ->resolveRoute($routeIdentifier)
                     ->prepare($routeArguments);
-                return $request->withAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME, $route);
+                return $request->withAttribute(RouteContext::ROUTE, $route);
 
             case RoutingResults::NOT_FOUND:
                 throw new HttpNotFoundException($request);

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -18,6 +18,7 @@ use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
 use Slim\Interfaces\RouteParserInterface;
 use Slim\Interfaces\RouteResolverInterface;
+use Slim\Routing\RouteContext;
 use Slim\Routing\RoutingResults;
 
 class RoutingMiddleware implements MiddlewareInterface
@@ -53,7 +54,7 @@ class RoutingMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $request = $request->withAttribute('routeParser', $this->routeParser);
+        $request = RouteContext::attachRouteParser($request, $this->routeParser);
         $request = $this->performRouting($request);
         return $handler->handle($request);
     }
@@ -76,7 +77,7 @@ class RoutingMiddleware implements MiddlewareInterface
         );
         $routeStatus = $routingResults->getRouteStatus();
 
-        $request = $request->withAttribute('routingResults', $routingResults);
+        $request = RouteContext::attachRoutingResults($request, $routingResults);
 
         switch ($routeStatus) {
             case RoutingResults::FOUND:
@@ -85,7 +86,7 @@ class RoutingMiddleware implements MiddlewareInterface
                 $route = $this->routeResolver
                     ->resolveRoute($routeIdentifier)
                     ->prepare($routeArguments);
-                return $request->withAttribute('route', $route);
+                return RouteContext::attachRoute($request, $route);
 
             case RoutingResults::NOT_FOUND:
                 throw new HttpNotFoundException($request);

--- a/Slim/Routing/RouteContext.php
+++ b/Slim/Routing/RouteContext.php
@@ -16,67 +16,13 @@ use Slim\Interfaces\RouteParserInterface;
 
 final class RouteContext
 {
-    private static $routeAttributeName = '__route__';
+    public const ROUTE_ATTRIBUTE_NAME = '__route__';
 
-    private static $routeParserAttributeName = '__routeParser__';
+    public const ROUTE_PARSER_ATTRIBUTE_NAME = '__routeParser__';
 
-    private static $routingResultsAttributeName = '__routingResults__';
+    public const ROUTING_RESULTS_ATTRIBUTE_NAME = '__routingResults__';
 
-    private static $basePathAttributeName = '__basePath__';
-
-    public static function setRouteAttributeName(string $routeAttributeName): void
-    {
-        self::$routeAttributeName = $routeAttributeName;
-    }
-
-    public static function setRouteParserAttributeName(string $routeParserAttributeName): void
-    {
-        self::$routeParserAttributeName = $routeParserAttributeName;
-    }
-
-    public static function setRoutingResultsAttributeName(string $routingResultsAttributeName): void
-    {
-        self::$routingResultsAttributeName = $routingResultsAttributeName;
-    }
-
-    public static function setBasePathAttributeName(string $basePathAttributeName): void
-    {
-        self::$basePathAttributeName = $basePathAttributeName;
-    }
-
-    public static function attachRoute(ServerRequestInterface $request, RouteInterface $route): ServerRequestInterface
-    {
-        return $request->withAttribute(self::$routeAttributeName, $route);
-    }
-
-    public static function grabRoute(ServerRequestInterface $request): ?RouteInterface
-    {
-        return $request->getAttribute(self::$routeAttributeName);
-    }
-
-    public static function attachRouteParser(
-        ServerRequestInterface $request,
-        RouteParserInterface $routeParser
-    ): ServerRequestInterface {
-        return $request->withAttribute(self::$routeParserAttributeName, $routeParser);
-    }
-
-    public static function attachRoutingResults(
-        ServerRequestInterface $request,
-        RoutingResults $routingResults
-    ): ServerRequestInterface {
-        return $request->withAttribute(self::$routingResultsAttributeName, $routingResults);
-    }
-
-    public static function routingResultsAttached(ServerRequestInterface $request): bool
-    {
-        return $request->getAttribute(self::$routingResultsAttributeName) !== null;
-    }
-
-    public static function attachBasePath(ServerRequestInterface $request, string $basePath): ServerRequestInterface
-    {
-        return $request->withAttribute(self::$basePathAttributeName, $basePath);
-    }
+    public const BASE_PATH_ATTRIBUTE_NAME = '__basePath__';
 
     /**
      * @param ServerRequestInterface $serverRequest
@@ -84,10 +30,10 @@ final class RouteContext
      */
     public static function fromRequest(ServerRequestInterface $serverRequest): self
     {
-        $route = $serverRequest->getAttribute(self::$routeAttributeName);
-        $routeParser = $serverRequest->getAttribute(self::$routeParserAttributeName);
-        $routingResults = $serverRequest->getAttribute(self::$routingResultsAttributeName);
-        $basePath = $serverRequest->getAttribute(self::$basePathAttributeName);
+        $route = $serverRequest->getAttribute(self::ROUTE_ATTRIBUTE_NAME);
+        $routeParser = $serverRequest->getAttribute(self::ROUTE_PARSER_ATTRIBUTE_NAME);
+        $routingResults = $serverRequest->getAttribute(self::ROUTING_RESULTS_ATTRIBUTE_NAME);
+        $basePath = $serverRequest->getAttribute(self::BASE_PATH_ATTRIBUTE_NAME);
 
         if ($routeParser === null || $routingResults === null) {
             throw new RuntimeException('Cannot create RouteContext before routing has been completed');

--- a/Slim/Routing/RouteContext.php
+++ b/Slim/Routing/RouteContext.php
@@ -16,16 +16,78 @@ use Slim\Interfaces\RouteParserInterface;
 
 final class RouteContext
 {
+    private static $routeAttributeName = '__route__';
+
+    private static $routeParserAttributeName = '__routeParser__';
+
+    private static $routingResultsAttributeName = '__routingResults__';
+
+    private static $basePathAttributeName = '__basePath__';
+
+    public static function setRouteAttributeName(string $routeAttributeName): void
+    {
+        self::$routeAttributeName = $routeAttributeName;
+    }
+
+    public static function setRouteParserAttributeName(string $routeParserAttributeName): void
+    {
+        self::$routeParserAttributeName = $routeParserAttributeName;
+    }
+
+    public static function setRoutingResultsAttributeName(string $routingResultsAttributeName): void
+    {
+        self::$routingResultsAttributeName = $routingResultsAttributeName;
+    }
+
+    public static function setBasePathAttributeName(string $basePathAttributeName): void
+    {
+        self::$basePathAttributeName = $basePathAttributeName;
+    }
+
+    public static function attachRoute(ServerRequestInterface $request, RouteInterface $route): ServerRequestInterface
+    {
+        return $request->withAttribute(self::$routeAttributeName, $route);
+    }
+
+    public static function grabRoute(ServerRequestInterface $request): ?RouteInterface
+    {
+        return $request->getAttribute(self::$routeAttributeName);
+    }
+
+    public static function attachRouteParser(
+        ServerRequestInterface $request,
+        RouteParserInterface $routeParser
+    ): ServerRequestInterface {
+        return $request->withAttribute(self::$routeParserAttributeName, $routeParser);
+    }
+
+    public static function attachRoutingResults(
+        ServerRequestInterface $request,
+        RoutingResults $routingResults
+    ): ServerRequestInterface {
+        return $request->withAttribute(self::$routingResultsAttributeName, $routingResults);
+    }
+
+    public static function routingResultsAttached(ServerRequestInterface $request): bool
+    {
+        return $request->getAttribute(self::$routingResultsAttributeName) !== null;
+    }
+
+    public static function attachBasePath(ServerRequestInterface $request, string $basePath): ServerRequestInterface
+    {
+        return $request->withAttribute(self::$basePathAttributeName, $basePath);
+    }
+
     /**
      * @param ServerRequestInterface $serverRequest
      * @return RouteContext
      */
     public static function fromRequest(ServerRequestInterface $serverRequest): self
     {
-        $route = $serverRequest->getAttribute('route');
-        $routeParser = $serverRequest->getAttribute('routeParser');
-        $routingResults = $serverRequest->getAttribute('routingResults');
-        $basePath = $serverRequest->getAttribute('basePath');
+        $route = $serverRequest->getAttribute(self::$routeAttributeName);
+        $routeParser = $serverRequest->getAttribute(self::$routeParserAttributeName);
+        $routingResults = $serverRequest->getAttribute(self::$routingResultsAttributeName);
+        $basePath = $serverRequest->getAttribute(self::$basePathAttributeName);
 
         if ($routeParser === null || $routingResults === null) {
             throw new RuntimeException('Cannot create RouteContext before routing has been completed');

--- a/Slim/Routing/RouteContext.php
+++ b/Slim/Routing/RouteContext.php
@@ -16,13 +16,13 @@ use Slim\Interfaces\RouteParserInterface;
 
 final class RouteContext
 {
-    public const ROUTE_ATTRIBUTE_NAME = '__route__';
+    public const ROUTE = '__route__';
 
-    public const ROUTE_PARSER_ATTRIBUTE_NAME = '__routeParser__';
+    public const ROUTE_PARSER = '__routeParser__';
 
-    public const ROUTING_RESULTS_ATTRIBUTE_NAME = '__routingResults__';
+    public const ROUTING_RESULTS = '__routingResults__';
 
-    public const BASE_PATH_ATTRIBUTE_NAME = '__basePath__';
+    public const BASE_PATH = '__basePath__';
 
     /**
      * @param ServerRequestInterface $serverRequest
@@ -30,10 +30,10 @@ final class RouteContext
      */
     public static function fromRequest(ServerRequestInterface $serverRequest): self
     {
-        $route = $serverRequest->getAttribute(self::ROUTE_ATTRIBUTE_NAME);
-        $routeParser = $serverRequest->getAttribute(self::ROUTE_PARSER_ATTRIBUTE_NAME);
-        $routingResults = $serverRequest->getAttribute(self::ROUTING_RESULTS_ATTRIBUTE_NAME);
-        $basePath = $serverRequest->getAttribute(self::BASE_PATH_ATTRIBUTE_NAME);
+        $route = $serverRequest->getAttribute(self::ROUTE);
+        $routeParser = $serverRequest->getAttribute(self::ROUTE_PARSER);
+        $routingResults = $serverRequest->getAttribute(self::ROUTING_RESULTS);
+        $basePath = $serverRequest->getAttribute(self::BASE_PATH);
 
         if ($routeParser === null || $routingResults === null) {
             throw new RuntimeException('Cannot create RouteContext before routing has been completed');

--- a/Slim/Routing/RouteRunner.php
+++ b/Slim/Routing/RouteRunner.php
@@ -66,20 +66,20 @@ class RouteRunner implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         // If routing hasn't been done, then do it now so we can dispatch
-        if ($request->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME) === null) {
+        if ($request->getAttribute(RouteContext::ROUTING_RESULTS) === null) {
             $routingMiddleware = new RoutingMiddleware($this->routeResolver, $this->routeParser);
             $request = $routingMiddleware->performRouting($request);
         }
 
         if ($this->routeCollectorProxy !== null) {
             $request = $request->withAttribute(
-                RouteContext::BASE_PATH_ATTRIBUTE_NAME,
+                RouteContext::BASE_PATH,
                 $this->routeCollectorProxy->getBasePath()
             );
         }
 
         /** @var Route $route */
-        $route = $request->getAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME);
+        $route = $request->getAttribute(RouteContext::ROUTE);
         return $route->run($request);
     }
 }

--- a/Slim/Routing/RouteRunner.php
+++ b/Slim/Routing/RouteRunner.php
@@ -66,17 +66,17 @@ class RouteRunner implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         // If routing hasn't been done, then do it now so we can dispatch
-        if ($request->getAttribute('routingResults') === null) {
+        if (!RouteContext::routingResultsAttached($request)) {
             $routingMiddleware = new RoutingMiddleware($this->routeResolver, $this->routeParser);
             $request = $routingMiddleware->performRouting($request);
         }
 
         if ($this->routeCollectorProxy !== null) {
-            $request = $request->withAttribute('basePath', $this->routeCollectorProxy->getBasePath());
+            $request = RouteContext::attachBasePath($request, $this->routeCollectorProxy->getBasePath());
         }
 
         /** @var Route $route */
-        $route = $request->getAttribute('route');
+        $route = RouteContext::grabRoute($request);
         return $route->run($request);
     }
 }

--- a/Slim/Routing/RouteRunner.php
+++ b/Slim/Routing/RouteRunner.php
@@ -66,17 +66,20 @@ class RouteRunner implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         // If routing hasn't been done, then do it now so we can dispatch
-        if (!RouteContext::routingResultsAttached($request)) {
+        if ($request->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME) === null) {
             $routingMiddleware = new RoutingMiddleware($this->routeResolver, $this->routeParser);
             $request = $routingMiddleware->performRouting($request);
         }
 
         if ($this->routeCollectorProxy !== null) {
-            $request = RouteContext::attachBasePath($request, $this->routeCollectorProxy->getBasePath());
+            $request = $request->withAttribute(
+                RouteContext::BASE_PATH_ATTRIBUTE_NAME,
+                $this->routeCollectorProxy->getBasePath()
+            );
         }
 
         /** @var Route $route */
-        $route = RouteContext::grabRoute($request);
+        $route = $request->getAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME);
         return $route->run($request);
     }
 }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -173,7 +173,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn($method);
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -214,7 +214,7 @@ class AppTest extends TestCase
             $requestProphecy = $this->prophesize(ServerRequestInterface::class);
             $requestProphecy->getMethod()->willReturn($method);
             $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-            $requestProphecy->getAttribute('routingResults')->willReturn(null);
+            $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
             $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
                 $clone = clone $this;
                 $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -265,8 +265,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn($method);
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -312,7 +311,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -352,7 +351,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -622,7 +621,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -836,7 +835,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -919,7 +918,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1040,7 +1039,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1084,7 +1083,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('POST');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1116,7 +1115,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1157,7 +1156,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1198,7 +1197,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1239,7 +1238,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1281,7 +1280,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1322,7 +1321,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1348,7 +1347,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1390,7 +1389,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1464,7 +1463,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1512,7 +1511,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1553,7 +1552,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1595,7 +1594,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1649,7 +1648,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1746,7 +1745,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('HEAD');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1908,7 +1907,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1956,7 +1955,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1972,7 +1971,7 @@ class AppTest extends TestCase
         $requestProphecy2 = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy2->getMethod()->willReturn('GET');
         $requestProphecy2->getUri()->willReturn($uriProphecy2->reveal());
-        $requestProphecy2->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy2->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy2->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2012,7 +2011,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2028,7 +2027,7 @@ class AppTest extends TestCase
         $requestProphecy2 = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy2->getMethod()->willReturn('GET');
         $requestProphecy2->getUri()->willReturn($uriProphecy2->reveal());
-        $requestProphecy2->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy2->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy2->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2072,8 +2071,8 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('route')->willReturn($route);
-        $requestProphecy->getAttribute('routingResults')->willReturn(null);
+        $requestProphecy->getAttribute('__route__')->willReturn($route);
+        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -35,6 +35,7 @@ use Slim\Middleware\RoutingMiddleware;
 use Slim\MiddlewareDispatcher;
 use Slim\Routing\RouteCollector;
 use Slim\Routing\RouteCollectorProxy;
+use Slim\Routing\RouteContext;
 use Slim\Tests\Mocks\MockAction;
 use stdClass;
 
@@ -173,7 +174,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn($method);
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -214,7 +215,7 @@ class AppTest extends TestCase
             $requestProphecy = $this->prophesize(ServerRequestInterface::class);
             $requestProphecy->getMethod()->willReturn($method);
             $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-            $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+            $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
             $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
                 $clone = clone $this;
                 $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -265,7 +266,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn($method);
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -311,7 +312,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -351,7 +352,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -621,7 +622,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -835,7 +836,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -918,7 +919,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1039,7 +1040,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1083,7 +1084,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('POST');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1115,7 +1116,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1156,7 +1157,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1197,7 +1198,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1238,7 +1239,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1280,7 +1281,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1321,7 +1322,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1347,7 +1348,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1389,7 +1390,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1463,7 +1464,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1511,7 +1512,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1552,7 +1553,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1594,7 +1595,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1648,7 +1649,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1745,7 +1746,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('HEAD');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1907,7 +1908,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1955,7 +1956,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1971,7 +1972,7 @@ class AppTest extends TestCase
         $requestProphecy2 = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy2->getMethod()->willReturn('GET');
         $requestProphecy2->getUri()->willReturn($uriProphecy2->reveal());
-        $requestProphecy2->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy2->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy2->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2011,7 +2012,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2027,7 +2028,7 @@ class AppTest extends TestCase
         $requestProphecy2 = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy2->getMethod()->willReturn('GET');
         $requestProphecy2->getUri()->willReturn($uriProphecy2->reveal());
-        $requestProphecy2->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy2->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy2->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2071,8 +2072,8 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute('__route__')->willReturn($route);
-        $requestProphecy->getAttribute('__routingResults__')->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME)->willReturn($route);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -174,7 +174,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn($method);
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -215,7 +215,7 @@ class AppTest extends TestCase
             $requestProphecy = $this->prophesize(ServerRequestInterface::class);
             $requestProphecy->getMethod()->willReturn($method);
             $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-            $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+            $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
             $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
                 $clone = clone $this;
                 $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -266,7 +266,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn($method);
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -312,7 +312,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -352,7 +352,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -622,7 +622,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -836,7 +836,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -919,7 +919,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1040,7 +1040,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1084,7 +1084,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('POST');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1116,7 +1116,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1157,7 +1157,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1198,7 +1198,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1239,7 +1239,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1281,7 +1281,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1322,7 +1322,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1348,7 +1348,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1390,7 +1390,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1464,7 +1464,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1512,7 +1512,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1553,7 +1553,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1595,7 +1595,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1649,7 +1649,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1746,7 +1746,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('HEAD');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1908,7 +1908,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1956,7 +1956,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -1972,7 +1972,7 @@ class AppTest extends TestCase
         $requestProphecy2 = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy2->getMethod()->willReturn('GET');
         $requestProphecy2->getUri()->willReturn($uriProphecy2->reveal());
-        $requestProphecy2->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy2->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy2->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2012,7 +2012,7 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2028,7 +2028,7 @@ class AppTest extends TestCase
         $requestProphecy2 = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy2->getMethod()->willReturn('GET');
         $requestProphecy2->getUri()->willReturn($uriProphecy2->reveal());
-        $requestProphecy2->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy2->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy2->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);
@@ -2072,8 +2072,8 @@ class AppTest extends TestCase
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getMethod()->willReturn('GET');
         $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
-        $requestProphecy->getAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME)->willReturn($route);
-        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME)->willReturn(null);
+        $requestProphecy->getAttribute(RouteContext::ROUTE)->willReturn($route);
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
         $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
             $clone = clone $this;
             $clone->getAttribute($args[0])->willReturn($args[1]);

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -42,17 +42,17 @@ class RoutingMiddlewareTest extends TestCase
         $responseFactory = $this->getResponseFactory();
         $mw = (function (ServerRequestInterface $request) use ($responseFactory) {
             // route is available
-            $route = $request->getAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME);
+            $route = $request->getAttribute(RouteContext::ROUTE);
             $this->assertNotNull($route);
             $this->assertEquals('foo', $route->getArgument('name'));
 
             // routeParser is available
-            $routeParser = $request->getAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME);
+            $routeParser = $request->getAttribute(RouteContext::ROUTE_PARSER);
             $this->assertNotNull($routeParser);
             $this->assertInstanceOf(RouteParserInterface::class, $routeParser);
 
             // routingResults is available
-            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME);
+            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS);
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             return $responseFactory->createResponse();
         })->bindTo($this);
@@ -95,16 +95,16 @@ class RoutingMiddlewareTest extends TestCase
             $request = $exception->getRequest();
 
             // route is not available
-            $route = $request->getAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME);
+            $route = $request->getAttribute(RouteContext::ROUTE);
             $this->assertNull($route);
 
             // routeParser is available
-            $routeParser = $request->getAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME);
+            $routeParser = $request->getAttribute(RouteContext::ROUTE_PARSER);
             $this->assertNotNull($routeParser);
             $this->assertInstanceOf(RouteParserInterface::class, $routeParser);
 
             // routingResults is available
-            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME);
+            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS);
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             $this->assertEquals(Dispatcher::METHOD_NOT_ALLOWED, $routingResults->getRouteStatus());
         }
@@ -132,16 +132,16 @@ class RoutingMiddlewareTest extends TestCase
             $request = $exception->getRequest();
 
             // route is not available
-            $route = $request->getAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME);
+            $route = $request->getAttribute(RouteContext::ROUTE);
             $this->assertNull($route);
 
             // routeParser is available
-            $routeParser = $request->getAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME);
+            $routeParser = $request->getAttribute(RouteContext::ROUTE_PARSER);
             $this->assertNotNull($routeParser);
             $this->assertInstanceOf(RouteParserInterface::class, $routeParser);
 
             // routingResults is available
-            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME);
+            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS);
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             $this->assertEquals(Dispatcher::NOT_FOUND, $routingResults->getRouteStatus());
         }

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -41,17 +41,17 @@ class RoutingMiddlewareTest extends TestCase
         $responseFactory = $this->getResponseFactory();
         $mw = (function (ServerRequestInterface $request) use ($responseFactory) {
             // route is available
-            $route = $request->getAttribute('route');
+            $route = $request->getAttribute('__route__');
             $this->assertNotNull($route);
             $this->assertEquals('foo', $route->getArgument('name'));
 
             // routeParser is available
-            $routeParser = $request->getAttribute('routeParser');
+            $routeParser = $request->getAttribute('__routeParser__');
             $this->assertNotNull($routeParser);
             $this->assertInstanceOf(RouteParserInterface::class, $routeParser);
 
             // routingResults is available
-            $routingResults = $request->getAttribute('routingResults');
+            $routingResults = $request->getAttribute('__routingResults__');
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             return $responseFactory->createResponse();
         })->bindTo($this);
@@ -94,16 +94,16 @@ class RoutingMiddlewareTest extends TestCase
             $request = $exception->getRequest();
 
             // route is not available
-            $route = $request->getAttribute('route');
+            $route = $request->getAttribute('__route__');
             $this->assertNull($route);
 
             // routeParser is available
-            $routeParser = $request->getAttribute('routeParser');
+            $routeParser = $request->getAttribute('__routeParser__');
             $this->assertNotNull($routeParser);
             $this->assertInstanceOf(RouteParserInterface::class, $routeParser);
 
             // routingResults is available
-            $routingResults = $request->getAttribute('routingResults');
+            $routingResults = $request->getAttribute('__routingResults__');
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             $this->assertEquals(Dispatcher::METHOD_NOT_ALLOWED, $routingResults->getRouteStatus());
         }
@@ -131,16 +131,16 @@ class RoutingMiddlewareTest extends TestCase
             $request = $exception->getRequest();
 
             // route is not available
-            $route = $request->getAttribute('route');
+            $route = $request->getAttribute('__route__');
             $this->assertNull($route);
 
             // routeParser is available
-            $routeParser = $request->getAttribute('routeParser');
+            $routeParser = $request->getAttribute('__routeParser__');
             $this->assertNotNull($routeParser);
             $this->assertInstanceOf(RouteParserInterface::class, $routeParser);
 
             // routingResults is available
-            $routingResults = $request->getAttribute('routingResults');
+            $routingResults = $request->getAttribute('__routingResults__');
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             $this->assertEquals(Dispatcher::NOT_FOUND, $routingResults->getRouteStatus());
         }

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -20,6 +20,7 @@ use Slim\Interfaces\RouteParserInterface;
 use Slim\Interfaces\RouteResolverInterface;
 use Slim\Middleware\RoutingMiddleware;
 use Slim\Routing\RouteCollector;
+use Slim\Routing\RouteContext;
 use Slim\Routing\RouteParser;
 use Slim\Routing\RouteResolver;
 use Slim\Routing\RoutingResults;
@@ -41,17 +42,17 @@ class RoutingMiddlewareTest extends TestCase
         $responseFactory = $this->getResponseFactory();
         $mw = (function (ServerRequestInterface $request) use ($responseFactory) {
             // route is available
-            $route = $request->getAttribute('__route__');
+            $route = $request->getAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME);
             $this->assertNotNull($route);
             $this->assertEquals('foo', $route->getArgument('name'));
 
             // routeParser is available
-            $routeParser = $request->getAttribute('__routeParser__');
+            $routeParser = $request->getAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME);
             $this->assertNotNull($routeParser);
             $this->assertInstanceOf(RouteParserInterface::class, $routeParser);
 
             // routingResults is available
-            $routingResults = $request->getAttribute('__routingResults__');
+            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME);
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             return $responseFactory->createResponse();
         })->bindTo($this);
@@ -94,16 +95,16 @@ class RoutingMiddlewareTest extends TestCase
             $request = $exception->getRequest();
 
             // route is not available
-            $route = $request->getAttribute('__route__');
+            $route = $request->getAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME);
             $this->assertNull($route);
 
             // routeParser is available
-            $routeParser = $request->getAttribute('__routeParser__');
+            $routeParser = $request->getAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME);
             $this->assertNotNull($routeParser);
             $this->assertInstanceOf(RouteParserInterface::class, $routeParser);
 
             // routingResults is available
-            $routingResults = $request->getAttribute('__routingResults__');
+            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME);
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             $this->assertEquals(Dispatcher::METHOD_NOT_ALLOWED, $routingResults->getRouteStatus());
         }
@@ -131,16 +132,16 @@ class RoutingMiddlewareTest extends TestCase
             $request = $exception->getRequest();
 
             // route is not available
-            $route = $request->getAttribute('__route__');
+            $route = $request->getAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME);
             $this->assertNull($route);
 
             // routeParser is available
-            $routeParser = $request->getAttribute('__routeParser__');
+            $routeParser = $request->getAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME);
             $this->assertNotNull($routeParser);
             $this->assertInstanceOf(RouteParserInterface::class, $routeParser);
 
             // routingResults is available
-            $routingResults = $request->getAttribute('__routingResults__');
+            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME);
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             $this->assertEquals(Dispatcher::NOT_FOUND, $routingResults->getRouteStatus());
         }

--- a/tests/Routing/RouteContextTest.php
+++ b/tests/Routing/RouteContextTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Slim\Tests\Routing;
 
 use Psr\Http\Message\ServerRequestInterface;
+use ReflectionClass;
 use RuntimeException;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouteParserInterface;
@@ -19,6 +20,30 @@ use Slim\Tests\TestCase;
 
 class RouteContextTest extends TestCase
 {
+    public function testStaticSetAttributeNames()
+    {
+        $routeContextReflection = new ReflectionClass(RouteContext::class);
+        $originals = $routeContextReflection->getStaticProperties();
+
+        RouteContext::setRouteAttributeName('##route##');
+        RouteContext::setRouteParserAttributeName('##routeParser##');
+        RouteContext::setRoutingResultsAttributeName('##routingResults##');
+        RouteContext::setBasePathAttributeName('##basePath##');
+
+        $properties = $routeContextReflection->getStaticProperties();
+
+        // Set the static properties back to their original values
+        RouteContext::setRouteAttributeName($originals['routeAttributeName']);
+        RouteContext::setRouteParserAttributeName($originals['routeParserAttributeName']);
+        RouteContext::setRoutingResultsAttributeName($originals['routingResultsAttributeName']);
+        RouteContext::setBasePathAttributeName($originals['basePathAttributeName']);
+
+        $this->assertEquals('##route##', $properties['routeAttributeName']);
+        $this->assertEquals('##routeParser##', $properties['routeParserAttributeName']);
+        $this->assertEquals('##routingResults##', $properties['routingResultsAttributeName']);
+        $this->assertEquals('##basePath##', $properties['basePathAttributeName']);
+    }
+
     public function testCanCreateInstanceFromServerRequest(): void
     {
         $route = $this->createMock(RouteInterface::class);
@@ -26,10 +51,10 @@ class RouteContextTest extends TestCase
         $routingResults = $this->createMock(RoutingResults::class);
 
         $serverRequest = $this->createServerRequest('/')
-                              ->withAttribute('basePath', '')
-                              ->withAttribute('route', $route)
-                              ->withAttribute('routeParser', $routeParser)
-                              ->withAttribute('routingResults', $routingResults);
+                              ->withAttribute('__basePath__', '')
+                              ->withAttribute('__route__', $route)
+                              ->withAttribute('__routeParser__', $routeParser)
+                              ->withAttribute('__routingResults__', $routingResults);
 
         $routeContext = RouteContext::fromRequest($serverRequest);
 
@@ -44,7 +69,7 @@ class RouteContextTest extends TestCase
         $serverRequest = $this->createServerRequestWithRouteAttributes();
 
         // Route attribute is not required
-        $serverRequest = $serverRequest->withoutAttribute('route');
+        $serverRequest = $serverRequest->withoutAttribute('__route__');
 
         $routeContext = RouteContext::fromRequest($serverRequest);
         $this->assertNull($routeContext->getRoute());
@@ -58,7 +83,7 @@ class RouteContextTest extends TestCase
         $serverRequest = $this->createServerRequestWithRouteAttributes();
 
         // Route attribute is not required
-        $serverRequest = $serverRequest->withoutAttribute('basePath');
+        $serverRequest = $serverRequest->withoutAttribute('__basePath__');
 
         $routeContext = RouteContext::fromRequest($serverRequest);
         $this->assertNotNull($routeContext->getRoute());
@@ -72,8 +97,8 @@ class RouteContextTest extends TestCase
     public function requiredRouteContextRequestAttributes(): array
     {
         return [
-            ['routeParser'],
-            ['routingResults'],
+            ['__routeParser__'],
+            ['__routingResults__'],
         ];
     }
 
@@ -96,9 +121,9 @@ class RouteContextTest extends TestCase
         $routingResults = $this->createMock(RoutingResults::class);
 
         return $this->createServerRequest('/')
-                    ->withAttribute('basePath', '')
-                    ->withAttribute('route', $route)
-                    ->withAttribute('routeParser', $routeParser)
-                    ->withAttribute('routingResults', $routingResults);
+                    ->withAttribute('__basePath__', '')
+                    ->withAttribute('__route__', $route)
+                    ->withAttribute('__routeParser__', $routeParser)
+                    ->withAttribute('__routingResults__', $routingResults);
     }
 }

--- a/tests/Routing/RouteContextTest.php
+++ b/tests/Routing/RouteContextTest.php
@@ -20,30 +20,6 @@ use Slim\Tests\TestCase;
 
 class RouteContextTest extends TestCase
 {
-    public function testStaticSetAttributeNames()
-    {
-        $routeContextReflection = new ReflectionClass(RouteContext::class);
-        $originals = $routeContextReflection->getStaticProperties();
-
-        RouteContext::setRouteAttributeName('##route##');
-        RouteContext::setRouteParserAttributeName('##routeParser##');
-        RouteContext::setRoutingResultsAttributeName('##routingResults##');
-        RouteContext::setBasePathAttributeName('##basePath##');
-
-        $properties = $routeContextReflection->getStaticProperties();
-
-        // Set the static properties back to their original values
-        RouteContext::setRouteAttributeName($originals['routeAttributeName']);
-        RouteContext::setRouteParserAttributeName($originals['routeParserAttributeName']);
-        RouteContext::setRoutingResultsAttributeName($originals['routingResultsAttributeName']);
-        RouteContext::setBasePathAttributeName($originals['basePathAttributeName']);
-
-        $this->assertEquals('##route##', $properties['routeAttributeName']);
-        $this->assertEquals('##routeParser##', $properties['routeParserAttributeName']);
-        $this->assertEquals('##routingResults##', $properties['routingResultsAttributeName']);
-        $this->assertEquals('##basePath##', $properties['basePathAttributeName']);
-    }
-
     public function testCanCreateInstanceFromServerRequest(): void
     {
         $route = $this->createMock(RouteInterface::class);
@@ -51,10 +27,10 @@ class RouteContextTest extends TestCase
         $routingResults = $this->createMock(RoutingResults::class);
 
         $serverRequest = $this->createServerRequest('/')
-                              ->withAttribute('__basePath__', '')
-                              ->withAttribute('__route__', $route)
-                              ->withAttribute('__routeParser__', $routeParser)
-                              ->withAttribute('__routingResults__', $routingResults);
+                              ->withAttribute(RouteContext::BASE_PATH_ATTRIBUTE_NAME, '')
+                              ->withAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME, $route)
+                              ->withAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME, $routeParser)
+                              ->withAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME, $routingResults);
 
         $routeContext = RouteContext::fromRequest($serverRequest);
 
@@ -69,7 +45,7 @@ class RouteContextTest extends TestCase
         $serverRequest = $this->createServerRequestWithRouteAttributes();
 
         // Route attribute is not required
-        $serverRequest = $serverRequest->withoutAttribute('__route__');
+        $serverRequest = $serverRequest->withoutAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME);
 
         $routeContext = RouteContext::fromRequest($serverRequest);
         $this->assertNull($routeContext->getRoute());
@@ -83,7 +59,7 @@ class RouteContextTest extends TestCase
         $serverRequest = $this->createServerRequestWithRouteAttributes();
 
         // Route attribute is not required
-        $serverRequest = $serverRequest->withoutAttribute('__basePath__');
+        $serverRequest = $serverRequest->withoutAttribute(RouteContext::BASE_PATH_ATTRIBUTE_NAME);
 
         $routeContext = RouteContext::fromRequest($serverRequest);
         $this->assertNotNull($routeContext->getRoute());
@@ -97,8 +73,8 @@ class RouteContextTest extends TestCase
     public function requiredRouteContextRequestAttributes(): array
     {
         return [
-            ['__routeParser__'],
-            ['__routingResults__'],
+            [RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME],
+            [RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME],
         ];
     }
 
@@ -121,9 +97,9 @@ class RouteContextTest extends TestCase
         $routingResults = $this->createMock(RoutingResults::class);
 
         return $this->createServerRequest('/')
-                    ->withAttribute('__basePath__', '')
-                    ->withAttribute('__route__', $route)
-                    ->withAttribute('__routeParser__', $routeParser)
-                    ->withAttribute('__routingResults__', $routingResults);
+                    ->withAttribute(RouteContext::BASE_PATH_ATTRIBUTE_NAME, '')
+                    ->withAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME, $route)
+                    ->withAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME, $routeParser)
+                    ->withAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME, $routingResults);
     }
 }

--- a/tests/Routing/RouteContextTest.php
+++ b/tests/Routing/RouteContextTest.php
@@ -27,10 +27,10 @@ class RouteContextTest extends TestCase
         $routingResults = $this->createMock(RoutingResults::class);
 
         $serverRequest = $this->createServerRequest('/')
-                              ->withAttribute(RouteContext::BASE_PATH_ATTRIBUTE_NAME, '')
-                              ->withAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME, $route)
-                              ->withAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME, $routeParser)
-                              ->withAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME, $routingResults);
+                              ->withAttribute(RouteContext::BASE_PATH, '')
+                              ->withAttribute(RouteContext::ROUTE, $route)
+                              ->withAttribute(RouteContext::ROUTE_PARSER, $routeParser)
+                              ->withAttribute(RouteContext::ROUTING_RESULTS, $routingResults);
 
         $routeContext = RouteContext::fromRequest($serverRequest);
 
@@ -45,7 +45,7 @@ class RouteContextTest extends TestCase
         $serverRequest = $this->createServerRequestWithRouteAttributes();
 
         // Route attribute is not required
-        $serverRequest = $serverRequest->withoutAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME);
+        $serverRequest = $serverRequest->withoutAttribute(RouteContext::ROUTE);
 
         $routeContext = RouteContext::fromRequest($serverRequest);
         $this->assertNull($routeContext->getRoute());
@@ -59,7 +59,7 @@ class RouteContextTest extends TestCase
         $serverRequest = $this->createServerRequestWithRouteAttributes();
 
         // Route attribute is not required
-        $serverRequest = $serverRequest->withoutAttribute(RouteContext::BASE_PATH_ATTRIBUTE_NAME);
+        $serverRequest = $serverRequest->withoutAttribute(RouteContext::BASE_PATH);
 
         $routeContext = RouteContext::fromRequest($serverRequest);
         $this->assertNotNull($routeContext->getRoute());
@@ -73,8 +73,8 @@ class RouteContextTest extends TestCase
     public function requiredRouteContextRequestAttributes(): array
     {
         return [
-            [RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME],
-            [RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME],
+            [RouteContext::ROUTE_PARSER],
+            [RouteContext::ROUTING_RESULTS],
         ];
     }
 
@@ -97,9 +97,9 @@ class RouteContextTest extends TestCase
         $routingResults = $this->createMock(RoutingResults::class);
 
         return $this->createServerRequest('/')
-                    ->withAttribute(RouteContext::BASE_PATH_ATTRIBUTE_NAME, '')
-                    ->withAttribute(RouteContext::ROUTE_ATTRIBUTE_NAME, $route)
-                    ->withAttribute(RouteContext::ROUTE_PARSER_ATTRIBUTE_NAME, $routeParser)
-                    ->withAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME, $routingResults);
+                    ->withAttribute(RouteContext::BASE_PATH, '')
+                    ->withAttribute(RouteContext::ROUTE, $route)
+                    ->withAttribute(RouteContext::ROUTE_PARSER, $routeParser)
+                    ->withAttribute(RouteContext::ROUTING_RESULTS, $routingResults);
     }
 }

--- a/tests/Routing/RouteRunnerTest.php
+++ b/tests/Routing/RouteRunnerTest.php
@@ -13,6 +13,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\MiddlewareDispatcher;
 use Slim\Routing\RouteCollector;
+use Slim\Routing\RouteContext;
 use Slim\Routing\RouteParser;
 use Slim\Routing\RouteResolver;
 use Slim\Routing\RouteRunner;
@@ -24,7 +25,7 @@ class RouteRunnerTest extends TestCase
     public function testRoutingIsPerformedIfRoutingResultsAreUnavailable()
     {
         $handler = (function (ServerRequestInterface $request, ResponseInterface $response) {
-            $routingResults = $request->getAttribute('__routingResults__');
+            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME);
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             return $response;
         })->bindTo($this);

--- a/tests/Routing/RouteRunnerTest.php
+++ b/tests/Routing/RouteRunnerTest.php
@@ -25,7 +25,7 @@ class RouteRunnerTest extends TestCase
     public function testRoutingIsPerformedIfRoutingResultsAreUnavailable()
     {
         $handler = (function (ServerRequestInterface $request, ResponseInterface $response) {
-            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS_ATTRIBUTE_NAME);
+            $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS);
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             return $response;
         })->bindTo($this);

--- a/tests/Routing/RouteRunnerTest.php
+++ b/tests/Routing/RouteRunnerTest.php
@@ -24,7 +24,7 @@ class RouteRunnerTest extends TestCase
     public function testRoutingIsPerformedIfRoutingResultsAreUnavailable()
     {
         $handler = (function (ServerRequestInterface $request, ResponseInterface $response) {
-            $routingResults = $request->getAttribute('routingResults');
+            $routingResults = $request->getAttribute('__routingResults__');
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
             return $response;
         })->bindTo($this);


### PR DESCRIPTION
PR for #2883 

The attribute names are even configurable - although I am not sure if that should be an option. If not, let me know - I will remove all the unnecessary calls to static methods and instead hard code the attribute names.

If yes, maybe we could find another solution than using static methods and properties in the `RouteContext` class - I am not totally happy with this *static* solution.