### PR TITLE
PHP 7.2 as minimal dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.phpunit.result.cache
 composer.lock
 phpunit.xml
 clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: php
 
-dist: trusty
-
 matrix:
   include:
-  - php: 7.1
   - php: 7.2
   - php: 7.3
+  - php: 7.4
     env: ANALYSIS='true'
   - php: nightly
 
@@ -14,7 +12,7 @@ matrix:
   - php: nightly
 
 before_script:
-- if [[ "$ANALYSIS" == 'true' ]]; then composer require php-coveralls/php-coveralls:^2.1.0 ; fi
+- if [[ "$ANALYSIS" == 'true' ]]; then composer require php-coveralls/php-coveralls:^2.2.0 ; fi
 - composer install -n
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ matrix:
   include:
   - php: 7.2
   - php: 7.3
-  - php: 7.4
     env: ANALYSIS='true'
+  - php: 7.4
   - php: nightly
 
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require": {
         "ext-json": "*",
         "nikic/fast-route": "^1.3",
-        "php": "^7.1",
+        "php": "^7.2",
         "psr/container": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
@@ -48,7 +48,7 @@
         "http-interop/http-factory-guzzle": "^1.0",
         "nyholm/psr7": "^1.1",
         "nyholm/psr7-server": "^0.3.0",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^8.5",
         "phpspec/prophecy": "^1.10",
         "phpstan/phpstan": "^0.11.5",
         "slim/http": "^0.7",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/7.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="true"

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -41,7 +41,7 @@ use stdClass;
 
 class AppTest extends TestCase
 {
-    public static function setupBeforeClass()
+    public static function setupBeforeClass(): void
     {
         ini_set('error_log', tempnam(sys_get_temp_dir(), 'slim'));
     }

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -26,7 +26,7 @@ class CallableResolverTest extends TestCase
      */
     private $containerProphecy;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         function testAdvancedCallable()
         {
@@ -34,7 +34,7 @@ class CallableResolverTest extends TestCase
         }
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         CallableTest::$CalledCount = 0;
         InvokableTest::$CalledCount = 0;

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -13,6 +13,7 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
 use Slim\CallableResolver;
 use Slim\Tests\Mocks\CallableTest;
 use Slim\Tests\Mocks\InvokableTest;
@@ -213,7 +214,7 @@ class CallableResolverTest extends TestCase
 
     public function testResolutionToAPsrRequestHandlerClass()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Slim\\Tests\\Mocks\\RequestHandlerTest is not resolvable');
 
         $resolver = new CallableResolver(); // No container injected
@@ -231,7 +232,7 @@ class CallableResolverTest extends TestCase
 
     public function testMiddlewareResolutionToAPsrRequestHandlerClass()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Slim\\Tests\\Mocks\\RequestHandlerTest is not resolvable');
 
         $resolver = new CallableResolver(); // No container injected
@@ -240,7 +241,7 @@ class CallableResolverTest extends TestCase
 
     public function testObjPsrRequestHandlerClass()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('{} is not resolvable');
 
         $obj = new RequestHandlerTest();
@@ -260,7 +261,7 @@ class CallableResolverTest extends TestCase
 
     public function testMiddlewareObjPsrRequestHandlerClass()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('{} is not resolvable');
 
         $obj = new RequestHandlerTest();
@@ -270,7 +271,7 @@ class CallableResolverTest extends TestCase
 
     public function testObjPsrRequestHandlerClassInContainer()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('a_requesthandler is not resolvable');
 
         $this->containerProphecy->has('a_requesthandler')->willReturn(true);
@@ -299,7 +300,7 @@ class CallableResolverTest extends TestCase
 
     public function testMiddlewareObjPsrRequestHandlerClassInContainer()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('a_requesthandler is not resolvable');
 
         $this->containerProphecy->has('a_requesthandler')->willReturn(true);
@@ -333,7 +334,7 @@ class CallableResolverTest extends TestCase
 
     public function testObjMiddlewareClass()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('{} is not resolvable');
 
         $obj = new MiddlewareTest();
@@ -343,7 +344,7 @@ class CallableResolverTest extends TestCase
 
     public function testRouteObjMiddlewareClass()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('{} is not resolvable');
 
         $obj = new MiddlewareTest();
@@ -363,7 +364,7 @@ class CallableResolverTest extends TestCase
 
     public function testMethodNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('callable_service:notFound is not resolvable');
 
         $this->containerProphecy->has('callable_service')->willReturn(true);
@@ -377,7 +378,7 @@ class CallableResolverTest extends TestCase
 
     public function testRouteMethodNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('callable_service:notFound is not resolvable');
 
         $this->containerProphecy->has('callable_service')->willReturn(true);
@@ -391,7 +392,7 @@ class CallableResolverTest extends TestCase
 
     public function testMiddlewareMethodNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('callable_service:notFound is not resolvable');
 
         $this->containerProphecy->has('callable_service')->willReturn(true);
@@ -405,7 +406,7 @@ class CallableResolverTest extends TestCase
 
     public function testFunctionNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable notFound does not exist');
 
         /** @var ContainerInterface $container */
@@ -416,7 +417,7 @@ class CallableResolverTest extends TestCase
 
     public function testRouteFunctionNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable notFound does not exist');
 
         /** @var ContainerInterface $container */
@@ -427,7 +428,7 @@ class CallableResolverTest extends TestCase
 
     public function testMiddlewareFunctionNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable notFound does not exist');
 
         /** @var ContainerInterface $container */
@@ -438,7 +439,7 @@ class CallableResolverTest extends TestCase
 
     public function testClassNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable Unknown does not exist');
 
         /** @var ContainerInterface $container */
@@ -449,7 +450,7 @@ class CallableResolverTest extends TestCase
 
     public function testRouteClassNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable Unknown does not exist');
 
         /** @var ContainerInterface $container */
@@ -460,7 +461,7 @@ class CallableResolverTest extends TestCase
 
     public function testMiddlewareClassNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable Unknown does not exist');
 
         /** @var ContainerInterface $container */
@@ -471,7 +472,7 @@ class CallableResolverTest extends TestCase
 
     public function testCallableClassNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('is not resolvable');
 
         /** @var ContainerInterface $container */
@@ -482,7 +483,7 @@ class CallableResolverTest extends TestCase
 
     public function testRouteCallableClassNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('is not resolvable');
 
         /** @var ContainerInterface $container */
@@ -493,7 +494,7 @@ class CallableResolverTest extends TestCase
 
     public function testMiddlewareCallableClassNotFoundThrowException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('is not resolvable');
 
         /** @var ContainerInterface $container */

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -211,12 +211,11 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(3, InvokableTest::$CalledCount);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Slim\Tests\Mocks\RequestHandlerTest is not resolvable
-     */
     public function testResolutionToAPsrRequestHandlerClass()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Slim\\Tests\\Mocks\\RequestHandlerTest is not resolvable');
+
         $resolver = new CallableResolver(); // No container injected
         $resolver->resolve(RequestHandlerTest::class);
     }
