### PR TITLE
Render errors uniformly

### DIFF
--- a/Slim/Error/AbstractErrorRenderer.php
+++ b/Slim/Error/AbstractErrorRenderer.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace Slim\Error;
 
+use Slim\Exception\HttpException;
 use Slim\Interfaces\ErrorRendererInterface;
+use Throwable;
 
 /**
  * Abstract Slim application error renderer
@@ -19,4 +21,31 @@ use Slim\Interfaces\ErrorRendererInterface;
  */
 abstract class AbstractErrorRenderer implements ErrorRendererInterface
 {
+    /**
+     * @var string
+     */
+    protected $defaultErrorTitle = 'Slim Application Error';
+
+    /**
+     * @var string
+     */
+    protected $defaultErrorDescription = 'A website error has occurred. Sorry for the temporary inconvenience.';
+
+    protected function getErrorTitle(Throwable $exception): string
+    {
+        if ($exception instanceof HttpException) {
+            return $exception->getTitle();
+        }
+
+        return $this->defaultErrorTitle;
+    }
+
+    protected function getErrorDescription(Throwable $exception): string
+    {
+        if ($exception instanceof HttpException) {
+            return $exception->getDescription();
+        }
+
+        return $this->defaultErrorDescription;
+    }
 }

--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -24,17 +24,15 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
      */
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
-        $title = 'Slim Application Error';
-
         if ($displayErrorDetails) {
             $html = '<p>The application could not run because of the following error:</p>';
             $html .= '<h2>Details</h2>';
             $html .= $this->renderExceptionFragment($exception);
         } else {
-            $html = '<p>A website error has occurred. Sorry for the temporary inconvenience.</p>';
+            $html = "<p>{$this->getErrorDescription($exception)}</p>";
         }
 
