### PR TITLE
PSR-12

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ pull request for each branch. This allows me to review and pull in new features 
 
 ## Style Guide
 
-All pull requests must adhere to the [PSR-2 standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).
+All pull requests must adhere to the [PSR-12 standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-12-extended-coding-style-guide.md).
 
 ## Unit Testing
 

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -28,6 +28,8 @@ use Slim\Routing\RouteCollectorProxy;
 use Slim\Routing\RouteResolver;
 use Slim\Routing\RouteRunner;
 
+use function strtoupper;
+
 class App extends RouteCollectorProxy implements RequestHandlerInterface
 {
     /**

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -17,14 +17,14 @@ use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 use Slim\Interfaces\AdvancedCallableResolverInterface;
 
-use function is_string;
-use function preg_match;
 use function class_exists;
-use function sprintf;
+use function is_array;
 use function is_callable;
 use function is_object;
+use function is_string;
 use function json_encode;
-use function is_array;
+use function preg_match;
+use function sprintf;
 
 final class CallableResolver implements AdvancedCallableResolverInterface
 {

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -17,6 +17,15 @@ use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 use Slim\Interfaces\AdvancedCallableResolverInterface;
 
+use function is_string;
+use function preg_match;
+use function class_exists;
+use function sprintf;
+use function is_callable;
+use function is_object;
+use function json_encode;
+use function is_array;
+
 final class CallableResolver implements AdvancedCallableResolverInterface
 {
     /**

--- a/Slim/Error/AbstractErrorRenderer.php
+++ b/Slim/Error/AbstractErrorRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -13,6 +13,10 @@ namespace Slim\Error\Renderers;
 use Slim\Error\AbstractErrorRenderer;
 use Throwable;
 
+use function get_class;
+use function htmlentities;
+use function sprintf;
+
 /**
  * Default Slim application HTML Error Renderer
  */

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -13,8 +13,8 @@ namespace Slim\Error\Renderers;
 use Slim\Error\AbstractErrorRenderer;
 use Throwable;
 
-use function json_encode;
 use function get_class;
+use function json_encode;
 
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -13,6 +13,12 @@ namespace Slim\Error\Renderers;
 use Slim\Error\AbstractErrorRenderer;
 use Throwable;
 
+use function json_encode;
+use function get_class;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+
 /**
  * Default Slim application JSON Error Renderer
  */

--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -13,6 +13,10 @@ namespace Slim\Error\Renderers;
 use Slim\Error\AbstractErrorRenderer;
 use Throwable;
 
+use function get_class;
+use function htmlentities;
+use function sprintf;
+
 /**
  * Default Slim application Plain Text Error Renderer
  */

--- a/Slim/Error/Renderers/XmlErrorRenderer.php
+++ b/Slim/Error/Renderers/XmlErrorRenderer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Error/Renderers/XmlErrorRenderer.php
+++ b/Slim/Error/Renderers/XmlErrorRenderer.php
@@ -13,6 +13,10 @@ namespace Slim\Error\Renderers;
 use Slim\Error\AbstractErrorRenderer;
 use Throwable;
 
+use function get_class;
+use function sprintf;
+use function str_replace;
+
 /**
  * Default Slim application XML Error Renderer
  */

--- a/Slim/Exception/HttpBadRequestException.php
+++ b/Slim/Exception/HttpBadRequestException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Exception/HttpException.php
+++ b/Slim/Exception/HttpException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Exception/HttpForbiddenException.php
+++ b/Slim/Exception/HttpForbiddenException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Exception/HttpInternalServerErrorException.php
+++ b/Slim/Exception/HttpInternalServerErrorException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Exception/HttpMethodNotAllowedException.php
+++ b/Slim/Exception/HttpMethodNotAllowedException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Exception/HttpMethodNotAllowedException.php
+++ b/Slim/Exception/HttpMethodNotAllowedException.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace Slim\Exception;
 
+use function implode;
+
 class HttpMethodNotAllowedException extends HttpSpecializedException
 {
     /**

--- a/Slim/Exception/HttpNotFoundException.php
+++ b/Slim/Exception/HttpNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Exception/HttpNotImplementedException.php
+++ b/Slim/Exception/HttpNotImplementedException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Exception/HttpSpecializedException.php
+++ b/Slim/Exception/HttpSpecializedException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Exception/HttpUnauthorizedException.php
+++ b/Slim/Exception/HttpUnauthorizedException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -179,7 +180,8 @@ class AppFactory
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
     ): ResponseFactoryInterface {
-        if (static::$slimHttpDecoratorsAutomaticDetectionEnabled
+        if (
+            static::$slimHttpDecoratorsAutomaticDetectionEnabled
             && SlimHttpPsr17Factory::isResponseFactoryAvailable()
         ) {
             return SlimHttpPsr17Factory::createDecoratedResponseFactory($responseFactory, $streamFactory);

--- a/Slim/Factory/Psr17/GuzzlePsr17Factory.php
+++ b/Slim/Factory/Psr17/GuzzlePsr17Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Factory/Psr17/NyholmPsr17Factory.php
+++ b/Slim/Factory/Psr17/NyholmPsr17Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Slim\Factory\Psr17;
@@ -21,7 +22,7 @@ class NyholmPsr17Factory extends Psr17Factory
          * Nyholm Psr17Factory implements all factories in one unified
          * factory which implements all of the PSR-17 factory interfaces
          */
-        $psr17Factory = new static::$responseFactoryClass;
+        $psr17Factory = new static::$responseFactoryClass();
 
         $serverRequestCreator = new static::$serverRequestCreatorClass(
             $psr17Factory,

--- a/Slim/Factory/Psr17/Psr17Factory.php
+++ b/Slim/Factory/Psr17/Psr17Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -46,7 +47,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
             throw new RuntimeException(get_called_class() . ' could not instantiate a response factory.');
         }
 
-        return new static::$responseFactoryClass;
+        return new static::$responseFactoryClass();
     }
 
     /**
@@ -58,7 +59,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
             throw new RuntimeException(get_called_class() . ' could not instantiate a stream factory.');
         }
 
-        return new static::$streamFactoryClass;
+        return new static::$streamFactoryClass();
     }
 
     /**

--- a/Slim/Factory/Psr17/Psr17Factory.php
+++ b/Slim/Factory/Psr17/Psr17Factory.php
@@ -16,8 +16,8 @@ use RuntimeException;
 use Slim\Interfaces\Psr17FactoryInterface;
 use Slim\Interfaces\ServerRequestCreatorInterface;
 
-use function get_called_class;
 use function class_exists;
+use function get_called_class;
 
 abstract class Psr17Factory implements Psr17FactoryInterface
 {

--- a/Slim/Factory/Psr17/Psr17Factory.php
+++ b/Slim/Factory/Psr17/Psr17Factory.php
@@ -16,6 +16,9 @@ use RuntimeException;
 use Slim\Interfaces\Psr17FactoryInterface;
 use Slim\Interfaces\ServerRequestCreatorInterface;
 
+use function get_called_class;
+use function class_exists;
+
 abstract class Psr17Factory implements Psr17FactoryInterface
 {
     /**

--- a/Slim/Factory/Psr17/Psr17FactoryProvider.php
+++ b/Slim/Factory/Psr17/Psr17FactoryProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Factory/Psr17/Psr17FactoryProvider.php
+++ b/Slim/Factory/Psr17/Psr17FactoryProvider.php
@@ -12,6 +12,8 @@ namespace Slim\Factory\Psr17;
 
 use Slim\Interfaces\Psr17FactoryProviderInterface;
 
+use function array_unshift;
+
 class Psr17FactoryProvider implements Psr17FactoryProviderInterface
 {
     /**

--- a/Slim/Factory/Psr17/ServerRequestCreator.php
+++ b/Slim/Factory/Psr17/ServerRequestCreator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Factory/Psr17/SlimHttpPsr17Factory.php
+++ b/Slim/Factory/Psr17/SlimHttpPsr17Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
+++ b/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
+++ b/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
@@ -14,6 +14,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use Slim\Interfaces\ServerRequestCreatorInterface;
 
+use function class_exists;
+
 class SlimHttpServerRequestCreator implements ServerRequestCreatorInterface
 {
     /**

--- a/Slim/Factory/Psr17/SlimPsr17Factory.php
+++ b/Slim/Factory/Psr17/SlimPsr17Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Factory/Psr17/ZendDiactorosPsr17Factory.php
+++ b/Slim/Factory/Psr17/ZendDiactorosPsr17Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Factory/ServerRequestCreatorFactory.php
+++ b/Slim/Factory/ServerRequestCreatorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -76,7 +77,8 @@ class ServerRequestCreatorFactory
     protected static function attemptServerRequestCreatorDecoration(
         ServerRequestCreatorInterface $serverRequestCreator
     ): ServerRequestCreatorInterface {
-        if (static::$slimHttpDecoratorsAutomaticDetectionEnabled
+        if (
+            static::$slimHttpDecoratorsAutomaticDetectionEnabled
             && SlimHttpServerRequestCreator::isServerRequestDecoratorAvailable()
         ) {
             return new SlimHttpServerRequestCreator($serverRequestCreator);

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -25,6 +25,18 @@ use Slim\Interfaces\ErrorHandlerInterface;
 use Slim\Interfaces\ErrorRendererInterface;
 use Throwable;
 
+use function array_intersect;
+use function explode;
+use function array_keys;
+use function count;
+use function current;
+use function next;
+use function preg_match;
+use function error_log;
+use function array_key_exists;
+use function implode;
+use function call_user_func;
+
 /**
  * Default Slim application error handler
  *

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -26,16 +26,16 @@ use Slim\Interfaces\ErrorRendererInterface;
 use Throwable;
 
 use function array_intersect;
-use function explode;
+use function array_key_exists;
 use function array_keys;
+use function call_user_func;
 use function count;
 use function current;
+use function error_log;
+use function explode;
+use function implode;
 use function next;
 use function preg_match;
-use function error_log;
-use function array_key_exists;
-use function implode;
-use function call_user_func;
 
 /**
  * Default Slim application error handler

--- a/Slim/Handlers/Strategies/RequestHandler.php
+++ b/Slim/Handlers/Strategies/RequestHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Handlers/Strategies/RequestResponse.php
+++ b/Slim/Handlers/Strategies/RequestResponse.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -14,6 +14,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Slim\Interfaces\InvocationStrategyInterface;
 
+use function array_values;
+
 /**
  * Route callback strategy with route parameters as individual arguments.
  */

--- a/Slim/Interfaces/AdvancedCallableResolverInterface.php
+++ b/Slim/Interfaces/AdvancedCallableResolverInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/DispatcherInterface.php
+++ b/Slim/Interfaces/DispatcherInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/ErrorHandlerInterface.php
+++ b/Slim/Interfaces/ErrorHandlerInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/ErrorRendererInterface.php
+++ b/Slim/Interfaces/ErrorRendererInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/InvocationStrategyInterface.php
+++ b/Slim/Interfaces/InvocationStrategyInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/MiddlewareDispatcherInterface.php
+++ b/Slim/Interfaces/MiddlewareDispatcherInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/Psr17FactoryInterface.php
+++ b/Slim/Interfaces/Psr17FactoryInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/Psr17FactoryProviderInterface.php
+++ b/Slim/Interfaces/Psr17FactoryProviderInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/RequestHandlerInvocationStrategyInterface.php
+++ b/Slim/Interfaces/RequestHandlerInvocationStrategyInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/RouteGroupInterface.php
+++ b/Slim/Interfaces/RouteGroupInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/RouteParserInterface.php
+++ b/Slim/Interfaces/RouteParserInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Interfaces/RouteResolverInterface.php
+++ b/Slim/Interfaces/RouteResolverInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Slim\Interfaces;

--- a/Slim/Interfaces/ServerRequestCreatorInterface.php
+++ b/Slim/Interfaces/ServerRequestCreatorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -16,6 +16,21 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 
+use function json_decode;
+use function parse_str;
+use function simplexml_load_string;
+use function libxml_disable_entity_loader;
+use function libxml_clear_errors;
+use function libxml_use_internal_errors;
+use function count;
+use function is_null;
+use function is_object;
+use function is_array;
+use function is_string;
+use function explode;
+use function strtolower;
+use function trim;
+
 class BodyParsingMiddleware implements MiddlewareInterface
 {
     /**

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -16,18 +16,18 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use RuntimeException;
 
-use function json_decode;
-use function parse_str;
-use function simplexml_load_string;
-use function libxml_disable_entity_loader;
-use function libxml_clear_errors;
-use function libxml_use_internal_errors;
 use function count;
+use function explode;
+use function is_array;
 use function is_null;
 use function is_object;
-use function is_array;
 use function is_string;
-use function explode;
+use function json_decode;
+use function libxml_clear_errors;
+use function libxml_disable_entity_loader;
+use function libxml_use_internal_errors;
+use function parse_str;
+use function simplexml_load_string;
 use function strtolower;
 use function trim;
 

--- a/Slim/Middleware/ContentLengthMiddleware.php
+++ b/Slim/Middleware/ContentLengthMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -21,6 +21,9 @@ use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\ErrorHandlerInterface;
 use Throwable;
 
+use function get_class;
+use function is_subclass_of;
+
 class ErrorMiddleware implements MiddlewareInterface
 {
     /**

--- a/Slim/Middleware/MethodOverrideMiddleware.php
+++ b/Slim/Middleware/MethodOverrideMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Middleware/MethodOverrideMiddleware.php
+++ b/Slim/Middleware/MethodOverrideMiddleware.php
@@ -15,6 +15,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+use function strtoupper;
+use function is_array;
+
 class MethodOverrideMiddleware implements MiddlewareInterface
 {
     /**

--- a/Slim/Middleware/MethodOverrideMiddleware.php
+++ b/Slim/Middleware/MethodOverrideMiddleware.php
@@ -15,8 +15,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-use function strtoupper;
 use function is_array;
+use function strtoupper;
 
 class MethodOverrideMiddleware implements MiddlewareInterface
 {

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -18,6 +18,11 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 
+use function in_array;
+use function ob_start;
+use function ob_get_clean;
+use function ob_end_clean;
+
 class OutputBufferingMiddleware implements MiddlewareInterface
 {
     public const APPEND = 'append';

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -19,9 +19,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Throwable;
 
 use function in_array;
-use function ob_start;
-use function ob_get_clean;
 use function ob_end_clean;
+use function ob_get_clean;
+use function ob_start;
 
 class OutputBufferingMiddleware implements MiddlewareInterface
 {

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -21,11 +21,11 @@ use Slim\Interfaces\AdvancedCallableResolverInterface;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\MiddlewareDispatcherInterface;
 
+use function class_exists;
+use function function_exists;
+use function is_callable;
 use function is_string;
 use function preg_match;
-use function function_exists;
-use function class_exists;
-use function is_callable;
 use function sprintf;
 
 class MiddlewareDispatcher implements MiddlewareDispatcherInterface

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -21,6 +21,13 @@ use Slim\Interfaces\AdvancedCallableResolverInterface;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\Interfaces\MiddlewareDispatcherInterface;
 
+use function is_string;
+use function preg_match;
+use function function_exists;
+use function class_exists;
+use function is_callable;
+use function sprintf;
+
 class MiddlewareDispatcher implements MiddlewareDispatcherInterface
 {
     /**

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -116,7 +117,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
     public function addMiddleware(MiddlewareInterface $middleware): MiddlewareDispatcherInterface
     {
         $next = $this->tip;
-        $this->tip = new class($middleware, $next) implements RequestHandlerInterface
+        $this->tip = new class ($middleware, $next) implements RequestHandlerInterface
         {
             private $middleware;
             private $next;
@@ -149,7 +150,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
     public function addDeferred(string $middleware): self
     {
         $next = $this->tip;
-        $this->tip = new class(
+        $this->tip = new class (
             $middleware,
             $next,
             $this->container,
@@ -259,7 +260,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
             $middleware = $middleware->bindTo($this->container);
         }
 
-        $this->tip = new class($middleware, $next) implements RequestHandlerInterface
+        $this->tip = new class ($middleware, $next) implements RequestHandlerInterface
         {
             private $middleware;
             private $next;

--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -12,11 +12,11 @@ namespace Slim;
 
 use Psr\Http\Message\ResponseInterface;
 
-use function strtolower;
-use function sprintf;
-use function min;
-use function strlen;
 use function in_array;
+use function min;
+use function sprintf;
+use function strlen;
+use function strtolower;
 
 use const CONNECTION_NORMAL;
 

--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -12,6 +12,14 @@ namespace Slim;
 
 use Psr\Http\Message\ResponseInterface;
 
+use function strtolower;
+use function sprintf;
+use function min;
+use function strlen;
+use function in_array;
+
+use const CONNECTION_NORMAL;
+
 class ResponseEmitter
 {
     /**

--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -12,6 +12,9 @@ namespace Slim;
 
 use Psr\Http\Message\ResponseInterface;
 
+use function connection_status;
+use function header;
+use function headers_sent;
 use function in_array;
 use function min;
 use function sprintf;

--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Slim\Routing;

--- a/Slim/Routing/FastRouteDispatcher.php
+++ b/Slim/Routing/FastRouteDispatcher.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -29,9 +29,9 @@ use Slim\MiddlewareDispatcher;
 use function array_key_exists;
 use function array_replace;
 use function array_reverse;
-use function is_array;
-use function in_array;
 use function class_implements;
+use function in_array;
+use function is_array;
 
 class Route implements RouteInterface, RequestHandlerInterface
 {

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -361,7 +362,8 @@ class Route implements RouteInterface, RequestHandlerInterface
         }
         $strategy = $this->invocationStrategy;
 
-        if (is_array($callable)
+        if (
+            is_array($callable)
             && $callable[0] instanceof RequestHandlerInterface
             && !in_array(RequestHandlerInvocationStrategyInterface::class, class_implements($strategy))
         ) {

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -26,6 +26,13 @@ use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;
 use Slim\MiddlewareDispatcher;
 
+use function array_key_exists;
+use function array_replace;
+use function array_reverse;
+use function is_array;
+use function in_array;
+use function class_implements;
+
 class Route implements RouteInterface, RequestHandlerInterface
 {
     /**

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -21,10 +21,10 @@ use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouteParserInterface;
 
+use function array_pop;
+use function dirname;
 use function file_exists;
 use function sprintf;
-use function dirname;
-use function array_pop;
 
 /**
  * RouteCollector is used to collect routes and route groups

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -21,6 +21,11 @@ use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouteParserInterface;
 
+use function file_exists;
+use function sprintf;
+use function dirname;
+use function array_pop;
+
 /**
  * RouteCollector is used to collect routes and route groups
  * as well as generate paths and URLs relative to its environment

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -25,6 +25,8 @@ use function array_pop;
 use function dirname;
 use function file_exists;
 use function sprintf;
+use function is_readable;
+use function is_writable;
 
 /**
  * RouteCollector is used to collect routes and route groups

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Routing/RouteContext.php
+++ b/Slim/Routing/RouteContext.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Routing/RouteGroup.php
+++ b/Slim/Routing/RouteGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -16,6 +16,12 @@ use Psr\Http\Message\UriInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteParserInterface;
 
+use function array_reverse;
+use function is_string;
+use function array_key_exists;
+use function implode;
+use function http_build_query;
+
 class RouteParser implements RouteParserInterface
 {
     /**

--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -16,11 +16,11 @@ use Psr\Http\Message\UriInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteParserInterface;
 
-use function array_reverse;
-use function is_string;
 use function array_key_exists;
-use function implode;
+use function array_reverse;
 use function http_build_query;
+use function implode;
+use function is_string;
 
 class RouteParser implements RouteParserInterface
 {

--- a/Slim/Routing/RouteResolver.php
+++ b/Slim/Routing/RouteResolver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Routing/RouteResolver.php
+++ b/Slim/Routing/RouteResolver.php
@@ -16,6 +16,8 @@ use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouteResolverInterface;
 
+use function rawurldecode;
+
 /**
  * RouteResolver instantiates the FastRoute dispatcher
  * and computes the routing results of a given URI and request method

--- a/Slim/Routing/RouteRunner.php
+++ b/Slim/Routing/RouteRunner.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Routing/RoutingResults.php
+++ b/Slim/Routing/RoutingResults.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/Slim/Routing/RoutingResults.php
+++ b/Slim/Routing/RoutingResults.php
@@ -12,6 +12,8 @@ namespace Slim\Routing;
 
 use Slim\Interfaces\DispatcherInterface;
 
+use function rawurldecode;
+
 class RoutingResults
 {
     public const NOT_FOUND = 0;

--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
         }
     ],
     "require": {
+        "php": "^7.2",
         "ext-json": "*",
         "nikic/fast-route": "^1.3",
-        "php": "^7.2",
         "psr/container": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
@@ -44,17 +44,18 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
+        "adriansuter/php-autoload-override": "v0.1-beta",
         "guzzlehttp/psr7": "^1.5",
         "http-interop/http-factory-guzzle": "^1.0",
+        "laminas/laminas-diactoros": "^2.1",
         "nyholm/psr7": "^1.1",
         "nyholm/psr7-server": "^0.3.0",
-        "phpunit/phpunit": "^8.5",
         "phpspec/prophecy": "^1.10",
         "phpstan/phpstan": "^0.11.5",
+        "phpunit/phpunit": "^8.5",
         "slim/http": "^0.7",
         "slim/psr7": "^0.3",
-        "squizlabs/php_codesniffer": "^3.4.2",
-        "laminas/laminas-diactoros": "^2.1"
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {
         "psr-4": {
@@ -81,5 +82,8 @@
         "ext-xml": "Needed to support XML format in BodyParsingMiddleware",
         "slim/psr7": "Slim PSR-7 implementation. See https://www.slimframework.com/docs/v4/start/installation.html for more information.",
         "php-di/php-di": "PHP-DI is the recommended container library to be used with Slim"
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,7 +8,7 @@
     <arg name="colors"/>
 
     <!-- inherit rules from: -->
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 
     <!-- Paths to check -->

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -19,6 +19,8 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use ReflectionClass;
+use ReflectionProperty;
 use RuntimeException;
 use Slim\App;
 use Slim\CallableResolver;
@@ -39,17 +41,15 @@ use Slim\Routing\RouteCollectorProxy;
 use Slim\Routing\RouteContext;
 use Slim\Tests\Mocks\MockAction;
 use stdClass;
-use ReflectionProperty;
-use ReflectionClass;
 
-use function ini_set;
-use function tempnam;
-use function sys_get_temp_dir;
-use function strtolower;
-use function array_shift;
-use function json_encode;
 use function array_key_exists;
+use function array_shift;
 use function count;
+use function ini_set;
+use function json_encode;
+use function strtolower;
+use function sys_get_temp_dir;
+use function tempnam;
 
 class AppTest extends TestCase
 {

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -39,6 +39,17 @@ use Slim\Routing\RouteCollectorProxy;
 use Slim\Routing\RouteContext;
 use Slim\Tests\Mocks\MockAction;
 use stdClass;
+use ReflectionProperty;
+use ReflectionClass;
+
+use function ini_set;
+use function tempnam;
+use function sys_get_temp_dir;
+use function strtolower;
+use function array_shift;
+use function json_encode;
+use function array_key_exists;
+use function count;
 
 class AppTest extends TestCase
 {
@@ -690,17 +701,17 @@ class AppTest extends TestCase
         $routingMiddleware = $app->addRoutingMiddleware();
 
         // Check that the routing middleware really has been added to the tip of the app middleware stack.
-        $middlewareDispatcherProperty = new \ReflectionProperty(App::class, 'middlewareDispatcher');
+        $middlewareDispatcherProperty = new ReflectionProperty(App::class, 'middlewareDispatcher');
         $middlewareDispatcherProperty->setAccessible(true);
         /** @var MiddlewareDispatcher $middlewareDispatcher */
         $middlewareDispatcher = $middlewareDispatcherProperty->getValue($app);
 
-        $tipProperty = new \ReflectionProperty(MiddlewareDispatcher::class, 'tip');
+        $tipProperty = new ReflectionProperty(MiddlewareDispatcher::class, 'tip');
         $tipProperty->setAccessible(true);
         /** @var RequestHandlerInterface $tip */
         $tip = $tipProperty->getValue($middlewareDispatcher);
 
-        $reflection = new \ReflectionClass($tip);
+        $reflection = new ReflectionClass($tip);
         $middlewareProperty = $reflection->getProperty('middleware');
         $middlewareProperty->setAccessible(true);
 
@@ -720,17 +731,17 @@ class AppTest extends TestCase
         $errorMiddleware = $app->addErrorMiddleware(true, true, true);
 
         // Check that the error middleware really has been added to the tip of the app middleware stack.
-        $middlewareDispatcherProperty = new \ReflectionProperty(App::class, 'middlewareDispatcher');
+        $middlewareDispatcherProperty = new ReflectionProperty(App::class, 'middlewareDispatcher');
         $middlewareDispatcherProperty->setAccessible(true);
         /** @var MiddlewareDispatcher $middlewareDispatcher */
         $middlewareDispatcher = $middlewareDispatcherProperty->getValue($app);
 
-        $tipProperty = new \ReflectionProperty(MiddlewareDispatcher::class, 'tip');
+        $tipProperty = new ReflectionProperty(MiddlewareDispatcher::class, 'tip');
         $tipProperty->setAccessible(true);
         /** @var RequestHandlerInterface $tip */
         $tip = $tipProperty->getValue($middlewareDispatcher);
 
-        $reflection = new \ReflectionClass($tip);
+        $reflection = new ReflectionClass($tip);
         $middlewareProperty = $reflection->getProperty('middleware');
         $middlewareProperty->setAccessible(true);
 
@@ -750,17 +761,17 @@ class AppTest extends TestCase
         $bodyParsingMiddleware = $app->addBodyParsingMiddleware();
 
         // Check that the body parsing middleware really has been added to the tip of the app middleware stack.
-        $middlewareDispatcherProperty = new \ReflectionProperty(App::class, 'middlewareDispatcher');
+        $middlewareDispatcherProperty = new ReflectionProperty(App::class, 'middlewareDispatcher');
         $middlewareDispatcherProperty->setAccessible(true);
         /** @var MiddlewareDispatcher $middlewareDispatcher */
         $middlewareDispatcher = $middlewareDispatcherProperty->getValue($app);
 
-        $tipProperty = new \ReflectionProperty(MiddlewareDispatcher::class, 'tip');
+        $tipProperty = new ReflectionProperty(MiddlewareDispatcher::class, 'tip');
         $tipProperty->setAccessible(true);
         /** @var RequestHandlerInterface $tip */
         $tip = $tipProperty->getValue($middlewareDispatcher);
 
-        $reflection = new \ReflectionClass($tip);
+        $reflection = new ReflectionClass($tip);
         $middlewareProperty = $reflection->getProperty('middleware');
         $middlewareProperty->setAccessible(true);
 

--- a/tests/Assets/HeaderStack.php
+++ b/tests/Assets/HeaderStack.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Assets;
 
+use function explode;
+use function trim;
+
 /**
  * Zend Framework (http://framework.zend.com/)
  *

--- a/tests/Assets/HeaderStack.php
+++ b/tests/Assets/HeaderStack.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This is a direct copy of zend-diactoros/test/TestAsset/Functions.php and is used to override
  * header() and headers_sent() so we can test that they do the right thing.

--- a/tests/Assets/PhpFunctionOverrides.php
+++ b/tests/Assets/PhpFunctionOverrides.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Override PHP namespaced functions into the Slim\App namespace.
  *

--- a/tests/Assets/PhpRoutingFunctionOverrides.php
+++ b/tests/Assets/PhpRoutingFunctionOverrides.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Assets/PhpRoutingFunctionOverrides.php
+++ b/tests/Assets/PhpRoutingFunctionOverrides.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace Slim\Routing;
 
+use function stripos;
+
 /**
  * Is a file descriptor writable
  *

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -88,9 +89,9 @@ class CallableResolverTest extends TestCase
     public function testFunctionName()
     {
         $resolver = new CallableResolver(); // No container injected
-        $callable = $resolver->resolve(__NAMESPACE__.'\testAdvancedCallable');
-        $callableRoute = $resolver->resolveRoute(__NAMESPACE__.'\testAdvancedCallable');
-        $callableMiddleware = $resolver->resolveMiddleware(__NAMESPACE__.'\testAdvancedCallable');
+        $callable = $resolver->resolve(__NAMESPACE__ . '\testAdvancedCallable');
+        $callableRoute = $resolver->resolveRoute(__NAMESPACE__ . '\testAdvancedCallable');
+        $callableMiddleware = $resolver->resolveMiddleware(__NAMESPACE__ . '\testAdvancedCallable');
 
         $this->assertEquals(true, $callable());
         $this->assertEquals(true, $callableRoute());
@@ -315,9 +316,9 @@ class CallableResolverTest extends TestCase
     public function testResolutionToAPsrRequestHandlerClassWithCustomMethod()
     {
         $resolver = new CallableResolver(); // No container injected
-        $callable = $resolver->resolve(RequestHandlerTest::class.':custom');
-        $callableRoute = $resolver->resolveRoute(RequestHandlerTest::class.':custom');
-        $callableMiddleware = $resolver->resolveMiddleware(RequestHandlerTest::class.':custom');
+        $callable = $resolver->resolve(RequestHandlerTest::class . ':custom');
+        $callableRoute = $resolver->resolveRoute(RequestHandlerTest::class . ':custom');
+        $callableMiddleware = $resolver->resolveMiddleware(RequestHandlerTest::class . ':custom');
 
         $this->assertIsArray($callable);
         $this->assertInstanceOf(RequestHandlerTest::class, $callable[0]);

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -21,6 +21,10 @@ use Slim\Exception\HttpException;
 use Slim\Tests\TestCase;
 use stdClass;
 
+use function json_decode;
+use function json_encode;
+use function simplexml_load_string;
+
 class AbstractErrorRendererTest extends TestCase
 {
     public function testHTMLErrorRendererDisplaysErrorDetails()

--- a/tests/Exception/HttpExceptionTest.php
+++ b/tests/Exception/HttpExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Exception/HttpUnauthorizedExceptionTest.php
+++ b/tests/Exception/HttpUnauthorizedExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Factory/Psr17/Psr17FactoryProviderTest.php
+++ b/tests/Factory/Psr17/Psr17FactoryProviderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Factory/Psr17/Psr17FactoryTest.php
+++ b/tests/Factory/Psr17/Psr17FactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
+++ b/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Middleware/BodyParsingMiddlewareTest.php
+++ b/tests/Middleware/BodyParsingMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -22,10 +23,10 @@ class BodyParsingMiddlewareTest extends TestCase
      * Create a request handler that simply assigns the $request that it receives to a public property
      * of the returned response, so that we can then inspect that request.
      */
-    protected function createRequestHandler() : RequestHandlerInterface
+    protected function createRequestHandler(): RequestHandlerInterface
     {
         $response = $this->createResponse();
-        return new class($response) implements RequestHandlerInterface {
+        return new class ($response) implements RequestHandlerInterface {
             private $response;
 
             public function __construct(ResponseInterface $response)

--- a/tests/Middleware/BodyParsingMiddlewareTest.php
+++ b/tests/Middleware/BodyParsingMiddlewareTest.php
@@ -17,6 +17,9 @@ use RuntimeException;
 use Slim\Middleware\BodyParsingMiddleware;
 use Slim\Tests\TestCase;
 
+use function is_string;
+use function simplexml_load_string;
+
 class BodyParsingMiddlewareTest extends TestCase
 {
     /**

--- a/tests/Middleware/ContentLengthMiddlewareTest.php
+++ b/tests/Middleware/ContentLengthMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Middleware/ErrorMiddlewareTest.php
+++ b/tests/Middleware/ErrorMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Middleware/MethodOverrideMiddlewareTest.php
+++ b/tests/Middleware/MethodOverrideMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Middleware/OutputBufferingMiddlewareTest.php
+++ b/tests/Middleware/OutputBufferingMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Middleware/OutputBufferingMiddlewareTest.php
+++ b/tests/Middleware/OutputBufferingMiddlewareTest.php
@@ -17,6 +17,8 @@ use ReflectionProperty;
 use Slim\Middleware\OutputBufferingMiddleware;
 use Slim\Tests\TestCase;
 
+use function ob_get_contents;
+
 class OutputBufferingMiddlewareTest extends TestCase
 {
     public function testStyleDefaultValid()

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -460,7 +460,7 @@ class MiddlewareDispatcherTest extends TestCase
         /** @var RequestHandlerInterface $kernel */
         $kernel = $kernelProphecy->reveal();
         $dispatcher = $this->createMiddlewareDispatcher($kernel, null);
-        $dispatcher->addDeferred(\stdClass::class);
+        $dispatcher->addDeferred(stdClass::class);
         $dispatcher->handle($requestProphecy->reveal());
 
         $kernelProphecy->handle(Argument::type(ServerRequestInterface::class))->shouldNotHaveBeenCalled();

--- a/tests/Mocks/CallableTest.php
+++ b/tests/Mocks/CallableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/InvocationStrategyTest.php
+++ b/tests/Mocks/InvocationStrategyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/InvokableTest.php
+++ b/tests/Mocks/InvokableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MiddlewareTest.php
+++ b/tests/Mocks/MiddlewareTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockAction.php
+++ b/tests/Mocks/MockAction.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockAction.php
+++ b/tests/Mocks/MockAction.php
@@ -12,6 +12,10 @@ namespace Slim\Tests\Mocks;
 
 use InvalidArgumentException;
 
+use function count;
+use function json_encode;
+use function compact;
+
 class MockAction
 {
     public function __call($name, array $arguments)

--- a/tests/Mocks/MockAction.php
+++ b/tests/Mocks/MockAction.php
@@ -12,9 +12,9 @@ namespace Slim\Tests\Mocks;
 
 use InvalidArgumentException;
 
+use function compact;
 use function count;
 use function json_encode;
-use function compact;
 
 class MockAction
 {

--- a/tests/Mocks/MockCustomException.php
+++ b/tests/Mocks/MockCustomException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockCustomRequestHandlerInvocationStrategy.php
+++ b/tests/Mocks/MockCustomRequestHandlerInvocationStrategy.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockMiddlewareSlimCallable.php
+++ b/tests/Mocks/MockMiddlewareSlimCallable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockMiddlewareWithConstructor.php
+++ b/tests/Mocks/MockMiddlewareWithConstructor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockMiddlewareWithoutConstructor.php
+++ b/tests/Mocks/MockMiddlewareWithoutConstructor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockMiddlewareWithoutInterface.php
+++ b/tests/Mocks/MockMiddlewareWithoutInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockPsr17Factory.php
+++ b/tests/Mocks/MockPsr17Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockPsr17FactoryWithoutStreamFactory.php
+++ b/tests/Mocks/MockPsr17FactoryWithoutStreamFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockRequestHandler.php
+++ b/tests/Mocks/MockRequestHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockSequenceMiddleware.php
+++ b/tests/Mocks/MockSequenceMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/MockStream.php
+++ b/tests/Mocks/MockStream.php
@@ -13,6 +13,25 @@ namespace Slim\Tests\Mocks;
 use Exception;
 use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
+
+use function is_string;
+use function fopen;
+use function gettype;
+use function is_resource;
+use function fclose;
+use function clearstatcache;
+use function fstat;
+use function ftell;
+use function feof;
+use function fseek;
+use function var_export;
+use function fwrite;
+use function fread;
+use function stream_get_contents;
+use function stream_get_meta_data;
+
+use const SEEK_SET;
 
 class MockStream implements StreamInterface
 {
@@ -56,15 +75,15 @@ class MockStream implements StreamInterface
      */
     public function __construct($body = '')
     {
-        if (\is_string($body)) {
-            $resource = \fopen('php://temp', 'rw+');
-            \fwrite($resource, $body);
+        if (is_string($body)) {
+            $resource = fopen('php://temp', 'rw+');
+            fwrite($resource, $body);
             $body = $resource;
         }
 
-        if ('resource' === \gettype($body)) {
+        if ('resource' === gettype($body)) {
             $this->stream = $body;
-            $meta = \stream_get_meta_data($this->stream);
+            $meta = stream_get_meta_data($this->stream);
             $this->seekable = $meta['seekable'];
             $this->readable = isset(self::$readWriteHash['read'][$meta['mode']]);
             $this->writable = isset(self::$readWriteHash['write'][$meta['mode']]);
@@ -100,8 +119,8 @@ class MockStream implements StreamInterface
     public function close(): void
     {
         if (isset($this->stream)) {
-            if (\is_resource($this->stream)) {
-                \fclose($this->stream);
+            if (is_resource($this->stream)) {
+                fclose($this->stream);
             }
             $this->detach();
         }
@@ -133,10 +152,10 @@ class MockStream implements StreamInterface
 
         // Clear the stat cache if the stream has a URI
         if ($this->uri) {
-            \clearstatcache(true, $this->uri);
+            clearstatcache(true, $this->uri);
         }
 
-        $stats = \fstat($this->stream);
+        $stats = fstat($this->stream);
         if (isset($stats['size'])) {
             $this->size = $stats['size'];
 
@@ -148,8 +167,8 @@ class MockStream implements StreamInterface
 
     public function tell(): int
     {
-        if (false === $result = \ftell($this->stream)) {
-            throw new \RuntimeException('Unable to determine stream position');
+        if (false === $result = ftell($this->stream)) {
+            throw new RuntimeException('Unable to determine stream position');
         }
 
         return $result;
@@ -157,7 +176,7 @@ class MockStream implements StreamInterface
 
     public function eof(): bool
     {
-        return !$this->stream || \feof($this->stream);
+        return !$this->stream || feof($this->stream);
     }
 
     public function isSeekable(): bool
@@ -165,14 +184,14 @@ class MockStream implements StreamInterface
         return $this->seekable;
     }
 
-    public function seek($offset, $whence = \SEEK_SET): void
+    public function seek($offset, $whence = SEEK_SET): void
     {
         if (!$this->seekable) {
-            throw new \RuntimeException('Stream is not seekable');
-        } elseif (\fseek($this->stream, $offset, $whence) === -1) {
-            throw new \RuntimeException(
+            throw new RuntimeException('Stream is not seekable');
+        } elseif (fseek($this->stream, $offset, $whence) === -1) {
+            throw new RuntimeException(
                 'Unable to seek to stream position '
-                . $offset . ' with whence ' . \var_export($whence, true)
+                . $offset . ' with whence ' . var_export($whence, true)
             );
         }
     }
@@ -190,14 +209,14 @@ class MockStream implements StreamInterface
     public function write($string): int
     {
         if (!$this->writable) {
-            throw new \RuntimeException('Cannot write to a non-writable stream');
+            throw new RuntimeException('Cannot write to a non-writable stream');
         }
 
         // We can't know the size after writing anything
         $this->size = null;
 
-        if (false === $result = \fwrite($this->stream, $string)) {
-            throw new \RuntimeException('Unable to write to stream');
+        if (false === $result = fwrite($this->stream, $string)) {
+            throw new RuntimeException('Unable to write to stream');
         }
 
         return $result;
@@ -211,20 +230,20 @@ class MockStream implements StreamInterface
     public function read($length): string
     {
         if (!$this->readable) {
-            throw new \RuntimeException('Cannot read from non-readable stream');
+            throw new RuntimeException('Cannot read from non-readable stream');
         }
 
-        return \fread($this->stream, $length);
+        return fread($this->stream, $length);
     }
 
     public function getContents(): string
     {
         if (!isset($this->stream)) {
-            throw new \RuntimeException('Unable to read stream contents');
+            throw new RuntimeException('Unable to read stream contents');
         }
 
-        if (false === $contents = \stream_get_contents($this->stream)) {
-            throw new \RuntimeException('Unable to read stream contents');
+        if (false === $contents = stream_get_contents($this->stream)) {
+            throw new RuntimeException('Unable to read stream contents');
         }
 
         return $contents;
@@ -235,10 +254,10 @@ class MockStream implements StreamInterface
         if (!isset($this->stream)) {
             return $key ? null : [];
         } elseif (null === $key) {
-            return \stream_get_meta_data($this->stream);
+            return stream_get_meta_data($this->stream);
         }
 
-        $meta = \stream_get_meta_data($this->stream);
+        $meta = stream_get_meta_data($this->stream);
 
         return isset($meta[$key]) ? $meta[$key] : null;
     }

--- a/tests/Mocks/MockStream.php
+++ b/tests/Mocks/MockStream.php
@@ -15,21 +15,21 @@ use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
-use function is_string;
-use function fopen;
-use function gettype;
-use function is_resource;
-use function fclose;
 use function clearstatcache;
+use function fclose;
+use function feof;
+use function fopen;
+use function fread;
+use function fseek;
 use function fstat;
 use function ftell;
-use function feof;
-use function fseek;
-use function var_export;
 use function fwrite;
-use function fread;
+use function gettype;
+use function is_resource;
+use function is_string;
 use function stream_get_contents;
 use function stream_get_meta_data;
+use function var_export;
 
 use const SEEK_SET;
 

--- a/tests/Mocks/MockStream.php
+++ b/tests/Mocks/MockStream.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -171,7 +172,7 @@ class MockStream implements StreamInterface
         } elseif (\fseek($this->stream, $offset, $whence) === -1) {
             throw new \RuntimeException(
                 'Unable to seek to stream position '
-                .$offset.' with whence '.\var_export($whence, true)
+                . $offset . ' with whence ' . \var_export($whence, true)
             );
         }
     }

--- a/tests/Mocks/RequestHandlerTest.php
+++ b/tests/Mocks/RequestHandlerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Mocks/RequestHandlerTest.php
+++ b/tests/Mocks/RequestHandlerTest.php
@@ -15,6 +15,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Slim\Tests\Providers\PSR7ObjectProvider;
 
+use function debug_backtrace;
+
 class RequestHandlerTest implements RequestHandlerInterface
 {
     public static $CalledCount = 0;

--- a/tests/Mocks/SlowPokeStream.php
+++ b/tests/Mocks/SlowPokeStream.php
@@ -13,6 +13,12 @@ namespace Slim\Tests\Mocks;
 use Exception;
 use Psr\Http\Message\StreamInterface;
 
+use function usleep;
+use function min;
+use function str_repeat;
+
+use const SEEK_SET;
+
 class SlowPokeStream implements StreamInterface
 {
     public const CHUNK_SIZE = 1;
@@ -83,7 +89,7 @@ class SlowPokeStream implements StreamInterface
 
     public function read($length)
     {
-        \usleep(1);
+        usleep(1);
         $size = min($this->amountToRead, self::CHUNK_SIZE, $length);
         $this->amountToRead -= $size;
         return str_repeat('.', $size);

--- a/tests/Mocks/SlowPokeStream.php
+++ b/tests/Mocks/SlowPokeStream.php
@@ -13,9 +13,9 @@ namespace Slim\Tests\Mocks;
 use Exception;
 use Psr\Http\Message\StreamInterface;
 
-use function usleep;
 use function min;
 use function str_repeat;
+use function usleep;
 
 use const SEEK_SET;
 

--- a/tests/Mocks/SlowPokeStream.php
+++ b/tests/Mocks/SlowPokeStream.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -14,8 +15,8 @@ use Psr\Http\Message\StreamInterface;
 
 class SlowPokeStream implements StreamInterface
 {
-    const CHUNK_SIZE = 1;
-    const SIZE = 500;
+    public const CHUNK_SIZE = 1;
+    public const SIZE = 500;
 
     /**
      * @var int

--- a/tests/Mocks/SmallChunksStream.php
+++ b/tests/Mocks/SmallChunksStream.php
@@ -13,6 +13,11 @@ namespace Slim\Tests\Mocks;
 use Exception;
 use Psr\Http\Message\StreamInterface;
 
+use function str_repeat;
+use function min;
+
+use const SEEK_SET;
+
 class SmallChunksStream implements StreamInterface
 {
     public const CHUNK_SIZE = 10;

--- a/tests/Mocks/SmallChunksStream.php
+++ b/tests/Mocks/SmallChunksStream.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -14,8 +15,8 @@ use Psr\Http\Message\StreamInterface;
 
 class SmallChunksStream implements StreamInterface
 {
-    const CHUNK_SIZE = 10;
-    const SIZE = 40;
+    public const CHUNK_SIZE = 10;
+    public const SIZE = 40;
 
     /**
      * @var int

--- a/tests/Mocks/SmallChunksStream.php
+++ b/tests/Mocks/SmallChunksStream.php
@@ -13,8 +13,8 @@ namespace Slim\Tests\Mocks;
 use Exception;
 use Psr\Http\Message\StreamInterface;
 
-use function str_repeat;
 use function min;
+use function str_repeat;
 
 use const SEEK_SET;
 

--- a/tests/Providers/PSR7ObjectProvider.php
+++ b/tests/Providers/PSR7ObjectProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Providers/PSR7ObjectProvider.php
+++ b/tests/Providers/PSR7ObjectProvider.php
@@ -19,8 +19,8 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 use function array_merge;
-use function time;
 use function microtime;
+use function time;
 
 /**
  * Class PSR7ObjectProvider

--- a/tests/Providers/PSR7ObjectProvider.php
+++ b/tests/Providers/PSR7ObjectProvider.php
@@ -18,6 +18,10 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
+use function array_merge;
+use function time;
+use function microtime;
+
 /**
  * Class PSR7ObjectProvider
  *

--- a/tests/Providers/PSR7ObjectProviderInterface.php
+++ b/tests/Providers/PSR7ObjectProviderInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -15,6 +15,25 @@ use Slim\Tests\Assets\HeaderStack;
 use Slim\Tests\Mocks\MockStream;
 use Slim\Tests\Mocks\SlowPokeStream;
 use Slim\Tests\Mocks\SmallChunksStream;
+use ReflectionClass;
+
+use function stream_get_filters;
+use function in_array;
+use function base64_decode;
+use function strlen;
+use function stream_filter_remove;
+use function stream_filter_append;
+use function fwrite;
+use function rewind;
+use function str_repeat;
+use function popen;
+use function trim;
+use function fopen;
+
+use const STREAM_FILTER_WRITE;
+use const STREAM_FILTER_READ;
+use const CONNECTION_ABORTED;
+use const CONNECTION_TIMEOUT;
 
 class ResponseEmitterTest extends TestCase
 {
@@ -295,7 +314,7 @@ class ResponseEmitterTest extends TestCase
 
         $responseEmitter = new ResponseEmitter();
 
-        $mirror = new \ReflectionClass(ResponseEmitter::class);
+        $mirror = new ReflectionClass(ResponseEmitter::class);
         $emitBodyMethod = $mirror->getMethod('emitBody');
         $emitBodyMethod->setAccessible(true);
         $emitBodyMethod->invoke($responseEmitter, $response);

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -10,30 +10,30 @@ declare(strict_types=1);
 
 namespace Slim\Tests;
 
+use ReflectionClass;
 use Slim\ResponseEmitter;
 use Slim\Tests\Assets\HeaderStack;
 use Slim\Tests\Mocks\MockStream;
 use Slim\Tests\Mocks\SlowPokeStream;
 use Slim\Tests\Mocks\SmallChunksStream;
-use ReflectionClass;
 
-use function stream_get_filters;
-use function in_array;
 use function base64_decode;
-use function strlen;
-use function stream_filter_remove;
-use function stream_filter_append;
+use function fopen;
 use function fwrite;
+use function in_array;
+use function popen;
 use function rewind;
 use function str_repeat;
-use function popen;
+use function stream_filter_append;
+use function stream_filter_remove;
+use function stream_get_filters;
+use function strlen;
 use function trim;
-use function fopen;
 
-use const STREAM_FILTER_WRITE;
-use const STREAM_FILTER_READ;
 use const CONNECTION_ABORTED;
 use const CONNECTION_TIMEOUT;
+use const STREAM_FILTER_READ;
+use const STREAM_FILTER_WRITE;
 
 class ResponseEmitterTest extends TestCase
 {

--- a/tests/Routing/DispatcherTest.php
+++ b/tests/Routing/DispatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Routing/DispatcherTest.php
+++ b/tests/Routing/DispatcherTest.php
@@ -19,6 +19,11 @@ use Slim\Routing\RouteCollector;
 use Slim\Routing\RoutingResults;
 use Slim\Tests\TestCase;
 
+use function dirname;
+use function uniqid;
+use function microtime;
+use function unlink;
+
 class DispatcherTest extends TestCase
 {
     public function testCreateDispatcher()

--- a/tests/Routing/DispatcherTest.php
+++ b/tests/Routing/DispatcherTest.php
@@ -20,8 +20,8 @@ use Slim\Routing\RoutingResults;
 use Slim\Tests\TestCase;
 
 use function dirname;
-use function uniqid;
 use function microtime;
+use function uniqid;
 use function unlink;
 
 class DispatcherTest extends TestCase

--- a/tests/Routing/FastRouteDispatcherTest.php
+++ b/tests/Routing/FastRouteDispatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *
@@ -14,6 +15,7 @@ use FastRoute\DataGenerator\GroupCountBased;
 use FastRoute\RouteCollector;
 use Slim\Routing\FastRouteDispatcher;
 use Slim\Tests\TestCase;
+
 use function FastRoute\simpleDispatcher;
 
 class FastRouteDispatcherTest extends TestCase

--- a/tests/Routing/RouteCollectorProxyTest.php
+++ b/tests/Routing/RouteCollectorProxyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Routing/RouteCollectorTest.php
+++ b/tests/Routing/RouteCollectorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Routing/RouteCollectorTest.php
+++ b/tests/Routing/RouteCollectorTest.php
@@ -20,6 +20,12 @@ use Slim\Routing\RouteCollector;
 use Slim\Routing\RouteCollectorProxy;
 use Slim\Tests\TestCase;
 
+use function file_exists;
+use function unlink;
+use function file_put_contents;
+use function sprintf;
+use function dirname;
+
 class RouteCollectorTest extends TestCase
 {
     /**

--- a/tests/Routing/RouteCollectorTest.php
+++ b/tests/Routing/RouteCollectorTest.php
@@ -20,11 +20,11 @@ use Slim\Routing\RouteCollector;
 use Slim\Routing\RouteCollectorProxy;
 use Slim\Tests\TestCase;
 
+use function dirname;
 use function file_exists;
-use function unlink;
 use function file_put_contents;
 use function sprintf;
-use function dirname;
+use function unlink;
 
 class RouteCollectorTest extends TestCase
 {

--- a/tests/Routing/RouteContextTest.php
+++ b/tests/Routing/RouteContextTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Routing/RouteParserTest.php
+++ b/tests/Routing/RouteParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Slim\Tests\Routing;

--- a/tests/Routing/RouteResolverTest.php
+++ b/tests/Routing/RouteResolverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Routing/RouteResolverTest.php
+++ b/tests/Routing/RouteResolverTest.php
@@ -19,6 +19,8 @@ use Slim\Routing\RouteResolver;
 use Slim\Routing\RoutingResults;
 use Slim\Tests\TestCase;
 
+use function sprintf;
+
 class RouteResolverTest extends TestCase
 {
     public function computeRoutingResultsDataProvider(): array

--- a/tests/Routing/RouteRunnerTest.php
+++ b/tests/Routing/RouteRunnerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -35,10 +35,10 @@ use Slim\Tests\Mocks\MockMiddlewareWithoutConstructor;
 use Slim\Tests\Mocks\MockMiddlewareWithoutInterface;
 use Slim\Tests\Mocks\RequestHandlerTest;
 
-use function is_string;
 use function is_callable;
-use function ob_start;
+use function is_string;
 use function ob_end_clean;
+use function ob_start;
 
 class RouteTest extends TestCase
 {

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -35,6 +35,11 @@ use Slim\Tests\Mocks\MockMiddlewareWithoutConstructor;
 use Slim\Tests\Mocks\MockMiddlewareWithoutInterface;
 use Slim\Tests\Mocks\RequestHandlerTest;
 
+use function is_string;
+use function is_callable;
+use function ob_start;
+use function ob_end_clean;
+
 class RouteTest extends TestCase
 {
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Slim Framework (https://slimframework.com)
  *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,50 @@
 
 declare(strict_types=1);
 
-require __DIR__ . '/../vendor/autoload.php';
+use AdrianSuter\Autoload\Override\Override;
+use Slim\ResponseEmitter;
+use Slim\Routing\RouteCollector;
+use Slim\Tests\Assets\HeaderStack;
 
-require __DIR__ . '/Assets/PhpFunctionOverrides.php';
-require __DIR__ . '/Assets/PhpRoutingFunctionOverrides.php';
+$classLoader = require __DIR__ . '/../vendor/autoload.php';
+
+//require __DIR__ . '/Assets/PhpFunctionOverrides.php';
+//require __DIR__ . '/Assets/PhpRoutingFunctionOverrides.php';
+
+Override::apply($classLoader, [
+    ResponseEmitter::class => [
+        'connection_status' => function (): int {
+            if (isset($GLOBALS['connection_status_return'])) {
+                return $GLOBALS['connection_status_return'];
+            }
+
+            return connection_status();
+        },
+        'header' => function (string $string, bool $replace = true, int $statusCode = null): void {
+            HeaderStack::push(
+                [
+                    'header' => $string,
+                    'replace' => $replace,
+                    'status_code' => $statusCode,
+                ]
+            );
+        },
+        'headers_sent' => function (): bool {
+            return false;
+        }
+    ],
+    RouteCollector::class => [
+        'is_readable' => function (string $file): bool {
+            if (stripos($file, 'non-readable.cache') !== false) {
+                return false;
+            }
+            return true;
+        },
+        'is_writable' => function (string $path): bool {
+            if (stripos($path, 'non-writable-directory') !== false) {
+                return false;
+            }
+            return true;
+        }
+    ]
+]);


### PR DESCRIPTION
PSR-12 expanded and replaced PSR-2. Can Slim switch to PSR-12 ?
[PSR-12: Extended Coding Style](https://www.php-fig.org/psr/psr-12/)

I also add fully-qualified function calls (`use function xxxx`). I didn't add 5 functions (`headers_sent`, `header`, `connection_status`, `is_readable` and `is_writable`) since we override them during tests (used on `ResponseEmitter` and `Routing/RouteCollector` classes).