@@ -230,22 +229,20 @@ class CallableResolverTest extends TestCase
         $this->assertEquals('1', RequestHandlerTest::$CalledCount);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Slim\Tests\Mocks\RequestHandlerTest is not resolvable
-     */
     public function testMiddlewareResolutionToAPsrRequestHandlerClass()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Slim\\Tests\\Mocks\\RequestHandlerTest is not resolvable');
+
         $resolver = new CallableResolver(); // No container injected
         $resolver->resolveMiddleware(RequestHandlerTest::class);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage {} is not resolvable
-     */
     public function testObjPsrRequestHandlerClass()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('{} is not resolvable');
+
         $obj = new RequestHandlerTest();
         $resolver = new CallableResolver(); // No container injected
         $resolver->resolve($obj);
@@ -261,23 +258,21 @@ class CallableResolverTest extends TestCase
         $this->assertEquals('1', RequestHandlerTest::$CalledCount);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage {} is not resolvable
-     */
     public function testMiddlewareObjPsrRequestHandlerClass()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('{} is not resolvable');
+
         $obj = new RequestHandlerTest();
         $resolver = new CallableResolver(); // No container injected
         $resolver->resolveMiddleware($obj);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage a_requesthandler is not resolvable
-     */
     public function testObjPsrRequestHandlerClassInContainer()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('a_requesthandler is not resolvable');
+
         $this->containerProphecy->has('a_requesthandler')->willReturn(true);
         $this->containerProphecy->get('a_requesthandler')->willReturn(new RequestHandlerTest());
 
@@ -302,12 +297,11 @@ class CallableResolverTest extends TestCase
         $this->assertEquals('1', RequestHandlerTest::$CalledCount);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage a_requesthandler is not resolvable
-     */
     public function testMiddlewareObjPsrRequestHandlerClassInContainer()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('a_requesthandler is not resolvable');
+
         $this->containerProphecy->has('a_requesthandler')->willReturn(true);
         $this->containerProphecy->get('a_requesthandler')->willReturn(new RequestHandlerTest());
 
@@ -337,23 +331,21 @@ class CallableResolverTest extends TestCase
         $this->assertEquals('custom', $callableMiddleware[1]);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage {} is not resolvable
-     */
     public function testObjMiddlewareClass()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('{} is not resolvable');
+
         $obj = new MiddlewareTest();
         $resolver = new CallableResolver(); // No container injected
         $resolver->resolve($obj);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage {} is not resolvable
-     */
     public function testRouteObjMiddlewareClass()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('{} is not resolvable');
+
         $obj = new MiddlewareTest();
         $resolver = new CallableResolver(); // No container injected
         $resolver->resolveRoute($obj);
@@ -369,12 +361,11 @@ class CallableResolverTest extends TestCase
         $this->assertEquals('1', MiddlewareTest::$CalledCount);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage callable_service:notFound is not resolvable
-     */
     public function testMethodNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('callable_service:notFound is not resolvable');
+
         $this->containerProphecy->has('callable_service')->willReturn(true);
         $this->containerProphecy->get('callable_service')->willReturn(new CallableTest());
 
@@ -384,12 +375,11 @@ class CallableResolverTest extends TestCase
         $resolver->resolve('callable_service:notFound');
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage callable_service:notFound is not resolvable
-     */
     public function testRouteMethodNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('callable_service:notFound is not resolvable');
+
         $this->containerProphecy->has('callable_service')->willReturn(true);
         $this->containerProphecy->get('callable_service')->willReturn(new CallableTest());
 
