### PR TITLE
Update README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@ Slim is a PHP micro-framework that helps you quickly write simple yet powerful w
 It's recommended that you use [Composer](https://getcomposer.org/) to install Slim.
 
 ```bash
-$ composer require slim/slim:^4.0
+$ composer require slim/slim
 ```
 
-This will install Slim and all required dependencies. Slim requires PHP 7.2 or newer.
+This will install Slim and all required dependencies. Slim requires PHP 7.3 or newer.
 
 ## Choose a PSR-7 Implementation & ServerRequest Creator
 
 Before you can get up and running with Slim you will need to choose a PSR-7 implementation that best fits your application. A few notable ones:
 - [Slim-Psr7](https://github.com/slimphp/Slim-Psr7) - This is the Slim Framework PSR-7 implementation
 - [Nyholm/psr7](https://github.com/Nyholm/psr7) & [Nyholm/psr7-server](https://github.com/Nyholm/psr7-server) - This is the fastest, strictest and most lightweight implementation available
-- [Guzzle/psr7](https://github.com/guzzle/psr7) & [http-interop/http-factory-guzzle](https://github.com/http-interop/http-factory-guzzle) - This is the implementation used by the Guzzle Client, featuring extra functionality for stream and file handling
+- [Guzzle/psr7](https://github.com/guzzle/psr7) - This is the implementation used by the Guzzle Client, featuring extra functionality for stream and file handling
 - [laminas-diactoros](https://github.com/laminas/laminas-diactoros) - This is the Laminas (Zend) PSR-7 implementation
 
 
@@ -54,7 +54,7 @@ $app = AppFactory::create();
 In order for auto-detection to work and enable you to use `AppFactory::create()` and `App::run()` without having to manually create a `ServerRequest` you need to install one of the following implementations:
 - [Slim-Psr7](https://github.com/slimphp/Slim-Psr7) - Install using `composer require slim/psr7`
 - [Nyholm/psr7](https://github.com/Nyholm/psr7) & [Nyholm/psr7-server](https://github.com/Nyholm/psr7-server) - Install using `composer require nyholm/psr7 nyholm/psr7-server`
-- [Guzzle/psr7](https://github.com/guzzle/psr7) & [http-interop/http-factory-guzzle](https://github.com/http-interop/http-factory-guzzle) - Install using `composer require guzzlehttp/psr7 http-interop/http-factory-guzzle`
+- [Guzzle/psr7](https://github.com/guzzle/psr7) - Install using `composer require guzzlehttp/psr7`
 - [laminas-diactoros](https://github.com/laminas/laminas-diactoros) - Install using `composer require laminas/laminas-diactoros`
 
 Then create file _public/index.php_.

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "nyholm/psr7-server": "^1.0",
         "phpspec/prophecy": "^1.13",
         "phpspec/prophecy-phpunit": "^2.0",
-        "phpstan/phpstan": "^0.12.94",
+        "phpstan/phpstan": "^0.12.96",
         "phpunit/phpunit": "^9.5",
         "slim/http": "^1.2",
         "slim/psr7": "^1.4",


### PR DESCRIPTION
Since we dropped PHP 7.2 and Guzzle PSR-7 packages does not requires `http-interop/http-factory-guzzle` anymore.


EDIT:
`Tests PHP 7.2` from GitHub CI should be removed from expected tests since we removed it from our configuration.