### PR TITLE
ResponseEmitter: Don't remove Content-Type and Content-Length when body is empty

### DIFF
--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -48,11 +48,6 @@ class ResponseEmitter
     {
         $isEmpty = $this->isResponseEmpty($response);
         if (headers_sent() === false) {
-            if ($isEmpty) {
-                $response = $response
-                    ->withoutHeader('Content-Type')
-                    ->withoutHeader('Content-Length');
-            }
             $this->emitStatusLine($response);
             $this->emitHeaders($response);
         }

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -58,42 +58,6 @@ class ResponseEmitterTest extends TestCase
         $this->expectOutputString('Hello');
     }
 
-    public function testResposeWithNoContentSkipsContentTypeAndContentLength()
-    {
-        $response = $this
-            ->createResponse()
-            ->withHeader('Content-Type', 'text/html')
-            ->withHeader('Content-Length', '4096')
-            ->withHeader('Cache-Control', 'no-cache');
-
-        $responseEmitter = new ResponseEmitter();
-        $responseEmitter->emit($response);
-
-        $this->assertFalse(HeaderStack::has('Content-Type'));
-        $this->assertFalse(HeaderStack::has('Content-Length'));
-        $this->assertTrue(HeaderStack::has('Cache-Control'));
-        $this->expectOutputString('');
-    }
-
-    public function testNonEmptyResponseDoesNotSkipContentTypeAndContentLength()
-    {
-        $response = $this
-            ->createResponse()
-            ->withHeader('Content-Type', 'text/html')
-            ->withHeader('Content-Length', '4096')
-            ->withHeader('Cache-Control', 'no-cache');
-
-        $response->getBody()->write('foo');
-
-        $responseEmitter = new ResponseEmitter();
-        $responseEmitter->emit($response);
-
-        $this->assertTrue(HeaderStack::has('Content-Type'));
-        $this->assertTrue(HeaderStack::has('Content-Length'));
-        $this->assertTrue(HeaderStack::has('Cache-Control'));
-        $this->expectOutputString('foo');
-    }
-
     public function testRespondWithPaddedStreamFilterOutput()
     {
         $availableFilter = stream_get_filters();


### PR DESCRIPTION
Fixes #2924

I am not really sure what would be the best way to allow users to control behavior here and I think trying to guess whether user wants this behavior (like by checking against well known `X-Accel-Redirect` header or `HEAD` method) is gonna end with unnecessary logic on our side as the list of conditions grows to accommodate different web servers and CDNs.

I am also not sure whether we need to grow ResponseEmitter by such logic. Correct me if I'm wrong, but I believe this would only get into play if user specifically set `->withHeader` on empty body before, right?