### PR TITLE
Micro optimization: Declare closures in BodyParsingMiddleware as static

### DIFF
--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -102,7 +102,7 @@ class BodyParsingMiddleware implements MiddlewareInterface
 
     protected function registerDefaultBodyParsers(): void
     {
-        $this->registerBodyParser('application/json', function ($input) {
+        $this->registerBodyParser('application/json', static function ($input) {
             $result = json_decode($input, true);
 
             if (!is_array($result)) {
@@ -112,12 +112,12 @@ class BodyParsingMiddleware implements MiddlewareInterface
             return $result;
         });
 
-        $this->registerBodyParser('application/x-www-form-urlencoded', function ($input) {
+        $this->registerBodyParser('application/x-www-form-urlencoded', static function ($input) {
             parse_str($input, $data);
             return $data;
         });
 
-        $xmlCallable = function ($input) {
+        $xmlCallable = static function ($input) {
             $backup = libxml_disable_entity_loader(true);
             $backup_errors = libxml_use_internal_errors(true);
             $result = simplexml_load_string($input);


### PR DESCRIPTION
All three anonymous functions used in `BodyParsingMiddleware::registerDefaultBodyParsers()` method never uses `$this`, so we can declare them `static` to apply a micro-optimization, which makes engine not bind the `$this` object to the closure.