### PR TITLE
Cover App creation from AppFactory with empty Container

### DIFF
--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -333,4 +333,37 @@ class AppFactoryTest extends TestCase
         $this->assertSame($app->getRouteResolver(), $routeResolverProphecy->reveal());
         $this->assertSame($app->getMiddlewareDispatcher(), $middlewareDispatcherProphecy->reveal());
     }
+
+    public function testCreateAppWithEmptyContainer()
+    {
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+
+        $containerProphecy
+            ->has(ResponseFactoryInterface::class)
+            ->willReturn(false)
+            ->shouldBeCalledOnce();
+
+        $containerProphecy
+            ->has(CallableResolverInterface::class)
+            ->willReturn(false)
+            ->shouldBeCalledOnce();
+
+        $containerProphecy
+            ->has(RouteCollectorInterface::class)
+            ->willReturn(false)
+            ->shouldBeCalledOnce();
+
+        $containerProphecy
+            ->has(RouteResolverInterface::class)
+            ->willReturn(false)
+            ->shouldBeCalledOnce();
+
+        $containerProphecy
+            ->has(MiddlewareDispatcherInterface::class)
+            ->willReturn(false)
+            ->shouldBeCalledOnce();
+
+        AppFactory::setSlimHttpDecoratorsAutomaticDetection(false);
+        AppFactory::createFromContainer($containerProphecy->reveal());
+    }
 }


### PR DESCRIPTION
This test get the code coverage back to 100%. It checks `App` creation from `AppFactory::createFromContainer` is not failing when using empty `Container`.