### PR TITLE
Minor optimizations in if() blocks

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -99,7 +99,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
         }
         if (is_string($toResolve)) {
             [$instance, $method] = $this->resolveSlimNotation($toResolve);
-            if ($predicate($instance) && $method === null) {
+            if ($method === null && $predicate($instance)) {
                 $method = $defaultMethod;
             }
             $resolved = [$instance, $method ?? '__invoke'];

--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -155,7 +155,7 @@ class AppFactory
             if ($psr17factory::isResponseFactoryAvailable()) {
                 $responseFactory = $psr17factory::getResponseFactory();
 
-                if ($psr17factory::isStreamFactoryAvailable() || static::$streamFactory) {
+                if (static::$streamFactory || $psr17factory::isStreamFactoryAvailable()) {
                     $streamFactory = static::$streamFactory ?? $psr17factory::getStreamFactory();
                     return static::attemptResponseFactoryDecoration($responseFactory, $streamFactory);
                 }

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -138,13 +138,15 @@ class ErrorMiddleware implements MiddlewareInterface
     {
         if (isset($this->handlers[$type])) {
             return $this->callableResolver->resolve($this->handlers[$type]);
-        } elseif (isset($this->subClassHandlers[$type])) {
+        }
+
+        if (isset($this->subClassHandlers[$type])) {
             return $this->callableResolver->resolve($this->subClassHandlers[$type]);
-        } else {
-            foreach ($this->subClassHandlers as $class => $handler) {
-                if (is_subclass_of($type, $class)) {
-                    return $this->callableResolver->resolve($handler);
-                }
+        }
+
+        foreach ($this->subClassHandlers as $class => $handler) {
+            if (is_subclass_of($type, $class)) {
+                return $this->callableResolver->resolve($handler);
             }
         }
 

--- a/tests/Mocks/MockStream.php
+++ b/tests/Mocks/MockStream.php
@@ -188,7 +188,9 @@ class MockStream implements StreamInterface
     {
         if (!$this->seekable) {
             throw new RuntimeException('Stream is not seekable');
-        } elseif (fseek($this->stream, $offset, $whence) === -1) {
+        }
+
+        if (fseek($this->stream, $offset, $whence) === -1) {
             throw new RuntimeException(
                 'Unable to seek to stream position '
                 . $offset . ' with whence ' . var_export($whence, true)
@@ -253,7 +255,9 @@ class MockStream implements StreamInterface
     {
         if (!isset($this->stream)) {
             return $key ? null : [];
-        } elseif (null === $key) {
+        }
+
+        if (null === $key) {
             return stream_get_meta_data($this->stream);
         }
 


### PR DESCRIPTION
A PR with a few micro-optimizations for performance and readability.

1. `if()` expression order

Expressions in `if()` are run left-to-right, and evaluating computationally smaller expressions can improve the performance a little bit. This PR contains two of such improvements where it puts `=== null` call and a truthy evaluation ahead of function calls. 

2. `if()`-`elseif()`-`else` branching optimizations. 

If such a block `return`s something, the execution of that function is complete, so we often do not need `elseif` or `else` blocks. While they don't provide any performance benefit, we take nested code outside, which reduces the cognitive load on developers. 