### PR TITLE
Add a new PSR-17 factory to Psr17FactoryProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This will install Slim and all required dependencies. Slim requires PHP 7.3 or n
 
 Before you can get up and running with Slim you will need to choose a PSR-7 implementation that best fits your application. A few notable ones:
 - [Slim-Psr7](https://github.com/slimphp/Slim-Psr7) - This is the Slim Framework PSR-7 implementation
-- [Nyholm/psr7](https://github.com/Nyholm/psr7) & [Nyholm/psr7-server](https://github.com/Nyholm/psr7-server) - This is the fastest, strictest and most lightweight implementation available
+- [httpsoft/http-message](https://github.com/httpsoft/http-message) & [httpsoft/http-server-request](https://github.com/httpsoft/http-server-request) - This is the fastest, strictest and most lightweight implementation available
+- [Nyholm/psr7](https://github.com/Nyholm/psr7) & [Nyholm/psr7-server](https://github.com/Nyholm/psr7-server) - Performance is almost the same as the HttpSoft implementation
 - [Guzzle/psr7](https://github.com/guzzle/psr7) - This is the implementation used by the Guzzle Client, featuring extra functionality for stream and file handling
 - [laminas-diactoros](https://github.com/laminas/laminas-diactoros) - This is the Laminas (Zend) PSR-7 implementation
 
@@ -53,6 +54,8 @@ $app = AppFactory::create();
 ## Hello World using AppFactory with PSR-7 auto-detection
 In order for auto-detection to work and enable you to use `AppFactory::create()` and `App::run()` without having to manually create a `ServerRequest` you need to install one of the following implementations:
 - [Slim-Psr7](https://github.com/slimphp/Slim-Psr7) - Install using `composer require slim/psr7`
+- [httpsoft/http-message](https://github.com/httpsoft/http-message) & [httpsoft/http-server-request](https://github.com/httpsoft/http-server-request) - Install using:
+`composer require httpsoft/http-message httpsoft/http-server-request`
 - [Nyholm/psr7](https://github.com/Nyholm/psr7) & [Nyholm/psr7-server](https://github.com/Nyholm/psr7-server) - Install using `composer require nyholm/psr7 nyholm/psr7-server`
 - [Guzzle/psr7](https://github.com/guzzle/psr7) - Install using `composer require guzzlehttp/psr7`
 - [laminas-diactoros](https://github.com/laminas/laminas-diactoros) - Install using `composer require laminas/laminas-diactoros`

--- a/Slim/Factory/Psr17/HttpSoftPsr17Factory.php
+++ b/Slim/Factory/Psr17/HttpSoftPsr17Factory.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Factory\Psr17;
+
+class HttpSoftPsr17Factory extends Psr17Factory
+{
+    protected static $responseFactoryClass = 'HttpSoft\Message\ResponseFactory';
+    protected static $streamFactoryClass = 'HttpSoft\Message\StreamFactory';
+    protected static $serverRequestCreatorClass = 'HttpSoft\ServerRequest\ServerRequestCreator';
+    protected static $serverRequestCreatorMethod = 'createFromGlobals';
+}

--- a/Slim/Factory/Psr17/Psr17FactoryProvider.php
+++ b/Slim/Factory/Psr17/Psr17FactoryProvider.php
@@ -21,6 +21,7 @@ class Psr17FactoryProvider implements Psr17FactoryProviderInterface
      */
     protected static $factories = [
         SlimPsr17Factory::class,
+        HttpSoftPsr17Factory::class,
         NyholmPsr17Factory::class,
         LaminasDiactorosPsr17Factory::class,
         GuzzlePsr17Factory::class,

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,8 @@
         "ext-simplexml": "*",
         "adriansuter/php-autoload-override": "^1.2",
         "guzzlehttp/psr7": "^2.0",
+        "httpsoft/http-message": "^1.0",
+        "httpsoft/http-server-request": "^1.0",
         "laminas/laminas-diactoros": "^2.8",
         "nyholm/psr7": "^1.4",
         "nyholm/psr7-server": "^1.0",

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -12,6 +12,7 @@ namespace Slim\Tests\Factory;
 
 use GuzzleHttp\Psr7\HttpFactory;
 use Laminas\Diactoros\ResponseFactory as LaminasDiactorosResponseFactory;
+use HttpSoft\Message\ResponseFactory as HttpSoftResponseFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -21,6 +22,7 @@ use ReflectionProperty;
 use RuntimeException;
 use Slim\Factory\AppFactory;
 use Slim\Factory\Psr17\GuzzlePsr17Factory;
+use Slim\Factory\Psr17\HttpSoftPsr17Factory;
 use Slim\Factory\Psr17\LaminasDiactorosPsr17Factory;
 use Slim\Factory\Psr17\NyholmPsr17Factory;
 use Slim\Factory\Psr17\Psr17FactoryProvider;
@@ -43,6 +45,7 @@ class AppFactoryTest extends TestCase
     {
         return [
             [SlimPsr17Factory::class, SlimResponseFactory::class],
+            [HttpSoftPsr17Factory::class, HttpSoftResponseFactory::class],
             [NyholmPsr17Factory::class, Psr17Factory::class],
             [GuzzlePsr17Factory::class, HttpFactory::class],
             [LaminasDiactorosPsr17Factory::class, LaminasDiactorosResponseFactory::class],

--- a/tests/Factory/ServerRequestCreatorFactoryTest.php
+++ b/tests/Factory/ServerRequestCreatorFactoryTest.php
@@ -13,9 +13,11 @@ namespace Slim\Tests\Factory;
 use GuzzleHttp\Psr7\ServerRequest as GuzzleServerRequest;
 use Laminas\Diactoros\ServerRequest as LaminasDiactorosServerRequest;
 use Nyholm\Psr7\ServerRequest as NyholmServerRequest;
+use HttpSoft\Message\ServerRequest as HttpSoftServerRequest;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use Slim\Factory\Psr17\GuzzlePsr17Factory;
+use Slim\Factory\Psr17\HttpSoftPsr17Factory;
 use Slim\Factory\Psr17\LaminasDiactorosPsr17Factory;
 use Slim\Factory\Psr17\NyholmPsr17Factory;
 use Slim\Factory\Psr17\Psr17FactoryProvider;
@@ -33,6 +35,7 @@ class ServerRequestCreatorFactoryTest extends TestCase
     {
         return [
             [SlimPsr17Factory::class, SlimServerRequest::class],
+            [HttpSoftPsr17Factory::class, HttpSoftServerRequest::class],
             [NyholmPsr17Factory::class, NyholmServerRequest::class],
             [GuzzlePsr17Factory::class, GuzzleServerRequest::class],
             [LaminasDiactorosPsr17Factory::class, LaminasDiactorosServerRequest::class],


### PR DESCRIPTION
There is curious performance benchmark of the PSR-7 and PSR-17 implementations (Guzzle, HttpSoft, Laminas, Nyholm, Slim) - https://github.com/devanych/psr-http-benchmark.

The fastest is HttpSoft, the slowest - Slim.

So I've added `HttpSoftPsr17Factory` to the Slim's factory set to give users the possibility to use the `HttpSoft` implementation of the PSR-7.

What was generally done:

**1\)** Adding `HttpSoftPsr17Factory::class` to the `$factories` property of the `Slim\Factory\Psr17\Psr17FactoryProvider` class

```php
protected static $factories = [
    SlimPsr17Factory::class,
    HttpSoftPsr17Factory::class,
    NyholmPsr17Factory::class,
    LaminasDiactorosPsr17Factory::class,
    GuzzlePsr17Factory::class,
];
```
I placed the class for the second position because it's the fastest implementation of the PSR-7 according to the benchmark. But the Slim's implementation remains in first place because I think it's normal to give priority to packages from the Slim's ecosystem.

**2\)** Adding the new `HttpSoftPsr17Factory` class to the Slim/Factory/Psr17 folder

**3\)** Adding the [httpsoft/http-message](https://github.com/httpsoft/http-message) and [httpsoft/http-server-request](https://github.com/httpsoft/http-server-request) packages to the `composer.json` file (--dev section)

**4\)** Adding `[HttpSoftPsr17Factory::class, HttpSoftServerRequest::class]` to the `provideImplementations()` method in the `ServerRequestCreatorFactoryTest` class

**5\)** Adding `[HttpSoftPsr17Factory::class, HttpSoftResponseFactory::class]` to the `provideImplementations()` method in the `AppFactoryTest` class

**6\)** Editing `README.md` (added a mention of the HttpSoft PSR-7 implementation along with other implementations)

### About tests

- There were: 420 tests, 779 assertions
- Became: 422 tests, 781 assertions