### PR TITLE
Don't use libxml_disable_entity_loader when deprecated

### DIFF
--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -205,10 +205,10 @@ class Request extends Message implements ServerRequestInterface
         });
 
         $this->registerMediaTypeParser('application/xml', function ($input) {
-            $backup = libxml_disable_entity_loader(true);
+            $backup = self::disableXmlEntityLoader(true);
             $backup_errors = libxml_use_internal_errors(true);
             $result = simplexml_load_string($input);
-            libxml_disable_entity_loader($backup);
+            self::disableXmlEntityLoader($backup);
             libxml_clear_errors();
             libxml_use_internal_errors($backup_errors);
             if ($result === false) {
@@ -218,10 +218,10 @@ class Request extends Message implements ServerRequestInterface
         });
 
         $this->registerMediaTypeParser('text/xml', function ($input) {
-            $backup = libxml_disable_entity_loader(true);
+            $backup = self::disableXmlEntityLoader(true);
             $backup_errors = libxml_use_internal_errors(true);
             $result = simplexml_load_string($input);
-            libxml_disable_entity_loader($backup);
+            self::disableXmlEntityLoader($backup);
             libxml_clear_errors();
             libxml_use_internal_errors($backup_errors);
             if ($result === false) {
@@ -1207,5 +1207,18 @@ class Request extends Message implements ServerRequestInterface
         }
 
         return $params;
+    }
+    
+    private static function disableXmlEntityLoader($disable)
+    {
+        if (\LIBXML_VERSION >= 20900) {
+            // libxml >= 2.9.0 disables entity loading by default, so it is
+            // safe to skip the real call (deprecated in PHP 8).
+            return true;
+        }
+
+        // @codeCoverageIgnoreStart
+        return libxml_disable_entity_loader($disable);
+        // @codeCoverageIgnoreEnd
     }
 }


### PR DESCRIPTION
Backports the important bit of https://github.com/slimphp/Slim-Http/commit/4715329d4241008a36f0cd479c310f505cfdcea0

You're on your own for full test suite to maintain PHP 5.5 compatibility, but this is the only thing I've run into where PHP 8 is a problem.