### PR TITLE
Update Container.php get and has methods

### DIFF
--- a/Slim/Container.php
+++ b/Slim/Container.php
@@ -100,7 +100,7 @@ class Container extends PimpleContainer implements ContainerInterface
      * @throws ContainerValueNotFoundException  No entry was found for this identifier.
      * @throws ContainerExceptionInterface      Error while retrieving the entry.
      */
-    public function get($id)
+    public function get(string $id)
     {
         if (!$this->offsetExists($id)) {
             throw new ContainerValueNotFoundException(sprintf('Identifier "%s" is not defined.', $id));
@@ -143,7 +143,7 @@ class Container extends PimpleContainer implements ContainerInterface
      *
      * @return boolean
      */
-    public function has($id)
+    public function has(string $id)
     {
         return $this->offsetExists($id);
     }


### PR DESCRIPTION
after breaking change in prs/container 1.1.1 the `get` and the `has` method definitions are changed so for the slim version 3.x which is using psr/container : "^1.0" there will be a fatal error. this commit will fix this issue 

https://github.com/php-fig/container/issues/30#issuecomment-791530874