### PR TITLE
Fix: FastRoute dispatcher and data generator should match

### DIFF
--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Slim\Routing;
 
+use FastRoute\DataGenerator\GroupCountBased;
 use FastRoute\RouteCollector as FastRouteCollector;
 use FastRoute\RouteParser\Std;
 use Slim\Interfaces\DispatcherInterface;
@@ -50,6 +51,7 @@ class Dispatcher implements DispatcherInterface
         if ($cacheFile) {
             /** @var FastRouteDispatcher $dispatcher */
             $dispatcher = \FastRoute\cachedDispatcher($routeDefinitionCallback, [
+                'dataGenerator' => GroupCountBased::class,
                 'dispatcher' => FastRouteDispatcher::class,
                 'routeParser' => new Std(),
                 'cacheFile' => $cacheFile,
@@ -57,6 +59,7 @@ class Dispatcher implements DispatcherInterface
         } else {
             /** @var FastRouteDispatcher $dispatcher */
             $dispatcher = \FastRoute\simpleDispatcher($routeDefinitionCallback, [
+                'dataGenerator' => GroupCountBased::class,
                 'dispatcher' => FastRouteDispatcher::class,
                 'routeParser' => new Std(),
             ]);


### PR DESCRIPTION
While testing with the `master` branch of [FastRoute](https://github.com/nikic/FastRoute), I found the following issue:

FastRoute has recently changed the default dispatcher to MarkBased, and Slim is based on GroupCountBased. The data generator should always match the dispatcher, so the data generator must be explicitly given to avoid breaking with future FastRoute releases.