### PR TITLE
Split the routing results to its own function.

### DIFF
--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -72,10 +72,7 @@ class RoutingMiddleware implements MiddlewareInterface
      */
     public function performRouting(ServerRequestInterface $request): ServerRequestInterface
     {
-        $routingResults = $this->routeResolver->computeRoutingResults(
-            $request->getUri()->getPath(),
-            $request->getMethod()
-        );
+        $routingResults = $this->resolveRouteFromRequest($request);
         $routeStatus = $routingResults->getRouteStatus();
 
         $request = $request->withAttribute(RouteContext::ROUTING_RESULTS, $routingResults);
@@ -100,5 +97,19 @@ class RoutingMiddleware implements MiddlewareInterface
             default:
                 throw new RuntimeException('An unexpected error occurred while performing routing.');
         }
+    }
+
+    /**
+     * Resolves the route from the given request
+     *
+     * @param  ServerRequestInterface $request
+     * @return RoutingResults
+     */
+    protected function resolveRouteFromRequest(ServerRequestInterface $request)
+    {
+        return $this->routeResolver->computeRoutingResults(
+            $request->getUri()->getPath(),
+            $request->getMethod()
+        );
     }
 }

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -72,7 +72,7 @@ class RoutingMiddleware implements MiddlewareInterface
      */
     public function performRouting(ServerRequestInterface $request): ServerRequestInterface
     {
-        $routingResults = $this->resolveRouteFromRequest($request);
+        $routingResults = $this->resolveRoutingResultsFromRequest($request);
         $routeStatus = $routingResults->getRouteStatus();
 
         $request = $request->withAttribute(RouteContext::ROUTING_RESULTS, $routingResults);
@@ -105,7 +105,7 @@ class RoutingMiddleware implements MiddlewareInterface
      * @param  ServerRequestInterface $request
      * @return RoutingResults
      */
-    protected function resolveRouteFromRequest(ServerRequestInterface $request)
+    protected function resolveRoutingResultsFromRequest(ServerRequestInterface $request): RoutingResults
     {
         return $this->routeResolver->computeRoutingResults(
             $request->getUri()->getPath(),


### PR DESCRIPTION
This allows the core logic of the RoutingMiddleware to be extended, without having to copy & paste the core logic.