### PR TITLE
if else for get_magic_quotes_gpc usage

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -57,7 +57,11 @@ class Util
      */
     public static function stripSlashesIfMagicQuotes($rawData, $overrideStripSlashes = null)
     {
-        $strip = is_null($overrideStripSlashes) ? get_magic_quotes_gpc() : $overrideStripSlashes;
+        if (version_compare(PHP_VERSION, '7.3', '>')) {
+            $strip = true;
+        } else {
+            $strip = is_null($overrideStripSlashes) ? get_magic_quotes_gpc() : $overrideStripSlashes;
+        }
         if ($strip) {
             return self::stripSlashes($rawData);
         }


### PR DESCRIPTION
`get_magic_quotes_gpc` is deprecated since php7.4
https://www.php.net/manual/en/function.get-magic-quotes-gpc.php

With an if else condition, could this method used by 7.4 and greater ...