### PR TITLE
fix: php81 deprecation message

### DIFF
--- a/Slim/Collection.php
+++ b/Slim/Collection.php
@@ -109,6 +109,7 @@ class Collection implements CollectionInterface
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return $this->has($key);
@@ -121,6 +122,7 @@ class Collection implements CollectionInterface
      *
      * @return mixed The key's value, or the default value
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->get($key);
@@ -132,6 +134,7 @@ class Collection implements CollectionInterface
      * @param string $key   The data key
      * @param mixed  $value The data value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->set($key, $value);
@@ -142,6 +145,7 @@ class Collection implements CollectionInterface
      *
      * @param string $key The data key
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         $this->remove($key);
@@ -152,6 +156,7 @@ class Collection implements CollectionInterface
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);
@@ -162,6 +167,7 @@ class Collection implements CollectionInterface
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->data);

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -216,7 +216,7 @@ class Uri implements UriInterface
         // Query string
         $queryString = $env->get('QUERY_STRING', '');
         if ($queryString === '') {
-            $queryString = parse_url('http://example.com' . $env->get('REQUEST_URI'), PHP_URL_QUERY);
+            $queryString = (string) parse_url('http://example.com' . $env->get('REQUEST_URI'), PHP_URL_QUERY);
         }
 
         // Fragment


### PR DESCRIPTION
For the change in `Slim/Http/Uri.php#L129`, that is because that  `preg_replace_callback` wouldn't accept the third parameter as `null`. As `parse_url` would return `null` on not found, converting the return value of `parse_url` to `string` should be the best solution.