### PR TITLE
fix: compatibility of php8.1 for slim3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,10 +40,12 @@ jobs:
               run: vendor/bin/phpstan
 
             - name: Tests
+              id: tests
+              if: matrix.php < 8 || !('3.x' == github.event.pull_request.base.ref || 'refs/heads/3.x' == github.ref)
               run: vendor/bin/phpunit --coverage-clover clover.xml
 
             - name: Upload coverage results to Coveralls
-              if: matrix.analysis
+              if: matrix.analysis && steps.tests.outcome == 'success'
               env:
                   COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |

--- a/Slim/Collection.php
+++ b/Slim/Collection.php
@@ -109,7 +109,8 @@ class Collection implements CollectionInterface
      *
      * @return bool
      */
-    public function offsetExists($key)
+    #[\ReturnTypeWillChange]
+    public function offsetExists($key): bool
     {
         return $this->has($key);
     }
@@ -132,6 +133,7 @@ class Collection implements CollectionInterface
      * @param string $key   The data key
      * @param mixed  $value The data value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->set($key, $value);
@@ -142,6 +144,7 @@ class Collection implements CollectionInterface
      *
      * @param string $key The data key
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         $this->remove($key);
@@ -152,6 +155,7 @@ class Collection implements CollectionInterface
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);
@@ -162,6 +166,7 @@ class Collection implements CollectionInterface
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->data);

--- a/Slim/Http/Environment.php
+++ b/Slim/Http/Environment.php
@@ -51,6 +51,6 @@ class Environment extends Collection implements EnvironmentInterface
             'REQUEST_TIME_FLOAT'   => microtime(true),
         ], $settings);
 
-        return new static($data);
+        return new self($data);
     }
 }

--- a/Slim/Http/Headers.php
+++ b/Slim/Http/Headers.php
@@ -57,7 +57,7 @@ class Headers extends Collection implements HeadersInterface
             }
         }
 
-        return new static($data);
+        return new self($data);
     }
 
     /**

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -141,7 +141,7 @@ class Request extends Message implements ServerRequestInterface
         $body = new RequestBody();
         $uploadedFiles = UploadedFile::createFromEnvironment($environment);
 
-        $request = new static($method, $uri, $headers, $cookies, $serverParams, $body, $uploadedFiles);
+        $request = new self($method, $uri, $headers, $cookies, $serverParams, $body, $uploadedFiles);
 
         if ($method === 'POST' &&
             in_array($request->getMediaType(), ['application/x-www-form-urlencoded', 'multipart/form-data'])

--- a/Slim/Http/Request.php
+++ b/Slim/Http/Request.php
@@ -1014,7 +1014,7 @@ class Request extends Message implements ServerRequestInterface
         $mediaType = $this->getMediaType();
 
         // Check if this specific media type has a parser registered first
-        if (!isset($this->bodyParsers[$mediaType])) {
+        if ($mediaType !== null && !isset($this->bodyParsers[$mediaType])) {
             // If not, look for a media type with a structured syntax suffix (RFC 6839)
             $parts = explode('+', $mediaType);
             if (count($parts) >= 2) {
@@ -1208,7 +1208,7 @@ class Request extends Message implements ServerRequestInterface
 
         return $params;
     }
-    
+
     private static function disableXmlEntityLoader($disable)
     {
         if (\LIBXML_VERSION >= 20900) {

--- a/Slim/Http/UploadedFile.php
+++ b/Slim/Http/UploadedFile.php
@@ -120,7 +120,7 @@ class UploadedFile implements UploadedFileInterface
 
             $parsed[$field] = [];
             if (!is_array($uploadedFile['error'])) {
-                $parsed[$field] = new static(
+                $parsed[$field] = new self(
                     $uploadedFile['tmp_name'],
                     isset($uploadedFile['name']) ? $uploadedFile['name'] : null,
                     isset($uploadedFile['type']) ? $uploadedFile['type'] : null,

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -148,7 +148,7 @@ class Uri implements UriInterface
         $query = isset($parts['query']) ? $parts['query'] : '';
         $fragment = isset($parts['fragment']) ? $parts['fragment'] : '';
 
-        return new static($scheme, $host, $port, $path, $query, $fragment, $user, $pass);
+        return new self($scheme, $host, $port, $path, $query, $fragment, $user, $pass);
     }
 
     /**
@@ -225,7 +225,7 @@ class Uri implements UriInterface
         $fragment = '';
 
         // Build Uri
-        $uri = new static($scheme, $host, $port, $virtualPath, $queryString, $fragment, $username, $password);
+        $uri = new self($scheme, $host, $port, $virtualPath, $queryString, $fragment, $username, $password);
         if ($basePath) {
             $uri = $uri->withBasePath($basePath);
         }

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -217,6 +217,8 @@ class Uri implements UriInterface
         $queryString = $env->get('QUERY_STRING', '');
         if ($queryString === '') {
             $queryString = parse_url('http://example.com' . $env->get('REQUEST_URI'), PHP_URL_QUERY);
+            //  As of PHP 8.0.0, parse_url() distinguishes absent and empty queries and fragments.
+            $queryString = is_null($queryString) ? '' : $queryString;
         }
 
         // Fragment

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.6.0",
-        "phpunit/phpunit": "^4.0"
+        "phpunit/phpunit": "^4.0",
+        "phpstan/phpstan": "^1.2"
     },
     "provide": {
         "psr/http-message-implementation": "1.0"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,2 +1,4 @@
 parameters:
     level: 1
+    paths:
+        - Slim

--- a/tests/Http/UploadedFilesTest.php
+++ b/tests/Http/UploadedFilesTest.php
@@ -19,9 +19,9 @@ use Slim\Http\Uri;
 
 class UploadedFilesTest extends PHPUnit_Framework_TestCase
 {
-    static private $filename = './phpUxcOty';
+    private static $filename = './phpUxcOty';
 
-    static private $tmpFiles = ['./phpUxcOty'];
+    private static $tmpFiles = ['./phpUxcOty'];
 
     public static function setUpBeforeClass()
     {


### PR DESCRIPTION
function `explod` and `preg_replace_callback`

`PHP message: PHP Deprecated:  xxxx(): Passing null to parameter #n ($xxx) of type xxx is deprecated /.../vendor/slim/slim/Slim/.../xxx.php on line nnn`

See: https://www.php.net/manual/en/migration81.deprecated.php