-        return $this->renderHtmlBody($title, $html);
+        return $this->renderHtmlBody($this->getErrorTitle($exception), $html);
     }
 
     /**

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -24,7 +24,7 @@ class JsonErrorRenderer extends AbstractErrorRenderer
      */
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
-        $error = ['message' => $exception->getMessage()];
+        $error = ['message' => $this->getErrorTitle($exception)];
 
         if ($displayErrorDetails) {
             $error['exception'] = [];

--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -24,12 +24,15 @@ class PlainTextErrorRenderer extends AbstractErrorRenderer
      */
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
-        $text = "Slim Application Error:\n";
-        $text .= $this->formatExceptionFragment($exception);
+        $text = "{$this->getErrorTitle($exception)}\n";
 
-        while ($displayErrorDetails && $exception = $exception->getPrevious()) {
-            $text .= "\nPrevious Error:\n";
+        if ($displayErrorDetails) {
             $text .= $this->formatExceptionFragment($exception);
+
+            while ($exception = $exception->getPrevious()) {
+                $text .= "\nPrevious Error:\n";
+                $text .= $this->formatExceptionFragment($exception);
+            }
         }
 
         return $text;

--- a/Slim/Error/Renderers/XmlErrorRenderer.php
+++ b/Slim/Error/Renderers/XmlErrorRenderer.php
@@ -25,7 +25,7 @@ class XmlErrorRenderer extends AbstractErrorRenderer
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
         $xml = '<' . '?xml version="1.0" encoding="UTF-8" standalone="yes"?' . ">\n";
-        $xml .= "<error>\n  <message>" . $this->createCdataSection($exception->getMessage()) . "</message>\n";
+        $xml .= "<error>\n  <message>" . $this->createCdataSection($this->getErrorTitle($exception)) . "</message>\n";
 
         if ($displayErrorDetails) {
             do {

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "nyholm/psr7": "^1.1",
         "nyholm/psr7-server": "^0.3.0",
         "phpunit/phpunit": "^7.5",
-        "phpspec/prophecy": "^1.8",
+        "phpspec/prophecy": "1.9",
         "phpstan/phpstan": "^0.11.5",
         "slim/http": "^0.7",
         "slim/psr7": "^0.3",

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -62,23 +62,23 @@ class AbstractErrorRendererTest extends TestCase
 
     public function testHTMLErrorRendererRenderHttpException()
     {
-        $exceptionTitle = 'exception-title';
-        $exceptionDescription = 'exception-description';
+        $exceptionTitle = 'title';
+        $exceptionDescription = 'description';
 
-        /** @var HttpException|MockObject $httpException */
-        $httpException = $this->getMockBuilder(HttpException::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $httpExceptionProphecy = $this->prophesize(HttpException::class);
 
-        $httpException->expects($this->any())
-            ->method('getTitle')
-            ->willReturn($exceptionTitle);
-        $httpException->expects($this->any())
-            ->method('getDescription')
-            ->willReturn($exceptionDescription);
+        $httpExceptionProphecy
+            ->getTitle()
+            ->willReturn($exceptionTitle)
+            ->shouldBeCalledOnce();
+
+        $httpExceptionProphecy
+            ->getDescription()
+            ->willReturn($exceptionDescription)
+            ->shouldBeCalledOnce();
 
         $renderer = new HtmlErrorRenderer();
-        $output = $renderer->__invoke($httpException, false);
+        $output = $renderer->__invoke($httpExceptionProphecy->reveal(), false);
 
         $this->assertContains($exceptionTitle, $output, 'Should contain http exception title');
         $this->assertContains($exceptionDescription, $output, 'Should contain http exception description');
@@ -134,19 +134,17 @@ class AbstractErrorRendererTest extends TestCase
 
     public function testJSONErrorRendererRenderHttpException()
     {
-        $exceptionTitle = 'exception-title';
+        $exceptionTitle = 'title';
 
-        /** @var HttpException|MockObject $httpException */
-        $httpException = $this->getMockBuilder(HttpException::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $httpExceptionProphecy = $this->prophesize(HttpException::class);
 
-        $httpException->expects($this->any())
-            ->method('getTitle')
-            ->willReturn($exceptionTitle);
+        $httpExceptionProphecy
+            ->getTitle()
+            ->willReturn($exceptionTitle)
+            ->shouldBeCalledOnce();
 
         $renderer = new JsonErrorRenderer();
-        $output = json_encode(json_decode($renderer->__invoke($httpException, false)));
+        $output = json_encode(json_decode($renderer->__invoke($httpExceptionProphecy->reveal(), false)));
 
         $this->assertEquals(
             $output,
@@ -175,21 +173,19 @@ class AbstractErrorRendererTest extends TestCase
 
     public function testXMLErrorRendererRenderHttpException()
     {
-        $exceptionTitle = 'exception-title';
+        $exceptionTitle = 'title';
 
-        /** @var HttpException|MockObject $httpException */
-        $httpException = $this->getMockBuilder(HttpException::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $httpExceptionProphecy = $this->prophesize(HttpException::class);
 
-        $httpException->expects($this->any())
-            ->method('getTitle')
-            ->willReturn($exceptionTitle);
+        $httpExceptionProphecy
+            ->getTitle()
+            ->willReturn($exceptionTitle)
+            ->shouldBeCalledOnce();
 
         $renderer = new XmlErrorRenderer();
 
         /** @var stdClass $output */
-        $output = simplexml_load_string($renderer->__invoke($httpException, true));
+        $output = simplexml_load_string($renderer->__invoke($httpExceptionProphecy->reveal(), true));
 
         $this->assertEquals($output->message[0], $exceptionTitle, 'Should contain http exception title');
     }
@@ -235,19 +231,17 @@ class AbstractErrorRendererTest extends TestCase
 
     public function testPlainTextErrorRendererRenderHttpException()
     {
-        $exceptionTitle = 'exception-title';
+        $exceptionTitle = 'title';
 
-        /** @var HttpException|MockObject $httpException */
-        $httpException = $this->getMockBuilder(HttpException::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $httpExceptionProphecy = $this->prophesize(HttpException::class);
 
-        $httpException->expects($this->any())
-            ->method('getTitle')
-            ->willReturn($exceptionTitle);
+        $httpExceptionProphecy
+            ->getTitle()
+            ->willReturn($exceptionTitle)
+            ->shouldBeCalledOnce();
 
         $renderer = new PlainTextErrorRenderer();
-        $output = $renderer->__invoke($httpException, true);
+        $output = $renderer->__invoke($httpExceptionProphecy->reveal(), true);
 
         $this->assertContains($exceptionTitle, $output, 'Should contain http exception title');
     }


### PR DESCRIPTION
In this PR solved several problems 

* Render error uniformly in different formats (#2746)
* Render http exceptions as custom error pages
* Hide backtraces in plain format too