### PR TITLE
Add a fallback route method

### DIFF
--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -157,4 +157,13 @@ interface RouteCollectorProxyInterface
      * @return RouteInterface
      */
     public function redirect(string $from, $to, int $status = 302): RouteInterface;
+
+    /**
+     * Add a route that will be executed when no other route matches the incoming request
+     *
+     * @param  callable|string $callable The route callback routine
+     *
+     * @return RouteInterface
+     */
+    public function fallback($callable): RouteInterface;
 }

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -206,4 +206,12 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
 
         return $this->get($from, $handler);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fallback($callable): RouteInterface
+    {
+        return $this->map(['*'], '/{routes:.+}', $callable);
+    }
 }

--- a/tests/Routing/RouteCollectorProxyTest.php
+++ b/tests/Routing/RouteCollectorProxyTest.php
@@ -455,4 +455,37 @@ class RouteCollectorProxyTest extends TestCase
 
         $routeCollectorProxy->group($pattern, $callable);
     }
+
+    public function testFallback()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $pattern = '/{routes:.+}';
+        $callable = function () {
+        };
+
+        $routeProphecy = $this->prophesize(RouteInterface::class);
+        $routeProphecy
+            ->getPattern()
+            ->willReturn($pattern)
+            ->shouldBeCalledOnce();
+
+        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+        $routeCollectorProphecy
+            ->map(['*'], $pattern, Argument::is($callable))
+            ->willReturn($routeProphecy->reveal())
+            ->shouldBeCalledOnce();
+
+        $routeCollectorProxy = new RouteCollectorProxy(
+            $responseFactoryProphecy->reveal(),
+            $callableResolverProphecy->reveal(),
+            null,
+            $routeCollectorProphecy->reveal()
+        );
+
+        $route = $routeCollectorProxy->fallback($callable);
+
+        $this->assertEquals($pattern, $route->getPattern());
+    }
 }


### PR DESCRIPTION
In [Slim's docs](https://www.slimframework.com/docs/v4/cookbook/enable-cors.html#the-simple-solution) I noticed the following example:

```php
/**
 * Catch-all route to serve a 404 Not Found page if none of the routes match
 * NOTE: make sure this route is defined last
 */
$app->map(['GET', 'POST', 'PUT', 'DELETE', 'PATCH'], '/{routes:.+}', function ($request, $response) {
    throw new HttpNotFoundException($request);
});
```

But there is no need to use the example above, there is a better solution. Let's look at the following examples:

**1\)** `Slim\Routing\FastRouteDispatcher` - the `dispatch()` method:

```php
...
// If nothing else matches, try fallback routes
$routingResults = $this->routingResults('*', $uri);
if ($routingResults[0] === self::FOUND) {
  return $routingResults;
}
...
```

**2\)** `FastRoute\Dispatcher\RegexBasedAbstract` - the original `dispatch()` method:

```php
...
// If nothing else matches, try fallback routes
if (isset($this->staticRouteMap['*'][$uri])) {
  $handler = $this->staticRouteMap['*'][$uri];
  return [self::FOUND, $handler, []];
}
if (isset($varRouteData['*'])) {
  $result = $this->dispatchVariableRoute($varRouteData['*'], $uri);
  if ($result[0] === self::FOUND) {
    return $result;
  }
}
...
```

### What follows from the given examples? It follows that:

- We can define the fallback route anywhere in the route definitions, even in the first place before all other routes - this will really work.

- We can define the fallback route in a more elegant way than the one currently is shown in Slim's docs.

So I've added:

**1\)** In `Slim\Routing\RouteCollectorProxy`:
```php
/**
 * {@inheritdoc}
 */
public function fallback($callable): RouteInterface
{
  return $this->map(['*'], '/{routes:.+}', $callable);
}
```

**2\)** In `Slim\Interfaces\RouteCollectorProxyInterface`:
```php
/**
 * Add a route that will be executed when no other route matches the incoming request
 *
 * @param  callable|string $callable The route callback routine
 *
 * @return RouteInterface
 */
public function fallback($callable): RouteInterface;
```

**3\)** The `testFallback()` unit test.

And now during route definition we can use:
```php
$app->fallback(function ($request, $response) {
  // your logic, e.g. throwing an exception
  throw new HttpNotFoundException($request);
});

// other routes
$app->get('/signup', [SignupController::class, 'request']);

$app->post('/signup', [SignupController::class, 'signup']);
...
```