### PR TITLE
Allow ^1.0 || ^2.0 in psr/container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "php": "^7.2 || ^8.0",
         "ext-json": "*",
         "nikic/fast-route": "^1.3",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0 || ^2.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",


### PR DESCRIPTION
FIG released a new version of `psr/container` today. The new 2.x series has parameter types and return types, but it does not remove any methods. 

Technically, we are compatible with any `psr/container ^1.0 || ^2.0` implementation. This PR updates the required `psr/container` versions to include 2.x as well, so users can use any `psr/container` implementation, including ones that implement the new version.

I use my own container implementation with `phpwatch/simple-container`, that just tagged 2.0.0 with `psr/container ^2.0` requirement. I think other containers will follow suit in coming weeks. 

Thank you.
