### PR TITLE
Declare compatibility with PHP 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "wiki": "https://github.com/slimphp/Slim/wiki"
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "nikic/fast-route": "^1.3",
         "psr/container": "^1.0",


### PR DESCRIPTION
Slim 4 should not be declared as compatible with PHP 8.