### PR TITLE
Allow updated psr log

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
   ignore:
   - dependency-name: phpunit/phpunit
     versions:
-    - 8.5.14
+    - "8.5.*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,5 +47,5 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          composer require php-coveralls/php-coveralls -n
+          composer require php-coveralls/php-coveralls -n -W
           vendor/bin/php-coveralls --coverage_clover=clover.xml -v

--- a/Slim/Logger.php
+++ b/Slim/Logger.php
@@ -14,6 +14,8 @@ use Psr\Log\AbstractLogger;
 use Psr\Log\InvalidArgumentException;
 use Stringable;
 
+use function error_log;
+
 class Logger extends AbstractLogger
 {
     /**

--- a/Slim/Logger.php
+++ b/Slim/Logger.php
@@ -12,20 +12,21 @@ namespace Slim;
 
 use Psr\Log\AbstractLogger;
 use Psr\Log\InvalidArgumentException;
+use Stringable;
 
 class Logger extends AbstractLogger
 {
     /**
-     * @param mixed        $level
-     * @param string       $message
-     * @param array<mixed> $context
+     * @param mixed             $level
+     * @param string|Stringable $message
+     * @param array<mixed>      $context
      *
      * @return void
      *
      * @throws InvalidArgumentException
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
-        error_log($message);
+        error_log((string) $message);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -51,23 +51,23 @@
         "psr/http-message": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "ext-simplexml": "*",
         "adriansuter/php-autoload-override": "^1.2",
-        "guzzlehttp/psr7": "^1.8",
-        "http-interop/http-factory-guzzle": "^1.0",
+        "guzzlehttp/psr7": "^2.0",
+        "http-interop/http-factory-guzzle": "^1.1",
         "laminas/laminas-diactoros": "^2.4",
         "nyholm/psr7": "^1.4",
-        "nyholm/psr7-server": "^1.0.2",
+        "nyholm/psr7-server": "^1.0",
         "phpspec/prophecy": "^1.13",
-        "phpstan/phpstan": "^0.12.90",
-        "phpunit/phpunit": "^8.5.13 || ^9.3.8",
+        "phpstan/phpstan": "^0.12.94",
+        "phpunit/phpunit": "^8.5 || ^9.5",
         "slim/http": "^1.2",
         "slim/psr7": "^1.4",
         "squizlabs/php_codesniffer": "^3.6",
-        "weirdan/prophecy-shim": "^1.0 || ^2.0.2"
+        "weirdan/prophecy-shim": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
SlimPHP is easily compatible with `psr/log` `^2.0` and `^3.0`.
String cast has be added to `\Slim\Logger` class since `\error_log` function takes a string as parameter.

To complete: Should we remove PHP 7.2 support ? Some dependencies of composer.json could not be updated to their higher version since most of them remove PHP 7.2 support. **This PHPversion is EOL for 8 months (30 Nov 2020).**
If needed, I can make another PR for this.

Closes #3096 
Closes #3097 
Closes #3098 