### PR TITLE
Use PSR-17 factory from Guzzle/psr7 2.0

### DIFF
--- a/Slim/Factory/Psr17/GuzzlePsr17Factory.php
+++ b/Slim/Factory/Psr17/GuzzlePsr17Factory.php
@@ -12,8 +12,8 @@ namespace Slim\Factory\Psr17;
 
 class GuzzlePsr17Factory extends Psr17Factory
 {
-    protected static $responseFactoryClass = 'Http\Factory\Guzzle\ResponseFactory';
-    protected static $streamFactoryClass = 'Http\Factory\Guzzle\StreamFactory';
+    protected static $responseFactoryClass = 'GuzzleHttp\Psr7\HttpFactory';
+    protected static $streamFactoryClass = 'GuzzleHttp\Psr7\HttpFactory';
     protected static $serverRequestCreatorClass = 'GuzzleHttp\Psr7\ServerRequest';
     protected static $serverRequestCreatorMethod = 'fromGlobals';
 }

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,6 @@
         "ext-simplexml": "*",
         "adriansuter/php-autoload-override": "^1.2",
         "guzzlehttp/psr7": "^2.0",
-        "http-interop/http-factory-guzzle": "^1.2",
         "laminas/laminas-diactoros": "^2.6",
         "nyholm/psr7": "^1.4",
         "nyholm/psr7-server": "^1.0",

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Factory;
 
-use Http\Factory\Guzzle\ResponseFactory as GuzzleResponseFactory;
+use GuzzleHttp\Psr7\HttpFactory;
 use Laminas\Diactoros\ResponseFactory as LaminasDiactorosResponseFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
@@ -46,7 +46,7 @@ class AppFactoryTest extends TestCase
         return [
             [SlimPsr17Factory::class, SlimResponseFactory::class],
             [NyholmPsr17Factory::class, Psr17Factory::class],
-            [GuzzlePsr17Factory::class, GuzzleResponseFactory::class],
+            [GuzzlePsr17Factory::class, HttpFactory::class],
             [LaminasDiactorosPsr17Factory::class, LaminasDiactorosResponseFactory::class],
             [ZendDiactorosPsr17Factory::class, ZendDiactorosResponseFactory::class],
         ];


### PR DESCRIPTION
`http-interop/http-factory-guzzle` recommends to use PSR-17 implementation from `guzzlehttp/psr7` if we can use version `^2.0`. Since it matches our dependencies, I replaced old package with the new one.
Users can still use `http-interop/http-factory-guzzle` if they add it manually.

Closes #3105 