### PR TITLE
Fix request creator factory test

### DIFF
--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -107,4 +107,22 @@ class ServerRequestCreatorFactoryTest extends TestCase
 
         $this->assertSame($serverRequestProphecy->reveal(), $serverRequestCreator->createServerRequestFromGlobals());
     }
+
+    public function testSetServerRequestCreatorWithDecorators()
+    {
+        ServerRequestCreatorFactory::setSlimHttpDecoratorsAutomaticDetection(true);
+        $serverRequestProphecy = $this->prophesize(ServerRequestInterface::class);
+
+        $serverRequestCreatorProphecy = $this->prophesize(ServerRequestCreatorInterface::class);
+        $serverRequestCreatorProphecy
+            ->createServerRequestFromGlobals()
+            ->willReturn($serverRequestProphecy->reveal())
+            ->shouldBeCalledOnce();
+
+        ServerRequestCreatorFactory::setServerRequestCreator($serverRequestCreatorProphecy->reveal());
+
+        $serverRequestCreator = ServerRequestCreatorFactory::create();
+
+        $this->assertInstanceOf(ServerRequest::class, $serverRequestCreator->createServerRequestFromGlobals());
+    }
 }

--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -90,8 +90,9 @@ class ServerRequestCreatorFactoryTest extends TestCase
         $this->assertInstanceOf(SlimServerRequest::class, $serverRequestCreator->createServerRequestFromGlobals());
     }
 
-    public function testSetServerRequestCreator()
+    public function testSetServerRequestCreatorWithoutDecorators()
     {
+        ServerRequestCreatorFactory::setSlimHttpDecoratorsAutomaticDetection(false);
         $serverRequestProphecy = $this->prophesize(ServerRequestInterface::class);
 
         $serverRequestCreatorProphecy = $this->prophesize(ServerRequestCreatorInterface::class);


### PR DESCRIPTION
Related to #2966 .

Before:

```
./vendor/bin/phpunit --filter 'Slim\\Tests\\Factory\\ServerRequestCreatorFactoryTest::testSetServerRequestCreator'

There was 1 failure:

1) Slim\Tests\Factory\ServerRequestCreatorFactoryTest::testSetServerRequestCreator
Failed asserting that two variables reference the same object.

/home/test/Slim/tests/Factory/ServerRequestCreatorFactoryTest.php:107

FAILURES!
Tests: 1, Assertions: 1, Failures: 1.
```

After:

```
./vendor/bin/phpunit --filter 'Slim\\Tests\\Factory\\ServerRequestCreatorFactoryTest::testSetServerRequestCreatorWithDecorators'

OK (1 test, 2 assertions)

./vendor/bin/phpunit --filter 'Slim\\Tests\\Factory\\ServerRequestCreatorFactoryTest::testSetServerRequestCreatorWithoutDecorators'

OK (1 test, 2 assertions)
```