### PR TITLE
Replace deprecated setMethods() in tests

### DIFF
--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -112,7 +112,7 @@ class ResponseEmitterTest extends TestCase
         $body = $this
             ->getMockBuilder(MockStream::class)
             ->setConstructorArgs([$stream])
-            ->setMethods(['getSize'])
+            ->onlyMethods(['getSize'])
             ->getMock();
         $body->method('getSize')->willReturn(null);
 


### PR DESCRIPTION
In PhpUnit `setMethods()` is deprecated (https://github.com/sebastianbergmann/phpunit/pull/3687) and will be removed in version 10 (https://github.com/sebastianbergmann/phpunit/issues/3769). The method was split into two methods (`onlyMethods` and `addMethods`) according to their responsibilities.

So I've replaced the method with `onlyMethods` in `ResponseEmitterTest`.