### PR TITLE
PHP 8 support

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -182,6 +182,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
             $callable = $callable[0];
         }
         if ($this->container && $callable instanceof Closure) {
+            /** @var Closure $callable */
             $callable = $callable->bindTo($this->container);
         }
         return $callable;

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -287,6 +287,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
         $next = $this->tip;
 
         if ($this->container && $middleware instanceof Closure) {
+            /** @var Closure $middleware */
             $middleware = $middleware->bindTo($this->container);
         }
 

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -369,10 +369,13 @@ class Route implements RouteInterface, RequestHandlerInterface
         }
         $strategy = $this->invocationStrategy;
 
+        /** @var string[] $strategyImplements */
+        $strategyImplements = class_implements($strategy);
+
         if (
             is_array($callable)
             && $callable[0] instanceof RequestHandlerInterface
-            && !in_array(RequestHandlerInvocationStrategyInterface::class, class_implements($strategy))
+            && !in_array(RequestHandlerInvocationStrategyInterface::class, $strategyImplements)
         ) {
             $strategy = new RequestHandler();
         }

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "wiki": "https://github.com/slimphp/Slim/wiki"
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "nikic/fast-route": "^1.3",
         "psr/container": "^1.0",
@@ -63,7 +63,7 @@
         "nyholm/psr7-server": "^1.0.0",
         "phpspec/prophecy": "^1.12",
         "phpstan/phpstan": "^0.12.54",
-        "phpunit/phpunit": "^8.5",
+        "phpunit/phpunit": "^8.5 || ^9.3",
         "slim/http": "^1.1",
         "slim/psr7": "^1.2",
         "squizlabs/php_codesniffer": "^3.5"

--- a/composer.json
+++ b/composer.json
@@ -65,8 +65,8 @@
         "phpspec/prophecy": "^1.12",
         "phpstan/phpstan": "^0.12.54",
         "phpunit/phpunit": "^8.5 || ^9.3",
-        "slim/http": "^1.1",
-        "slim/psr7": "^1.2",
+        "slim/http": "^1.2",
+        "slim/psr7": "^1.3",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1",
+        "weirdan/prophecy-shim": "^1.0 || ^2.0.2"
     },
     "require-dev": {
         "ext-simplexml": "*",

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -33,7 +33,10 @@ class AbstractErrorRendererTest extends TestCase
         $renderer = new HtmlErrorRenderer();
         $output = $renderer->__invoke($exception, true);
 
-        $this->assertRegExp('/.*The application could not run because of the following error:.*/', $output);
+        $this->assertMatchesRegularExpression(
+            '/.*The application could not run because of the following error:.*/',
+            $output
+        );
         $this->assertStringContainsString('Oops..', $output);
     }
 
@@ -43,7 +46,10 @@ class AbstractErrorRendererTest extends TestCase
         $renderer = new HtmlErrorRenderer();
         $output = $renderer->__invoke($exception, false);
 
-        $this->assertRegExp('/.*A website error has occurred. Sorry for the temporary inconvenience.*/', $output);
+        $this->assertMatchesRegularExpression(
+            '/.*A website error has occurred. Sorry for the temporary inconvenience.*/',
+            $output
+        );
         $this->assertStringNotContainsString('Oops..', $output);
     }
 
@@ -57,11 +63,11 @@ class AbstractErrorRendererTest extends TestCase
         $method->setAccessible(true);
         $output = $method->invoke($renderer, $exception);
 
-        $this->assertRegExp('/.*Type:*/', $output);
-        $this->assertRegExp('/.*Code:*/', $output);
-        $this->assertRegExp('/.*Message*/', $output);
-        $this->assertRegExp('/.*File*/', $output);
-        $this->assertRegExp('/.*Line*/', $output);
+        $this->assertMatchesRegularExpression('/.*Type:*/', $output);
+        $this->assertMatchesRegularExpression('/.*Code:*/', $output);
+        $this->assertMatchesRegularExpression('/.*Message*/', $output);
+        $this->assertMatchesRegularExpression('/.*File*/', $output);
+        $this->assertMatchesRegularExpression('/.*Line*/', $output);
     }
 
     public function testHTMLErrorRendererRenderHttpException()
@@ -204,11 +210,11 @@ class AbstractErrorRendererTest extends TestCase
         $method->setAccessible(true);
         $output = $method->invoke($renderer, $exception);
 
