### PR TITLE
Modify usage of deprecated expectExceptionMessageRegExp() method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "nyholm/psr7-server": "^0.3.0",
         "phpspec/prophecy": "^1.10",
         "phpstan/phpstan": "^0.11.5",
-        "phpunit/phpunit": "^8.5|^9",
+        "phpunit/phpunit": "^8.5",
         "slim/http": "^1.0",
         "slim/psr7": "^1.0",
         "squizlabs/php_codesniffer": "^3.5"

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "nyholm/psr7-server": "^0.3.0",
         "phpspec/prophecy": "^1.10",
         "phpstan/phpstan": "^0.11.5",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.5|^9",
         "slim/http": "^1.0",
         "slim/psr7": "^1.0",
         "squizlabs/php_codesniffer": "^3.5"

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -283,7 +283,7 @@ class MiddlewareDispatcherTest extends TestCase
     public function testResolveThrowsExceptionWithoutContainerAndUnresolvableClass()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unresolvable::class does not exist');
+        $this->expectExceptionMessageMatches('/(Middleware|Callable) Unresolvable::class does not exist/');
 
         $handler = new MockRequestHandler();
         $middlewareDispatcher = $this->createMiddlewareDispatcher($handler, null);
@@ -296,7 +296,7 @@ class MiddlewareDispatcherTest extends TestCase
     public function testResolveThrowsExceptionWithoutContainerNonAdvancedCallableResolverAndUnresolvableClass()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unresolvable::class does not exist');
+        $this->expectExceptionMessageMatches('/(Middleware|Callable) Unresolvable::class does not exist/');
 
         $unresolvable = 'Unresolvable::class';
 

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -283,7 +283,7 @@ class MiddlewareDispatcherTest extends TestCase
     public function testResolveThrowsExceptionWithoutContainerAndUnresolvableClass()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('/(Middleware|Callable) Unresolvable::class does not exist/');
+        $this->expectExceptionMessage('Unresolvable::class does not exist');
 
         $handler = new MockRequestHandler();
         $middlewareDispatcher = $this->createMiddlewareDispatcher($handler, null);
@@ -296,7 +296,7 @@ class MiddlewareDispatcherTest extends TestCase
     public function testResolveThrowsExceptionWithoutContainerNonAdvancedCallableResolverAndUnresolvableClass()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageRegExp('/(Middleware|Callable) Unresolvable::class does not exist/');
+        $this->expectExceptionMessage('Unresolvable::class does not exist');
 
         $unresolvable = 'Unresolvable::class';
 


### PR DESCRIPTION
Fixes slimphp/Slim#2936