@@ -399,12 +389,11 @@ class CallableResolverTest extends TestCase
         $resolver->resolveRoute('callable_service:notFound');
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage callable_service:notFound is not resolvable
-     */
     public function testMiddlewareMethodNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('callable_service:notFound is not resolvable');
+
         $this->containerProphecy->has('callable_service')->willReturn(true);
         $this->containerProphecy->get('callable_service')->willReturn(new CallableTest());
 
@@ -414,108 +403,99 @@ class CallableResolverTest extends TestCase
         $resolver->resolveMiddleware('callable_service:notFound');
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Callable notFound does not exist
-     */
     public function testFunctionNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Callable notFound does not exist');
+
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);
         $resolver->resolve('notFound');
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Callable notFound does not exist
-     */
     public function testRouteFunctionNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Callable notFound does not exist');
+
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);
         $resolver->resolveRoute('notFound');
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Callable notFound does not exist
-     */
     public function testMiddlewareFunctionNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Callable notFound does not exist');
+
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);
         $resolver->resolveMiddleware('notFound');
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Callable Unknown does not exist
-     */
     public function testClassNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Callable Unknown does not exist');
+
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);
         $resolver->resolve('Unknown:notFound');
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Callable Unknown does not exist
-     */
     public function testRouteClassNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Callable Unknown does not exist');
+
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);
         $resolver->resolveRoute('Unknown:notFound');
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Callable Unknown does not exist
-     */
     public function testMiddlewareClassNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Callable Unknown does not exist');
+
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);
         $resolver->resolveMiddleware('Unknown:notFound');
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage is not resolvable
-     */
     public function testCallableClassNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('is not resolvable');
+
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);
         $resolver->resolve(['Unknown', 'notFound']);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage is not resolvable
-     */
     public function testRouteCallableClassNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('is not resolvable');
+
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);
         $resolver->resolveRoute(['Unknown', 'notFound']);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage is not resolvable
-     */
     public function testMiddlewareCallableClassNotFoundThrowException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('is not resolvable');
+
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Slim\Tests\Error;
 
 use Exception;
-use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
 use RuntimeException;
 use Slim\Error\Renderers\HtmlErrorRenderer;

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -30,7 +30,7 @@ class AbstractErrorRendererTest extends TestCase
         $output = $renderer->__invoke($exception, true);
 
         $this->assertRegExp('/.*The application could not run because of the following error:.*/', $output);
-        $this->assertContains('Oops..', $output);
+        $this->assertStringContainsString('Oops..', $output);
     }
 
     public function testHTMLErrorRendererNoErrorDetails()
@@ -40,7 +40,7 @@ class AbstractErrorRendererTest extends TestCase
         $output = $renderer->__invoke($exception, false);
 
         $this->assertRegExp('/.*A website error has occurred. Sorry for the temporary inconvenience.*/', $output);
-        $this->assertNotContains('Oops..', $output);
+        $this->assertStringNotContainsString('Oops..', $output);
     }
 
     public function testHTMLErrorRendererRenderFragmentMethod()
@@ -80,8 +80,8 @@ class AbstractErrorRendererTest extends TestCase
         $renderer = new HtmlErrorRenderer();
         $output = $renderer->__invoke($httpExceptionProphecy->reveal(), false);
 
-        $this->assertContains($exceptionTitle, $output, 'Should contain http exception title');
-        $this->assertContains($exceptionDescription, $output, 'Should contain http exception description');
+        $this->assertStringContainsString($exceptionTitle, $output, 'Should contain http exception title');
+        $this->assertStringContainsString($exceptionDescription, $output, 'Should contain http exception description');
     }
 
     public function testJSONErrorRendererDisplaysErrorDetails()
@@ -243,6 +243,6 @@ class AbstractErrorRendererTest extends TestCase
         $renderer = new PlainTextErrorRenderer();
         $output = $renderer->__invoke($httpExceptionProphecy->reveal(), true);
 
-        $this->assertContains($exceptionTitle, $output, 'Should contain http exception title');
+        $this->assertStringContainsString($exceptionTitle, $output, 'Should contain http exception title');
     }
 }

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -79,11 +79,10 @@ class AppFactoryTest extends TestCase
         $this->assertInstanceOf(DecoratedResponseFactory::class, $app->getResponseFactory());
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testDetermineResponseFactoryThrowsRuntimeException()
     {
+        $this->expectException(\RuntimeException::class);
+
         Psr17FactoryProvider::setFactories([]);
         AppFactory::create();
     }

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use ReflectionProperty;
+use RuntimeException;
 use Slim\Factory\AppFactory;
 use Slim\Factory\Psr17\GuzzlePsr17Factory;
 use Slim\Factory\Psr17\NyholmPsr17Factory;
@@ -81,7 +82,7 @@ class AppFactoryTest extends TestCase
 
     public function testDetermineResponseFactoryThrowsRuntimeException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         Psr17FactoryProvider::setFactories([]);
         AppFactory::create();

