### PR TITLE
weirdan/prophecy-shim must be a dev requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,8 +51,7 @@
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "psr/log": "^1.1",
-        "weirdan/prophecy-shim": "^1.0 || ^2.0.2"
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "ext-simplexml": "*",
@@ -67,7 +66,8 @@
         "phpunit/phpunit": "^8.5 || ^9.3",
         "slim/http": "^1.2",
         "slim/psr7": "^1.3",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.5",
+        "weirdan/prophecy-shim": "^1.0 || ^2.0.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As it is to support both PHPUnit 8 & 9, that dependency must be in dev requirement.
It breaks code from project using Slim with PHPUnit-Bridge for example. Anyway a PHPUnit related deps must not be in `require` but in `require-dev`.

Following https://github.com/slimphp/Slim/pull/3015
Related to that commit https://github.com/slimphp/Slim/pull/3015/commits/d971acb358660c171a9b61d2be28ec94f0414fd8