-        $this->assertRegExp('/.*Type:*/', $output);
-        $this->assertRegExp('/.*Code:*/', $output);
-        $this->assertRegExp('/.*Message*/', $output);
-        $this->assertRegExp('/.*File*/', $output);
-        $this->assertRegExp('/.*Line*/', $output);
+        $this->assertMatchesRegularExpression('/.*Type:*/', $output);
+        $this->assertMatchesRegularExpression('/.*Code:*/', $output);
+        $this->assertMatchesRegularExpression('/.*Message*/', $output);
+        $this->assertMatchesRegularExpression('/.*File*/', $output);
+        $this->assertMatchesRegularExpression('/.*Line*/', $output);
     }
 
     public function testPlainTextErrorRendererDisplaysErrorDetails()
@@ -219,7 +225,7 @@ class AbstractErrorRendererTest extends TestCase
         $renderer = new PlainTextErrorRenderer();
         $output = $renderer->__invoke($exception, true);
 
-        $this->assertRegExp('/Ooops.../', $output);
+        $this->assertMatchesRegularExpression('/Ooops.../', $output);
     }
 
     public function testPlainTextErrorRendererNotDisplaysErrorDetails()

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -118,6 +118,26 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertEquals(1, $handler->getCalledCount());
     }
 
+    public function testDeferredResolvedCallableWithDirectConstructorCall()
+    {
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $callableResolverProphecy
+            ->resolve(MockMiddlewareWithoutConstructor::class)
+            ->willThrow(new RuntimeException('Callable not available from resolver'))
+            ->shouldBeCalledOnce();
+
+        $handler = new MockRequestHandler();
+
+        $middlewareDispatcher = $this->createMiddlewareDispatcher($handler, null, $callableResolverProphecy->reveal());
+        $middlewareDispatcher->addDeferred(MockMiddlewareWithoutConstructor::class);
+
+        $request = $this->createServerRequest('/');
+        $middlewareDispatcher->handle($request);
+
+        $this->assertEquals(1, $handler->getCalledCount());
+    }
+
     public function deferredCallableProvider()
     {
         return [

--- a/tests/MigratePhpUnitDeprecations.php
+++ b/tests/MigratePhpUnitDeprecations.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Slim\Tests;
+
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+if (method_exists(PHPUnitTestCase::class, 'assertMatchesRegularExpression')) {
+    trait MigratePhpUnitDeprecations
+    {
+
+    }
+} else {
+    // @codingStandardsIgnoreStart
+    trait MigratePhpUnitDeprecations
+    {
+        // @codingStandardsIgnoreEnd
+        public static function assertMatchesRegularExpression(
+            string $pattern,
+            string $string,
+            string $message = ''
+        ): void {
+            static::assertRegExp($pattern, $string, $message);
+        }
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Slim\Tests;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -26,6 +27,9 @@ use Slim\Tests\Providers\PSR7ObjectProvider;
 
 abstract class TestCase extends PhpUnitTestCase
 {
+    use MigratePhpUnitDeprecations;
+    use ProphecyTrait;
+
     /**
      * @return ServerRequestFactoryInterface
      */


### PR DESCRIPTION
This PR allows Slim to be installed in PHP 8 and passes all the tests and checks.

History: I've raised some points in https://github.com/slimphp/Slim/issues/2977#issuecomment-703194522 and since that time I've worked around other repositories to make this possible. This is also my first open-source contribution to a major project :)

**Test fixes:**

* Added a test for an uncovered branch of `MiddlewareDispatcher->addDeferred`. PHPUnit 8 was miscalculating coverage – see https://coveralls.io/builds/33553304/source?filename=Slim/MiddlewareDispatcher.php.

**My questions:**

* I implemented `disableXmlEntityLoader` as a `private static method`. Is this okay? I thought about making it `protected` or extracting it to a class, but I'm unsure about creating new "contracts".
* Coverage – conditional call to `libxml_disable_entity_loader`. Is it okay to just `@codeCoverageIgnore` some part that will only run in PHP 7 or PHP 8? How should situations like this be handled?

**Dependencies:**  I have gone through all dependencies that are blocking the PHP 8 upgrade and temporarily linked to development branches where the PHP 8 issues are solved. Surely this must be addressed before this can be merged (this is isolated in a single commit that can be removed). Those are the open PRs, some by me and some by others:

* [x] https://github.com/slimphp/Slim-Psr7/pull/169
* [x] https://github.com/slimphp/Slim-Http/pull/142
* [x] https://github.com/php-fig/http-message-util/pull/19
* [x] https://github.com/Nyholm/psr7-server/pull/40
* [x] https://github.com/laminas/laminas-diactoros/pull/46