--- a/tests/Factory/Psr17/Psr17FactoryTest.php
+++ b/tests/Factory/Psr17/Psr17FactoryTest.php
@@ -14,30 +14,28 @@ use Slim\Tests\TestCase;
 
 class Psr17FactoryTest extends TestCase
 {
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Slim\Tests\Mocks\MockPsr17Factory could not instantiate a response factory.
-     */
     public function testGetResponseFactoryThrowsRuntimeException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Slim\\Tests\\Mocks\\MockPsr17Factory could not instantiate a response factory.');
+
         MockPsr17Factory::getResponseFactory();
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Slim\Tests\Mocks\MockPsr17Factory could not instantiate a stream factory.
-     */
     public function testGetStreamFactoryThrowsRuntimeException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Slim\\Tests\\Mocks\\MockPsr17Factory could not instantiate a stream factory.');
+
         MockPsr17Factory::getStreamFactory();
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage Slim\Tests\Mocks\MockPsr17Factory could not instantiate a server request creator.
-     */
     public function testGetServerRequestCreatorThrowsRuntimeException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Slim\\Tests\\Mocks\\MockPsr17Factory' .
+                                      ' could not instantiate a server request creator.');
+
         MockPsr17Factory::getServerRequestCreator();
     }
 }

--- a/tests/Factory/Psr17/Psr17FactoryTest.php
+++ b/tests/Factory/Psr17/Psr17FactoryTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Factory\Psr17;
 
+use RuntimeException;
 use Slim\Tests\Mocks\MockPsr17Factory;
 use Slim\Tests\TestCase;
 
@@ -16,7 +17,7 @@ class Psr17FactoryTest extends TestCase
 {
     public function testGetResponseFactoryThrowsRuntimeException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Slim\\Tests\\Mocks\\MockPsr17Factory could not instantiate a response factory.');
 
         MockPsr17Factory::getResponseFactory();
@@ -24,7 +25,7 @@ class Psr17FactoryTest extends TestCase
 
     public function testGetStreamFactoryThrowsRuntimeException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Slim\\Tests\\Mocks\\MockPsr17Factory could not instantiate a stream factory.');
 
         MockPsr17Factory::getStreamFactory();
@@ -32,7 +33,7 @@ class Psr17FactoryTest extends TestCase
 
     public function testGetServerRequestCreatorThrowsRuntimeException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Slim\\Tests\\Mocks\\MockPsr17Factory' .
                                       ' could not instantiate a server request creator.');
 

--- a/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
+++ b/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
@@ -11,6 +11,7 @@ namespace Slim\Tests\Factory\Psr17;
 
 use Psr\Http\Message\ServerRequestInterface;
 use ReflectionProperty;
+use RuntimeException;
 use Slim\Factory\Psr17\SlimHttpServerRequestCreator;
 use Slim\Http\ServerRequest;
 use Slim\Interfaces\ServerRequestCreatorInterface;
@@ -54,7 +55,7 @@ class SlimHttpServerRequestCreatorTest extends TestCase
 
     public function testCreateServerRequestFromGlobalsThrowsRuntimeException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('The Slim-Http ServerRequest decorator is not available.');
 
         $serverRequestCreatorProphecy = $this->prophesize(ServerRequestCreatorInterface::class);

--- a/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
+++ b/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
@@ -22,7 +22,7 @@ class SlimHttpServerRequestCreatorTest extends TestCase
      * We need to reset the static property of SlimHttpServerRequestCreator back to its original value
      * Otherwise other tests will fail
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         $serverRequestCreatorProphecy = $this->prophesize(ServerRequestCreatorInterface::class);
 

--- a/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
+++ b/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
@@ -52,12 +52,11 @@ class SlimHttpServerRequestCreatorTest extends TestCase
         $this->assertInstanceOf(ServerRequest::class, $slimHttpServerRequestCreator->createServerRequestFromGlobals());
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage The Slim-Http ServerRequest decorator is not available.
-     */
     public function testCreateServerRequestFromGlobalsThrowsRuntimeException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The Slim-Http ServerRequest decorator is not available.');
+
         $serverRequestCreatorProphecy = $this->prophesize(ServerRequestCreatorInterface::class);
 
         $slimHttpServerRequestCreator = new SlimHttpServerRequestCreator($serverRequestCreatorProphecy->reveal());

--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -12,6 +12,7 @@ namespace Slim\Tests\Factory;
 use GuzzleHttp\Psr7\ServerRequest as GuzzleServerRequest;
 use Nyholm\Psr7\ServerRequest as NyholmServerRequest;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 use Slim\Factory\Psr17\GuzzlePsr17Factory;
 use Slim\Factory\Psr17\NyholmPsr17Factory;
 use Slim\Factory\Psr17\Psr17FactoryProvider;
@@ -66,7 +67,7 @@ class ServerRequestCreatorFactoryTest extends TestCase
 
     public function testDetermineServerRequestCreatorThrowsRuntimeException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         Psr17FactoryProvider::setFactories([]);
         ServerRequestCreatorFactory::create();

--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -64,11 +64,10 @@ class ServerRequestCreatorFactoryTest extends TestCase
         $this->assertInstanceOf(ServerRequest::class, $serverRequestCreator->createServerRequestFromGlobals());
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testDetermineServerRequestCreatorThrowsRuntimeException()
     {
+        $this->expectException(\RuntimeException::class);
+
         Psr17FactoryProvider::setFactories([]);
         ServerRequestCreatorFactory::create();
     }

