### PR TITLE
removing obsolete get_magic_quotes_gpc usage

### DIFF
--- a/Slim/Http/Util.php
+++ b/Slim/Http/Util.php
@@ -55,14 +55,9 @@ class Util
      * @param  bool            $overrideStripSlashes
      * @return array|string
      */
-    public static function stripSlashesIfMagicQuotes($rawData, $overrideStripSlashes = null)
+    public static function stripSlashesIfMagicQuotes($rawData, $overrideStripSlashes = false)
     {
-        $strip = is_null($overrideStripSlashes) ? get_magic_quotes_gpc() : $overrideStripSlashes;
-        if ($strip) {
-            return self::stripSlashes($rawData);
-        }
-
-        return $rawData;
+        return $overrideStripSlashes ? self::stripSlashes($rawData) : $rawData;
     }
 
     /**


### PR DESCRIPTION
I know that Slim V2 is no longer supported and we actively use Slim V4 mostly but I still support some isolated Slim V2 dependent components that need to be updated to PHP 7.4 but would require dramatically more effort to update to Slim V4. Any chance we can provide a small update to the Slim V2 project so it's functional with PHP 7.4?