### PR TITLE
Strict empty string content type checking in BodyParsingMiddleware::getMediaType

### DIFF
--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -181,7 +181,7 @@ class BodyParsingMiddleware implements MiddlewareInterface
     {
         $contentType = $request->getHeader('Content-Type')[0] ?? null;
 
-        if (is_string($contentType) && trim($contentType) != '') {
+        if (is_string($contentType) && trim($contentType) !== '') {
             $contentTypeParts = explode(';', $contentType);
             return strtolower(trim($contentTypeParts[0]));
         }


### PR DESCRIPTION
`\Slim\Middleware\BodyParsingMiddleware::getMediaType()` method has a loose comparison operator, which can make the function return `(string) 0` when the request `content-type` header has a value of `(string) 0`. This is because PHP considers `0 == ''`.

While this is unhighlike unlikely that it will lead to a bug, because the body parsers need to be registered by the `content-type` header values, the `===` seems the accurate one to use to reduce this unexpected execution. 