--- a/tests/Middleware/ErrorMiddlewareTest.php
+++ b/tests/Middleware/ErrorMiddlewareTest.php
@@ -75,11 +75,10 @@ class ErrorMiddlewareTest extends TestCase
         $this->expectOutputString('Oops..');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testSetDefaultErrorHandlerThrowsException()
     {
+        $this->expectException(\RuntimeException::class);
+
         $responseFactory = $this->getResponseFactory();
         $app = new App($responseFactory);
         $callableResolver = $app->getCallableResolver();

--- a/tests/Middleware/ErrorMiddlewareTest.php
+++ b/tests/Middleware/ErrorMiddlewareTest.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 use LogicException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
 use Slim\App;
 use Slim\Exception\HttpNotFoundException;
 use Slim\Handlers\ErrorHandler;
@@ -77,7 +78,7 @@ class ErrorMiddlewareTest extends TestCase
 
     public function testSetDefaultErrorHandlerThrowsException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $responseFactory = $this->getResponseFactory();
         $app = new App($responseFactory);

--- a/tests/Middleware/OutputBufferingMiddlewareTest.php
+++ b/tests/Middleware/OutputBufferingMiddlewareTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Slim\Tests\Middleware;
 
 use Exception;
+use InvalidArgumentException;
 use Psr\Http\Server\RequestHandlerInterface;
 use ReflectionProperty;
 use Slim\Middleware\OutputBufferingMiddleware;
@@ -41,7 +42,7 @@ class OutputBufferingMiddlewareTest extends TestCase
 
     public function testStyleCustomInvalid()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         new OutputBufferingMiddleware($this->getStreamFactory(), 'foo');
     }

--- a/tests/Middleware/OutputBufferingMiddlewareTest.php
+++ b/tests/Middleware/OutputBufferingMiddlewareTest.php
@@ -39,11 +39,10 @@ class OutputBufferingMiddlewareTest extends TestCase
         $this->assertEquals('prepend', $value);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testStyleCustomInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         new OutputBufferingMiddleware($this->getStreamFactory(), 'foo');
     }
 

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -13,6 +13,7 @@ use FastRoute\Dispatcher;
 use Prophecy\Argument;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
 use Slim\CallableResolver;
 use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
@@ -149,7 +150,7 @@ class RoutingMiddlewareTest extends TestCase
 
     public function testPerformRoutingThrowsExceptionOnInvalidRoutingResultsRouteStatus()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('An unexpected error occurred while performing routing.');
 
         // Prophesize the `RoutingResults` instance that would return an invalid route

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -147,12 +147,11 @@ class RoutingMiddlewareTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage An unexpected error occurred while performing routing.
-     */
     public function testPerformRoutingThrowsExceptionOnInvalidRoutingResultsRouteStatus()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('An unexpected error occurred while performing routing.');
+
         // Prophesize the `RoutingResults` instance that would return an invalid route
         // status when the method `getRouteStatus()` gets called.
         $routingResultsProphecy = $this->prophesize(RoutingResults::class);

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -26,7 +26,7 @@ use stdClass;
 
 class MiddlewareDispatcherTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         function testProcessRequest(ServerRequestInterface $request, RequestHandlerInterface $handler)
         {

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -254,12 +254,11 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertEquals(1, $handler->getCalledCount());
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessage MiddlewareInterfaceNotImplemented is not resolvable
-     */
     public function testResolveThrowsExceptionWhenResolvableDoesNotImplementMiddlewareInterface()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('MiddlewareInterfaceNotImplemented is not resolvable');
+
         $containerProphecy = $this->prophesize(ContainerInterface::class);
 
         $containerProphecy
@@ -280,12 +279,11 @@ class MiddlewareDispatcherTest extends TestCase
         $middlewareDispatcher->handle($request);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessageRegExp /(Middleware|Callable) Unresolvable::class does not exist/
-     */
     public function testResolveThrowsExceptionWithoutContainerAndUnresolvableClass()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageRegExp('/(Middleware|Callable) Unresolvable::class does not exist/');
+
         $handler = new MockRequestHandler();
         $middlewareDispatcher = $this->createMiddlewareDispatcher($handler, null);
         $middlewareDispatcher->addDeferred('Unresolvable::class');
@@ -294,12 +292,11 @@ class MiddlewareDispatcherTest extends TestCase
         $middlewareDispatcher->handle($request);
     }
 
-    /**
-     * @expectedException RuntimeException
-     * @expectedExceptionMessageRegExp /(Middleware|Callable) Unresolvable::class does not exist/
-     */
     public function testResolveThrowsExceptionWithoutContainerNonAdvancedCallableResolverAndUnresolvableClass()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageRegExp('/(Middleware|Callable) Unresolvable::class does not exist/');
+
         $unresolvable = 'Unresolvable::class';
 
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -256,7 +256,7 @@ class MiddlewareDispatcherTest extends TestCase
 
     public function testResolveThrowsExceptionWhenResolvableDoesNotImplementMiddlewareInterface()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('MiddlewareInterfaceNotImplemented is not resolvable');
 
         $containerProphecy = $this->prophesize(ContainerInterface::class);
@@ -281,7 +281,7 @@ class MiddlewareDispatcherTest extends TestCase
 
     public function testResolveThrowsExceptionWithoutContainerAndUnresolvableClass()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageRegExp('/(Middleware|Callable) Unresolvable::class does not exist/');
 
         $handler = new MockRequestHandler();
