### PR TITLE
Use autoload-dev with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Slim\\": "Slim",
+            "Slim\\": "Slim"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Slim\\Tests\\": "tests"
         }
     },


### PR DESCRIPTION
We can use autoload-dev for the namespace `Slim\Tests`. I don't see anything blocking.

[Link to composer doc](https://getcomposer.org/doc/04-schema.md#autoload-dev)