### PR TITLE
Support for PHP 7.4

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -57,7 +57,7 @@ class Util
      */
     public static function stripSlashesIfMagicQuotes($rawData, $overrideStripSlashes = null)
     {
-        $strip = is_null($overrideStripSlashes) ? get_magic_quotes_gpc() : $overrideStripSlashes;
+        $strip = !is_null($overrideStripSlashes) ?? $overrideStripSlashes;
         if ($strip) {
             return self::stripSlashes($rawData);
         }


### PR DESCRIPTION
Function get_magic_quotes_gpc() is deprecated in PHP 7.4