@@ -294,7 +294,7 @@ class MiddlewareDispatcherTest extends TestCase
 
     public function testResolveThrowsExceptionWithoutContainerNonAdvancedCallableResolverAndUnresolvableClass()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageRegExp('/(Middleware|Callable) Unresolvable::class does not exist/');
 
         $unresolvable = 'Unresolvable::class';

--- a/tests/Mocks/MockStream.php
+++ b/tests/Mocks/MockStream.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Mocks;
 
+use Exception;
+use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;
 
 class MockStream implements StreamInterface
@@ -67,7 +69,7 @@ class MockStream implements StreamInterface
             $this->writable = isset(self::$readWriteHash['write'][$meta['mode']]);
             $this->uri = $this->getMetadata('uri');
         } else {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'First argument to Stream::create() must be a string, resource or StreamInterface.'
             );
         }
@@ -89,7 +91,7 @@ class MockStream implements StreamInterface
             }
 
             return $this->getContents();
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             return '';
         }
     }

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -17,12 +17,12 @@ use Slim\Tests\Mocks\SlowPokeStream;
 
 class ResponseEmitterTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         HeaderStack::reset();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         HeaderStack::reset();
     }

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -12,8 +12,8 @@ namespace Slim\Tests;
 use Slim\ResponseEmitter;
 use Slim\Tests\Assets\HeaderStack;
 use Slim\Tests\Mocks\MockStream;
-use Slim\Tests\Mocks\SmallChunksStream;
 use Slim\Tests\Mocks\SlowPokeStream;
+use Slim\Tests\Mocks\SmallChunksStream;
 
 class ResponseEmitterTest extends TestCase
 {

--- a/tests/Routing/FastRouteDispatcherTest.php
+++ b/tests/Routing/FastRouteDispatcherTest.php
@@ -98,35 +98,32 @@ class FastRouteDispatcherTest extends TestCase
         $this->assertSame($results, $allowedMethods);
     }
 
-    /**
-     * @expectedException \FastRoute\BadRouteException
-     * @expectedExceptionMessage Cannot use the same placeholder "test" twice
-     */
     public function testDuplicateVariableNameError()
     {
+        $this->expectException(\FastRoute\BadRouteException::class);
+        $this->expectExceptionMessage('Cannot use the same placeholder "test" twice');
+
         \FastRoute\simpleDispatcher(function (RouteCollector $r) {
             $r->addRoute('GET', '/foo/{test}/{test:\d+}', 'handler0');
         }, $this->generateDispatcherOptions());
     }
 
-    /**
-     * @expectedException \FastRoute\BadRouteException
-     * @expectedExceptionMessage Cannot register two routes matching "/user/([^/]+)" for method "GET"
-     */
     public function testDuplicateVariableRoute()
     {
+        $this->expectException(\FastRoute\BadRouteException::class);
+        $this->expectExceptionMessage('Cannot register two routes matching "/user/([^/]+)" for method "GET"');
+
         \FastRoute\simpleDispatcher(function (RouteCollector $r) {
             $r->addRoute('GET', '/user/{id}', 'handler0'); // oops, forgot \d+ restriction ;)
             $r->addRoute('GET', '/user/{name}', 'handler1');
         }, $this->generateDispatcherOptions());
     }
 
