### PR TITLE
Test against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ matrix:
   include:
   - php: 7.2
   - php: 7.3
-    env: ANALYSIS='true'
   - php: 7.4
+    env: ANALYSIS='true'
   - php: nightly
 
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,8 @@
         "phpspec/prophecy": "^1.10",
         "phpstan/phpstan": "^0.11.5",
         "phpunit/phpunit": "^8.5",
-        "slim/http": "^0.7",
-        "slim/psr7": "^0.3",
+        "slim/http": "^1.0",
+        "slim/psr7": "^1.0",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {


### PR DESCRIPTION
As mentionned [here](https://github.com/slimphp/Slim/pull/2905#issuecomment-568439240), since Xdebug 2.9.1 have been released with PHP 7.4 on Travis, we can now test against PHP 7.4.

I also upgraded `slim/psr7` and `slim/http` to the first stable version (`^1.0`).