### PR TITLE
Improve typehinting for `RouteParserInterface`

### DIFF
--- a/Slim/Interfaces/RouteParserInterface.php
+++ b/Slim/Interfaces/RouteParserInterface.php
@@ -19,9 +19,9 @@ interface RouteParserInterface
     /**
      * Build the path for a named route excluding the base path
      *
-     * @param string   $routeName   Route name
-     * @param string[] $data        Named argument replacement data
-     * @param string[] $queryParams Optional query string parameters
+     * @param string                $routeName   Route name
+     * @param array<string, string> $data        Named argument replacement data
+     * @param array<string, string> $queryParams Optional query string parameters
      *
      * @return string
      *
@@ -33,9 +33,9 @@ interface RouteParserInterface
     /**
      * Build the path for a named route including the base path
      *
-     * @param string   $routeName   Route name
-     * @param string[] $data        Named argument replacement data
-     * @param string[] $queryParams Optional query string parameters
+     * @param string                $routeName   Route name
+     * @param array<string, string> $data        Named argument replacement data
+     * @param array<string, string> $queryParams Optional query string parameters
      *
      * @return string
      *
@@ -47,10 +47,10 @@ interface RouteParserInterface
     /**
      * Get fully qualified URL for named route
      *
-     * @param UriInterface $uri
-     * @param string       $routeName   Route name
-     * @param string[]     $data        Named argument replacement data
-     * @param string[]     $queryParams Optional query string parameters
+     * @param UriInterface              $uri
+     * @param string                    $routeName   Route name
+     * @param array<string, string>     $data        Named argument replacement data
+     * @param array<string, string>     $queryParams Optional query string parameters
      *
      * @return string
      */


### PR DESCRIPTION
# Description
Previous typehinting (by docblock) in `RouteParserInterface` was not sufficient, it only defined the value of the array. However, both `$data` as `$queryParams` are arrays where the key as well as value is a string.

```php
/**
 * @param string[] ... // < only defines the type of the value
 * @param array<string, string> ... // < defines the type of both key and value
 */
```

By improving the typehinting for these values, e.g. static analysis tools will recognize this instead of failing due to type mismatch.

## Changes
- [x] Improved typehinting for `$data` and `$queryParams` in `RouteParserInterface`

## Links
- https://psalm.dev/docs/annotating_code/type_syntax/array_types/
- https://phpstan.org/writing-php-code/phpdoc-types#general-arrays