-    /**
-     * @expectedException \FastRoute\BadRouteException
-     * @expectedExceptionMessage Cannot register two routes matching "/user" for method "GET"
-     */
     public function testDuplicateStaticRoute()
     {
+        $this->expectException(\FastRoute\BadRouteException::class);
+        $this->expectExceptionMessage('Cannot register two routes matching "/user" for method "GET"');
+
         \FastRoute\simpleDispatcher(function (RouteCollector $r) {
             $r->addRoute('GET', '/user', 'handler0');
             $r->addRoute('GET', '/user', 'handler1');
@@ -135,25 +132,25 @@ class FastRouteDispatcherTest extends TestCase
 
     /**
      * @codingStandardsIgnoreStart
-     * @expectedException \FastRoute\BadRouteException
-     * @expectedExceptionMessage Static route "/user/nikic" is shadowed by previously defined variable route
-     *                           "/user/([^/]+)" for method "GET"
      * @codingStandardsIgnoreEnd
      */
     public function testShadowedStaticRoute()
     {
+        $this->expectException(\FastRoute\BadRouteException::class);
+        $this->expectExceptionMessage('Static route "/user/nikic" is shadowed by previously defined variable route' .
+                                      ' "/user/([^/]+)" for method "GET"');
+
         \FastRoute\simpleDispatcher(function (RouteCollector $r) {
             $r->addRoute('GET', '/user/{name}', 'handler0');
             $r->addRoute('GET', '/user/nikic', 'handler1');
         }, $this->generateDispatcherOptions());
     }
 
-    /**
-     * @expectedException \FastRoute\BadRouteException
-     * @expectedExceptionMessage Regex "(en|de)" for parameter "lang" contains a capturing group
-     */
     public function testCapturing()
     {
+        $this->expectException(\FastRoute\BadRouteException::class);
+        $this->expectExceptionMessage('Regex "(en|de)" for parameter "lang" contains a capturing group');
+
         \FastRoute\simpleDispatcher(function (RouteCollector $r) {
             $r->addRoute('GET', '/{lang:(en|de)}', 'handler0');
         }, $this->generateDispatcherOptions());

--- a/tests/Routing/FastRouteDispatcherTest.php
+++ b/tests/Routing/FastRouteDispatcherTest.php
@@ -9,10 +9,12 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Routing;
 
+use FastRoute\BadRouteException;
 use FastRoute\DataGenerator\GroupCountBased;
 use FastRoute\RouteCollector;
 use Slim\Routing\FastRouteDispatcher;
 use Slim\Tests\TestCase;
+use function FastRoute\simpleDispatcher;
 
 class FastRouteDispatcherTest extends TestCase
 {
@@ -22,7 +24,7 @@ class FastRouteDispatcherTest extends TestCase
     public function testFoundDispatches($method, $uri, $callback, $handler, $argDict)
     {
         /** @var FastRouteDispatcher $dispatcher */
-        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+        $dispatcher = simpleDispatcher($callback, $this->generateDispatcherOptions());
 
         $results = $dispatcher->dispatch($method, $uri);
 
@@ -58,7 +60,7 @@ class FastRouteDispatcherTest extends TestCase
     public function testNotFoundDispatches($method, $uri, $callback)
     {
         /** @var FastRouteDispatcher $dispatcher */
-        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+        $dispatcher = simpleDispatcher($callback, $this->generateDispatcherOptions());
 
         $results = $dispatcher->dispatch($method, $uri);
 
@@ -74,7 +76,7 @@ class FastRouteDispatcherTest extends TestCase
     public function testMethodNotAllowedDispatches($method, $uri, $callback)
     {
         /** @var FastRouteDispatcher $dispatcher */
-        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+        $dispatcher = simpleDispatcher($callback, $this->generateDispatcherOptions());
 
         $results = $dispatcher->dispatch($method, $uri);
 
@@ -91,7 +93,7 @@ class FastRouteDispatcherTest extends TestCase
     public function testGetAllowedMethods($method, $uri, $callback, $allowedMethods)
     {
         /** @var FastRouteDispatcher $dispatcher */
-        $dispatcher = \FastRoute\simpleDispatcher($callback, $this->generateDispatcherOptions());
+        $dispatcher = simpleDispatcher($callback, $this->generateDispatcherOptions());
 
         $results = $dispatcher->getAllowedMethods($uri);
 
@@ -100,20 +102,20 @@ class FastRouteDispatcherTest extends TestCase
 
     public function testDuplicateVariableNameError()
     {
-        $this->expectException(\FastRoute\BadRouteException::class);
+        $this->expectException(BadRouteException::class);
         $this->expectExceptionMessage('Cannot use the same placeholder "test" twice');
 
-        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+        simpleDispatcher(function (RouteCollector $r) {
             $r->addRoute('GET', '/foo/{test}/{test:\d+}', 'handler0');
         }, $this->generateDispatcherOptions());
     }
 
     public function testDuplicateVariableRoute()
     {
-        $this->expectException(\FastRoute\BadRouteException::class);
+        $this->expectException(BadRouteException::class);
         $this->expectExceptionMessage('Cannot register two routes matching "/user/([^/]+)" for method "GET"');
 
-        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+        simpleDispatcher(function (RouteCollector $r) {
             $r->addRoute('GET', '/user/{id}', 'handler0'); // oops, forgot \d+ restriction ;)
             $r->addRoute('GET', '/user/{name}', 'handler1');
         }, $this->generateDispatcherOptions());
@@ -121,10 +123,10 @@ class FastRouteDispatcherTest extends TestCase
 
     public function testDuplicateStaticRoute()
     {
-        $this->expectException(\FastRoute\BadRouteException::class);
+        $this->expectException(BadRouteException::class);
         $this->expectExceptionMessage('Cannot register two routes matching "/user" for method "GET"');
 
-        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+        simpleDispatcher(function (RouteCollector $r) {
             $r->addRoute('GET', '/user', 'handler0');
             $r->addRoute('GET', '/user', 'handler1');
         }, $this->generateDispatcherOptions());
@@ -136,11 +138,11 @@ class FastRouteDispatcherTest extends TestCase
      */
     public function testShadowedStaticRoute()
     {
-        $this->expectException(\FastRoute\BadRouteException::class);
+        $this->expectException(BadRouteException::class);
         $this->expectExceptionMessage('Static route "/user/nikic" is shadowed by previously defined variable route' .
                                       ' "/user/([^/]+)" for method "GET"');
 
-        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+        simpleDispatcher(function (RouteCollector $r) {
             $r->addRoute('GET', '/user/{name}', 'handler0');
             $r->addRoute('GET', '/user/nikic', 'handler1');
         }, $this->generateDispatcherOptions());
@@ -148,10 +150,10 @@ class FastRouteDispatcherTest extends TestCase
 
     public function testCapturing()
     {
-        $this->expectException(\FastRoute\BadRouteException::class);
+        $this->expectException(BadRouteException::class);
         $this->expectExceptionMessage('Regex "(en|de)" for parameter "lang" contains a capturing group');
 
-        \FastRoute\simpleDispatcher(function (RouteCollector $r) {
+        simpleDispatcher(function (RouteCollector $r) {
             $r->addRoute('GET', '/{lang:(en|de)}', 'handler0');
         }, $this->generateDispatcherOptions());
     }

--- a/tests/Routing/RouteCollectorTest.php
+++ b/tests/Routing/RouteCollectorTest.php
@@ -121,7 +121,7 @@ class RouteCollectorTest extends TestCase
 
     public function testRemoveNamedRouteWithARouteThatDoesNotExist()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
@@ -132,7 +132,7 @@ class RouteCollectorTest extends TestCase
 
     public function testLookupRouteThrowsExceptionIfRouteNotFound()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);

--- a/tests/Routing/RouteCollectorTest.php
+++ b/tests/Routing/RouteCollectorTest.php
@@ -119,11 +119,10 @@ class RouteCollectorTest extends TestCase
         $this->assertCount(0, $routes);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testRemoveNamedRouteWithARouteThatDoesNotExist()
     {
+        $this->expectException(\RuntimeException::class);
+
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
 
@@ -131,11 +130,10 @@ class RouteCollectorTest extends TestCase
         $routeCollector->removeNamedRoute('missing');
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testLookupRouteThrowsExceptionIfRouteNotFound()
     {
+        $this->expectException(\RuntimeException::class);
+
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
 

--- a/tests/Routing/RouteCollectorTest.php
+++ b/tests/Routing/RouteCollectorTest.php
@@ -26,7 +26,7 @@ class RouteCollectorTest extends TestCase
      */
     protected $cacheFile;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if ($this->cacheFile && file_exists($this->cacheFile)) {
             unlink($this->cacheFile);

--- a/tests/Routing/RouteContextTest.php
+++ b/tests/Routing/RouteContextTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace Slim\Tests\Routing;
 
 use Psr\Http\Message\ServerRequestInterface;
-use ReflectionClass;
 use RuntimeException;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouteParserInterface;
@@ -84,7 +83,7 @@ class RouteContextTest extends TestCase
      */
     public function testCannotCreateInstanceIfRequestIsMissingAttributes(string $attribute): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $serverRequest = $this->createServerRequestWithRouteAttributes()->withoutAttribute($attribute);
 

--- a/tests/Routing/RouteContextTest.php
+++ b/tests/Routing/RouteContextTest.php
@@ -80,11 +80,12 @@ class RouteContextTest extends TestCase
 
     /**
      * @dataProvider requiredRouteContextRequestAttributes
-     * @expectedException RuntimeException
      * @param string $attribute
      */
     public function testCannotCreateInstanceIfRequestIsMissingAttributes(string $attribute): void
     {
+        $this->expectException(\RuntimeException::class);
+
         $serverRequest = $this->createServerRequestWithRouteAttributes()->withoutAttribute($attribute);
 
         RouteContext::fromRequest($serverRequest);

--- a/tests/Routing/RouteParserTest.php
+++ b/tests/Routing/RouteParserTest.php
@@ -126,11 +126,10 @@ class RouteParserTest extends TestCase
         $this->assertEquals($expectedResult, $results);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUrlForWithMissingSegmentData()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
 
@@ -143,11 +142,10 @@ class RouteParserTest extends TestCase
         $routeParser->urlFor('test', ['last' => 'world']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testUrlForRouteThatDoesNotExist()
     {
+        $this->expectException(\RuntimeException::class);
+
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
 

--- a/tests/Routing/RouteParserTest.php
+++ b/tests/Routing/RouteParserTest.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Routing;
 
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\UriInterface;
+use RuntimeException;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteInterface;
@@ -128,7 +130,7 @@ class RouteParserTest extends TestCase
 
     public function testUrlForWithMissingSegmentData()
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
@@ -144,7 +146,7 @@ class RouteParserTest extends TestCase
 
     public function testUrlForRouteThatDoesNotExist()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -18,6 +18,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
 use Slim\CallableResolver;
 use Slim\Handlers\Strategies\RequestHandler;
 use Slim\Handlers\Strategies\RequestResponse;
@@ -365,7 +366,7 @@ class RouteTest extends TestCase
 
     public function testAddMiddlewareAsStringNotImplementingInterfaceThrowsException()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
             'A middleware must be an object/class name referencing an implementation of ' .
             'MiddlewareInterface or a callable with a matching signature.'
@@ -516,7 +517,7 @@ class RouteTest extends TestCase
 
     public function testInvokeWithException()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $callable = function (ServerRequestInterface $request, ResponseInterface $response) {
             throw new Exception();

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -514,11 +514,10 @@ class RouteTest extends TestCase
         $this->assertEquals('foo', (string) $response->getBody());
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testInvokeWithException()
     {
+        $this->expectException(\Exception::class);
+
         $callable = function (ServerRequestInterface $request, ResponseInterface $response) {
             throw new Exception();
         };


### PR DESCRIPTION
As mentionned [here](https://www.php.net/supported-versions.php), PHP 7.1 reached its end of life 3 weeks ago.

With this PR, I proposed to update our composer.json to PHP ^7.2.
I updated PHPUnit to 8.5 (which support PHP 7.4) and corrected some deprecated functions.

I can send PR for other repos which need an update.

Maybe we could release a new version of Slim before merging.