### PR TITLE
Classname/Method Callable Arrays

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -51,6 +51,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
      */
     public function resolve($toResolve): callable
     {
+        $toResolve = $this->prepareToResolve($toResolve);
         if (is_callable($toResolve)) {
             return $this->bindToContainer($toResolve);
         }
@@ -90,6 +91,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
      */
     private function resolveByPredicate($toResolve, callable $predicate, string $defaultMethod): callable
     {
+        $toResolve = $this->prepareToResolve($toResolve);
         if (is_callable($toResolve)) {
             return $this->bindToContainer($toResolve);
         }
@@ -186,5 +188,23 @@ final class CallableResolver implements AdvancedCallableResolverInterface
             $callable = $callable->bindTo($this->container);
         }
         return $callable;
+    }
+
+    /**
+     * @param string|callable $toResolve
+     * @return string|callable
+     */
+    private function prepareToResolve($toResolve)
+    {
+        if (!is_array($toResolve)) {
+            return $toResolve;
+        }
+        $array = $toResolve;
+        $class = array_shift($array);
+        $method = array_shift($array);
+        if (is_string($class) && is_string($method)) {
+            return $class . ':' . $method;
+        }
+        return $toResolve;
     }
 }

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -146,6 +146,9 @@ final class CallableResolver implements AdvancedCallableResolverInterface
             $instance = $this->container->get($class);
         } else {
             if (!class_exists($class)) {
+                if ($method) {
+                    $class .= '::' . $method . '()';
+                }
                 throw new RuntimeException(sprintf('Callable %s does not exist', $class));
             }
             $instance = new $class($this->container);

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -199,9 +199,9 @@ final class CallableResolver implements AdvancedCallableResolverInterface
         if (!is_array($toResolve)) {
             return $toResolve;
         }
-        $array = $toResolve;
-        $class = array_shift($array);
-        $method = array_shift($array);
+        $candidate = $toResolve;
+        $class = array_shift($candidate);
+        $method = array_shift($candidate);
         if (is_string($class) && is_string($method)) {
             return $class . ':' . $method;
         }

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -133,6 +133,23 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(3, CallableTest::$CalledCount);
     }
 
+    public function testSlimCallableAsArray()
+    {
+        $resolver = new CallableResolver(); // No container injected
+        $callable = $resolver->resolve([CallableTest::class, 'toCall']);
+        $callableRoute = $resolver->resolveRoute([CallableTest::class, 'toCall']);
+        $callableMiddleware = $resolver->resolveMiddleware([CallableTest::class, 'toCall']);
+
+        $callable();
+        $this->assertEquals(1, CallableTest::$CalledCount);
+
+        $callableRoute();
+        $this->assertEquals(2, CallableTest::$CalledCount);
+
+        $callableMiddleware();
+        $this->assertEquals(3, CallableTest::$CalledCount);
+    }
+
     public function testSlimCallableContainer()
     {
         /** @var ContainerInterface $container */
@@ -147,6 +164,23 @@ class CallableResolverTest extends TestCase
 
         CallableTest::$CalledContainer = null;
         $resolver->resolveMiddleware('Slim\Tests\Mocks\CallableTest:toCall');
+        $this->assertEquals($container, CallableTest::$CalledContainer);
+    }
+
+    public function testSlimCallableAsArrayContainer()
+    {
+        /** @var ContainerInterface $container */
+        $container = $this->containerProphecy->reveal();
+        $resolver = new CallableResolver($container);
+        $resolver->resolve([CallableTest::class, 'toCall']);
+        $this->assertEquals($container, CallableTest::$CalledContainer);
+
+        CallableTest::$CalledContainer = null;
+        $resolver->resolveRoute([CallableTest::class, 'toCall']);
+        $this->assertEquals($container, CallableTest::$CalledContainer);
+
+        CallableTest::$CalledContainer = null;
+        $resolver->resolveMiddleware([CallableTest::class ,'toCall']);
         $this->assertEquals($container, CallableTest::$CalledContainer);
     }
 
@@ -474,7 +508,7 @@ class CallableResolverTest extends TestCase
     public function testCallableClassNotFoundThrowException()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('is not resolvable');
+        $this->expectExceptionMessage('Callable Unknown does not exist');
 
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
@@ -485,7 +519,7 @@ class CallableResolverTest extends TestCase
     public function testRouteCallableClassNotFoundThrowException()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('is not resolvable');
+        $this->expectExceptionMessage('Callable Unknown does not exist');
 
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
@@ -496,7 +530,7 @@ class CallableResolverTest extends TestCase
     public function testMiddlewareCallableClassNotFoundThrowException()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('is not resolvable');
+        $this->expectExceptionMessage('Callable Unknown does not exist');
 
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -475,7 +475,7 @@ class CallableResolverTest extends TestCase
     public function testClassNotFoundThrowException()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Callable Unknown does not exist');
+        $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
 
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
@@ -486,7 +486,7 @@ class CallableResolverTest extends TestCase
     public function testRouteClassNotFoundThrowException()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Callable Unknown does not exist');
+        $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
 
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
@@ -497,7 +497,7 @@ class CallableResolverTest extends TestCase
     public function testMiddlewareClassNotFoundThrowException()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Callable Unknown does not exist');
+        $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
 
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
@@ -508,7 +508,7 @@ class CallableResolverTest extends TestCase
     public function testCallableClassNotFoundThrowException()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Callable Unknown does not exist');
+        $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
 
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
@@ -519,7 +519,7 @@ class CallableResolverTest extends TestCase
     public function testRouteCallableClassNotFoundThrowException()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Callable Unknown does not exist');
+        $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
 
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
@@ -530,7 +530,7 @@ class CallableResolverTest extends TestCase
     public function testMiddlewareCallableClassNotFoundThrowException()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Callable Unknown does not exist');
+        $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
 
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();


### PR DESCRIPTION
These changes will allow the route handler to be specified as an array. This allows you to open the handler method in PhPStorm in ctrl + click, and also allows you to avoid the "unused method" type of bindings. 

For example:

```php
<?php

$app->get('/', [App\Controllers\PageController::class, 'home'])->setName('home');
```