### PR TITLE
Allow "none" as SameSite value in cookies

### DIFF
--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -135,7 +135,7 @@ class Cookies implements CookiesInterface
             $result .= '; HttpOnly';
         }
 
-        if (isset($properties['samesite']) 
+        if (isset($properties['samesite'])
             && in_array(strtolower($properties['samesite']), ['lax', 'strict', 'none'], true)) {
             // While strtolower is needed for correct comparison, the RFC doesn't care about case
             $result .= '; SameSite=' . $properties['samesite'];

--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -136,8 +136,7 @@ class Cookies implements CookiesInterface
         }
 
         if (isset($properties['samesite']) 
-            && in_array(strtolower($properties['samesite']), ['lax', 'strict', 'none'], true)
-        ) {
+            && in_array(strtolower($properties['samesite']), ['lax', 'strict', 'none'], true)) {
             // While strtolower is needed for correct comparison, the RFC doesn't care about case
             $result .= '; SameSite=' . $properties['samesite'];
         }

--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -135,7 +135,7 @@ class Cookies implements CookiesInterface
             $result .= '; HttpOnly';
         }
 
-        if (isset($properties['samesite']) && in_array(strtolower($properties['samesite']), ['lax', 'strict'], true)) {
+        if (isset($properties['samesite']) && in_array(strtolower($properties['samesite']), ['lax', 'strict', 'none'], true)) {
             // While strtolower is needed for correct comparison, the RFC doesn't care about case
             $result .= '; SameSite=' . $properties['samesite'];
         }

--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -135,8 +135,7 @@ class Cookies implements CookiesInterface
             $result .= '; HttpOnly';
         }
 
-        if (
-            isset($properties['samesite']) 
+        if (isset($properties['samesite']) 
             && in_array(strtolower($properties['samesite']), ['lax', 'strict', 'none'], true)
         ) {
             // While strtolower is needed for correct comparison, the RFC doesn't care about case

--- a/Slim/Http/Cookies.php
+++ b/Slim/Http/Cookies.php
@@ -135,7 +135,10 @@ class Cookies implements CookiesInterface
             $result .= '; HttpOnly';
         }
 
-        if (isset($properties['samesite']) && in_array(strtolower($properties['samesite']), ['lax', 'strict', 'none'], true)) {
+        if (
+            isset($properties['samesite']) 
+            && in_array(strtolower($properties['samesite']), ['lax', 'strict', 'none'], true)
+        ) {
             // While strtolower is needed for correct comparison, the RFC doesn't care about case
             $result .= '; SameSite=' . $properties['samesite'];
         }


### PR DESCRIPTION
Hi,

"None" is a valid value for the SameSite attribute of cookies.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite