### PR TITLE
Declare types

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -40,15 +40,9 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
      */
     public const VERSION = '4.10.0';
 
-    /**
-     * @var RouteResolverInterface
-     */
-    protected $routeResolver;
+    protected RouteResolverInterface $routeResolver;
 
-    /**
-     * @var MiddlewareDispatcherInterface
-     */
-    protected $middlewareDispatcher;
+    protected MiddlewareDispatcherInterface $middlewareDispatcher;
 
     /**
      * @param ResponseFactoryInterface              $responseFactory

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -28,15 +28,9 @@ use function sprintf;
 
 final class CallableResolver implements AdvancedCallableResolverInterface
 {
-    /**
-     * @var string
-     */
-    public static $callablePattern = '!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!';
+    public static string $callablePattern = '!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!';
 
-    /**
-     * @var ContainerInterface|null
-     */
-    private $container;
+    private ?ContainerInterface $container;
 
     /**
      * @param ContainerInterface|null $container

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -32,20 +32,12 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
 {
     /**
      * Tip of the middleware call stack
-     *
-     * @var RequestHandlerInterface
      */
-    protected $tip;
+    protected RequestHandlerInterface $tip;
 
-    /**
-     * @var CallableResolverInterface|null
-     */
-    protected $callableResolver;
+    protected ?CallableResolverInterface $callableResolver;
 
-    /**
-     * @var ContainerInterface|null
-     */
-    protected $container;
+    protected ?ContainerInterface $container;
 
     /**
      * @param RequestHandlerInterface        $kernel
@@ -170,25 +162,13 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
             $this->container,
             $this->callableResolver
         ) implements RequestHandlerInterface {
-            /**
-             * @var string
-             */
-            private $middleware;
+            private string $middleware;
 
-            /**
-             * @var RequestHandlerInterface
-             */
-            private $next;
+            private RequestHandlerInterface $next;
 
-            /**
-             * @var ContainerInterface|null
-             */
-            private $container;
+            private ?ContainerInterface $container;
 
-            /**
-             * @var CallableResolverInterface|null
-             */
-            private $callableResolver;
+            private ?CallableResolverInterface $callableResolver;
 
             public function __construct(
                 string $middleware,

--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -25,10 +25,7 @@ use const CONNECTION_NORMAL;
 
 class ResponseEmitter
 {
-    /**
-     * @var int
-     */
-    private $responseChunkSize;
+    private int $responseChunkSize;
 
     /**
      * @param int $responseChunkSize

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -60,7 +60,7 @@ class AppTest extends TestCase
         ini_set('error_log', tempnam(sys_get_temp_dir(), 'slim'));
     }
 
-    public function testDoesNotUseContainerAsServiceLocator()
+    public function testDoesNotUseContainerAsServiceLocator(): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $containerProphecy = $this->prophesize(ContainerInterface::class);
@@ -74,7 +74,7 @@ class AppTest extends TestCase
      * Getter methods
      *******************************************************************************/
 
-    public function testGetContainer()
+    public function testGetContainer(): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $containerProphecy = $this->prophesize(ContainerInterface::class);
@@ -83,7 +83,7 @@ class AppTest extends TestCase
         $this->assertSame($containerProphecy->reveal(), $app->getContainer());
     }
 
-    public function testGetCallableResolverReturnsInjectedInstance()
+    public function testGetCallableResolverReturnsInjectedInstance(): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
@@ -92,7 +92,7 @@ class AppTest extends TestCase
         $this->assertSame($callableResolverProphecy->reveal(), $app->getCallableResolver());
     }
 
-    public function testCreatesCallableResolverWhenNull()
+    public function testCreatesCallableResolverWhenNull(): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $containerProphecy = $this->prophesize(ContainerInterface::class);
@@ -102,7 +102,7 @@ class AppTest extends TestCase
         $this->assertEquals($callableResolver, $app->getCallableResolver());
     }
 
-    public function testGetRouteCollectorReturnsInjectedInstance()
+    public function testGetRouteCollectorReturnsInjectedInstance(): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
@@ -115,7 +115,7 @@ class AppTest extends TestCase
         $this->assertSame($routeCollectorProphecy->reveal(), $app->getRouteCollector());
     }
 
-    public function testCreatesRouteCollectorWhenNullWithInjectedContainer()
+    public function testCreatesRouteCollectorWhenNullWithInjectedContainer(): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $containerProphecy = $this->prophesize(ContainerInterface::class);
@@ -134,7 +134,7 @@ class AppTest extends TestCase
         $this->assertEquals($routeCollector, $app->getRouteCollector());
     }
 
-    public function testGetMiddlewareDispatcherGetsSeededAndReturnsInjectedInstance()
+    public function testGetMiddlewareDispatcherGetsSeededAndReturnsInjectedInstance(): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
 
@@ -171,7 +171,7 @@ class AppTest extends TestCase
      * @param string $method
      * @dataProvider upperCaseRequestMethodsProvider()
      */
-    public function testGetPostPutPatchDeleteOptionsMethods(string $method)
+    public function testGetPostPutPatchDeleteOptionsMethods(string $method): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('Hello World');
@@ -204,7 +204,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testAnyRoute()
+    public function testAnyRoute(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('Hello World');
@@ -261,7 +261,7 @@ class AppTest extends TestCase
      * @dataProvider lowerCaseRequestMethodsProvider
      * @dataProvider upperCaseRequestMethodsProvider
      */
-    public function testMapRoute(string $method)
+    public function testMapRoute(string $method): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('Hello World');
@@ -293,7 +293,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testRedirectRoute()
+    public function testRedirectRoute(): void
     {
         $from = '/from';
         $to = '/to';
@@ -337,7 +337,7 @@ class AppTest extends TestCase
         $this->assertEquals($to, $response->getHeaderLine('Location'));
     }
 
-    public function testRouteWithInternationalCharacters()
+    public function testRouteWithInternationalCharacters(): void
     {
         $path = '/новости';
 
@@ -391,7 +391,7 @@ class AppTest extends TestCase
      * @param string $pattern
      * @dataProvider routePatternsProvider
      */
-    public function testRoutePatterns(string $pattern)
+    public function testRoutePatterns(string $pattern): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
 
@@ -409,7 +409,7 @@ class AppTest extends TestCase
      * Route Groups
      *******************************************************************************/
 
-    public function routeGroupsDataProvider()
+    public function routeGroupsDataProvider(): array
     {
         return [
             'empty group with empty route' => [
@@ -523,7 +523,7 @@ class AppTest extends TestCase
         ];
     }
 
-    public function testGroupClosureIsBoundToThisClass()
+    public function testGroupClosureIsBoundToThisClass(): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $app = new App($responseFactoryProphecy->reveal());
@@ -539,7 +539,7 @@ class AppTest extends TestCase
      * @param array  $sequence
      * @param string $expectedPath
      */
-    public function testRouteGroupCombinations(array $sequence, string $expectedPath)
+    public function testRouteGroupCombinations(array $sequence, string $expectedPath): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $app = new App($responseFactoryProphecy->reveal());
@@ -569,7 +569,7 @@ class AppTest extends TestCase
         $this->assertEquals($expectedPath, $route->getPattern());
     }
 
-    public function testRouteGroupPattern()
+    public function testRouteGroupPattern(): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
 
@@ -586,7 +586,7 @@ class AppTest extends TestCase
      * Middleware
      *******************************************************************************/
 
-    public function testAddMiddleware()
+    public function testAddMiddleware(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('Hello World');
@@ -650,7 +650,7 @@ class AppTest extends TestCase
         $this->assertSame($responseProphecy->reveal(), $response);
     }
 
-    public function testAddMiddlewareUsingDeferredResolution()
+    public function testAddMiddlewareUsingDeferredResolution(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('Hello World');
@@ -685,7 +685,7 @@ class AppTest extends TestCase
         $this->assertSame('Hello World', (string) $response->getBody());
     }
 
-    public function testAddRoutingMiddleware()
+    public function testAddRoutingMiddleware(): void
     {
         /** @var ResponseFactoryInterface $responseFactory */
         $responseFactory = $this->prophesize(ResponseFactoryInterface::class)->reveal();
@@ -715,7 +715,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RoutingMiddleware::class, $routingMiddleware);
     }
 
-    public function testAddErrorMiddleware()
+    public function testAddErrorMiddleware(): void
     {
         /** @var ResponseFactoryInterface $responseFactory */
         $responseFactory = $this->prophesize(ResponseFactoryInterface::class)->reveal();
@@ -748,7 +748,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(ErrorMiddleware::class, $errorMiddleware);
     }
 
-    public function testAddBodyParsingMiddleware()
+    public function testAddBodyParsingMiddleware(): void
     {
         /** @var ResponseFactoryInterface $responseFactory */
         $responseFactory = $this->prophesize(ResponseFactoryInterface::class)->reveal();
@@ -778,7 +778,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(BodyParsingMiddleware::class, $bodyParsingMiddleware);
     }
 
-    public function testAddMiddlewareOnRoute()
+    public function testAddMiddlewareOnRoute(): void
     {
         $output = '';
 
@@ -858,7 +858,7 @@ class AppTest extends TestCase
         $this->assertEquals('In2In1CenterOut1Out2', $output);
     }
 
-    public function testAddMiddlewareOnRouteGroup()
+    public function testAddMiddlewareOnRouteGroup(): void
     {
         $output = '';
 
@@ -940,7 +940,7 @@ class AppTest extends TestCase
         $this->assertEquals('In2In1CenterOut1Out2', $output);
     }
 
-    public function testAddMiddlewareOnTwoRouteGroup()
+    public function testAddMiddlewareOnTwoRouteGroup(): void
     {
         $output = '';
 
@@ -1060,7 +1060,7 @@ class AppTest extends TestCase
         $this->assertEquals('In1In2In3CenterOut3Out2Out1', $output);
     }
 
-    public function testAddMiddlewareAsStringNotImplementingInterfaceThrowsException()
+    public function testAddMiddlewareAsStringNotImplementingInterfaceThrowsException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(
@@ -1077,7 +1077,7 @@ class AppTest extends TestCase
      * Runner
      *******************************************************************************/
 
-    public function testInvokeReturnMethodNotAllowed()
+    public function testInvokeReturnMethodNotAllowed(): void
     {
         $this->expectException(HttpMethodNotAllowedException::class);
 
@@ -1101,7 +1101,7 @@ class AppTest extends TestCase
         $app->handle($requestProphecy->reveal());
     }
 
-    public function testInvokeWithMatchingRoute()
+    public function testInvokeWithMatchingRoute(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('Hello World');
@@ -1135,7 +1135,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testInvokeWithMatchingRouteWithSetArgument()
+    public function testInvokeWithMatchingRouteWithSetArgument(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1175,7 +1175,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testInvokeWithMatchingRouteWithSetArguments()
+    public function testInvokeWithMatchingRouteWithSetArguments(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1215,7 +1215,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseStrategy()
+    public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseStrategy(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1255,7 +1255,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseArgStrategy()
+    public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseArgStrategy(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1296,7 +1296,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseNamedArgsStrategy()
+    public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseNamedArgsStrategy(): void
     {
         if (PHP_VERSION_ID < 80000) {
             $this->markTestSkipped('Named arguments are not supported in PHP versions prior to 8.0');
@@ -1344,7 +1344,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testInvokeWithMatchingRouteWithNamedParameterOverwritesSetArgument()
+    public function testInvokeWithMatchingRouteWithNamedParameterOverwritesSetArgument(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1384,7 +1384,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testInvokeWithoutMatchingRoute()
+    public function testInvokeWithoutMatchingRoute(): void
     {
         $this->expectException(HttpNotFoundException::class);
 
@@ -1406,7 +1406,7 @@ class AppTest extends TestCase
         $app->handle($requestProphecy->reveal());
     }
 
-    public function testInvokeWithCallableRegisteredInContainer()
+    public function testInvokeWithCallableRegisteredInContainer(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('Hello World');
@@ -1450,7 +1450,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testInvokeWithNonExistentMethodOnCallableRegisteredInContainer()
+    public function testInvokeWithNonExistentMethodOnCallableRegisteredInContainer(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -1486,7 +1486,7 @@ class AppTest extends TestCase
         $app->handle($requestProphecy->reveal());
     }
 
-    public function testInvokeWithCallableInContainerViaCallMagicMethod()
+    public function testInvokeWithCallableInContainerViaCallMagicMethod(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1530,7 +1530,7 @@ class AppTest extends TestCase
         $this->assertEquals($expectedPayload, (string) $response->getBody());
     }
 
-    public function testInvokeFunctionName()
+    public function testInvokeFunctionName(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1576,7 +1576,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testCurrentRequestAttributesAreNotLostWhenAddingRouteArguments()
+    public function testCurrentRequestAttributesAreNotLostWhenAddingRouteArguments(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1616,7 +1616,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testCurrentRequestAttributesAreNotLostWhenAddingRouteArgumentsRequestResponseArg()
+    public function testCurrentRequestAttributesAreNotLostWhenAddingRouteArgumentsRequestResponseArg(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1657,7 +1657,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testRun()
+    public function testRun(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1709,7 +1709,7 @@ class AppTest extends TestCase
         $this->expectOutputString('Hello World');
     }
 
-    public function testRunWithoutPassingInServerRequest()
+    public function testRunWithoutPassingInServerRequest(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1749,7 +1749,7 @@ class AppTest extends TestCase
         $this->expectOutputString('Hello World');
     }
 
-    public function testHandleReturnsEmptyResponseBodyWithHeadRequestMethod()
+    public function testHandleReturnsEmptyResponseBodyWithHeadRequestMethod(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1805,7 +1805,7 @@ class AppTest extends TestCase
         $this->assertEmpty((string) $response->getBody());
     }
 
-    public function testCanBeReExecutedRecursivelyDuringDispatch()
+    public function testCanBeReExecutedRecursivelyDuringDispatch(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -1926,7 +1926,7 @@ class AppTest extends TestCase
 
     // TODO: Re-add testUnsupportedMethodWithRoute
 
-    public function testContainerSetToRoute()
+    public function testContainerSetToRoute(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('Hello World');
@@ -1964,7 +1964,7 @@ class AppTest extends TestCase
         $this->assertEquals('Hello World', (string) $response->getBody());
     }
 
-    public function testAppIsARequestHandler()
+    public function testAppIsARequestHandler(): void
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
         $app = new App($responseFactoryProphecy->reveal());
@@ -1972,7 +1972,7 @@ class AppTest extends TestCase
         $this->assertInstanceOf(RequestHandlerInterface::class, $app);
     }
 
-    public function testInvokeSequentialProccessToAPathWithOptionalArgsAndWithoutOptionalArgs()
+    public function testInvokeSequentialProcessToAPathWithOptionalArgsAndWithoutOptionalArgs(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -2026,7 +2026,7 @@ class AppTest extends TestCase
         $this->assertEquals('0', (string) $response->getBody());
     }
 
-    public function testInvokeSequentialProccessToAPathWithOptionalArgsAndWithoutOptionalArgsAndKeepSetedArgs()
+    public function testInvokeSequentialProcessToAPathWithOptionalArgsAndWithoutOptionalArgsAndKeepSetedArgs(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');
@@ -2080,7 +2080,7 @@ class AppTest extends TestCase
         $this->assertEquals('1', (string) $response->getBody());
     }
 
-    public function testInvokeSequentialProccessAfterAddingAnotherRouteArgument()
+    public function testInvokeSequentialProcessAfterAddingAnotherRouteArgument(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);
         $streamProphecy->__toString()->willReturn('');

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -155,7 +155,7 @@ class AppTest extends TestCase
         $this->assertSame($middlewareDispatcherProphecy->reveal(), $app->getMiddlewareDispatcher());
     }
 
-    public function lowerCaseRequestMethodsProvider()
+    public function lowerCaseRequestMethodsProvider(): array
     {
         return [
             ['get'],
@@ -244,7 +244,7 @@ class AppTest extends TestCase
      * Route collector proxy methods
      *******************************************************************************/
 
-    public function upperCaseRequestMethodsProvider()
+    public function upperCaseRequestMethodsProvider(): array
     {
         return [
             ['GET'],
@@ -376,7 +376,7 @@ class AppTest extends TestCase
      * Route Patterns
      *******************************************************************************/
 
-    public function routePatternsProvider()
+    public function routePatternsProvider(): array
     {
         return [
             [''], // Empty Route

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -23,10 +23,7 @@ use Slim\Tests\Mocks\RequestHandlerTest;
 
 class CallableResolverTest extends TestCase
 {
-    /**
-     * @var ObjectProphecy
-     */
-    private $containerProphecy;
+    private ObjectProphecy $containerProphecy;
 
     public static function setUpBeforeClass(): void
     {

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -43,7 +43,7 @@ class CallableResolverTest extends TestCase
         $this->containerProphecy->has(Argument::type('string'))->willReturn(false);
     }
 
-    public function testClosure()
+    public function testClosure(): void
     {
         $test = function () {
             return true;
@@ -58,7 +58,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(true, $callableMiddleware());
     }
 
-    public function testClosureContainer()
+    public function testClosureContainer(): void
     {
         $this->containerProphecy->has('ultimateAnswer')->willReturn(true);
         $this->containerProphecy->get('ultimateAnswer')->willReturn(42);
@@ -83,7 +83,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(42, $callableMiddleware());
     }
 
-    public function testFunctionName()
+    public function testFunctionName(): void
     {
         $resolver = new CallableResolver(); // No container injected
         $callable = $resolver->resolve(__NAMESPACE__ . '\testAdvancedCallable');
@@ -95,7 +95,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(true, $callableMiddleware());
     }
 
-    public function testObjMethodArray()
+    public function testObjMethodArray(): void
     {
         $obj = new CallableTest();
         $resolver = new CallableResolver(); // No container injected
@@ -113,7 +113,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(3, CallableTest::$CalledCount);
     }
 
-    public function testSlimCallable()
+    public function testSlimCallable(): void
     {
         $resolver = new CallableResolver(); // No container injected
         $callable = $resolver->resolve('Slim\Tests\Mocks\CallableTest:toCall');
@@ -130,7 +130,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(3, CallableTest::$CalledCount);
     }
 
-    public function testSlimCallableAsArray()
+    public function testSlimCallableAsArray(): void
     {
         $resolver = new CallableResolver(); // No container injected
         $callable = $resolver->resolve([CallableTest::class, 'toCall']);
@@ -147,7 +147,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(3, CallableTest::$CalledCount);
     }
 
-    public function testSlimCallableContainer()
+    public function testSlimCallableContainer(): void
     {
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
@@ -164,7 +164,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals($container, CallableTest::$CalledContainer);
     }
 
-    public function testSlimCallableAsArrayContainer()
+    public function testSlimCallableAsArrayContainer(): void
     {
         /** @var ContainerInterface $container */
         $container = $this->containerProphecy->reveal();
@@ -181,7 +181,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals($container, CallableTest::$CalledContainer);
     }
 
-    public function testContainer()
+    public function testContainer(): void
     {
         $this->containerProphecy->has('callable_service')->willReturn(true);
         $this->containerProphecy->get('callable_service')->willReturn(new CallableTest());
@@ -204,7 +204,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(3, CallableTest::$CalledCount);
     }
 
-    public function testResolutionToAnInvokableClassInContainer()
+    public function testResolutionToAnInvokableClassInContainer(): void
     {
         $this->containerProphecy->has('an_invokable')->willReturn(true);
         $this->containerProphecy->get('an_invokable')->willReturn(new InvokableTest());
@@ -227,7 +227,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(3, InvokableTest::$CalledCount);
     }
 
-    public function testResolutionToAnInvokableClass()
+    public function testResolutionToAnInvokableClass(): void
     {
         $resolver = new CallableResolver(); // No container injected
         $callable = $resolver->resolve('Slim\Tests\Mocks\InvokableTest');
@@ -244,7 +244,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals(3, InvokableTest::$CalledCount);
     }
 
-    public function testResolutionToAPsrRequestHandlerClass()
+    public function testResolutionToAPsrRequestHandlerClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Slim\\Tests\\Mocks\\RequestHandlerTest is not resolvable');
@@ -253,7 +253,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolve(RequestHandlerTest::class);
     }
 
-    public function testRouteResolutionToAPsrRequestHandlerClass()
+    public function testRouteResolutionToAPsrRequestHandlerClass(): void
     {
         $request = $this->createServerRequest('/', 'GET');
         $resolver = new CallableResolver(); // No container injected
@@ -262,7 +262,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals('1', RequestHandlerTest::$CalledCount);
     }
 
-    public function testMiddlewareResolutionToAPsrRequestHandlerClass()
+    public function testMiddlewareResolutionToAPsrRequestHandlerClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Slim\\Tests\\Mocks\\RequestHandlerTest is not resolvable');
@@ -271,7 +271,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveMiddleware(RequestHandlerTest::class);
     }
 
-    public function testObjPsrRequestHandlerClass()
+    public function testObjPsrRequestHandlerClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('{} is not resolvable');
@@ -281,7 +281,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolve($obj);
     }
 
-    public function testRouteObjPsrRequestHandlerClass()
+    public function testRouteObjPsrRequestHandlerClass(): void
     {
         $obj = new RequestHandlerTest();
         $request = $this->createServerRequest('/', 'GET');
@@ -291,7 +291,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals('1', RequestHandlerTest::$CalledCount);
     }
 
-    public function testMiddlewareObjPsrRequestHandlerClass()
+    public function testMiddlewareObjPsrRequestHandlerClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('{} is not resolvable');
@@ -301,7 +301,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveMiddleware($obj);
     }
 
-    public function testObjPsrRequestHandlerClassInContainer()
+    public function testObjPsrRequestHandlerClassInContainer(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('a_requesthandler is not resolvable');
@@ -315,7 +315,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolve('a_requesthandler');
     }
 
-    public function testRouteObjPsrRequestHandlerClassInContainer()
+    public function testRouteObjPsrRequestHandlerClassInContainer(): void
     {
         $this->containerProphecy->has('a_requesthandler')->willReturn(true);
         $this->containerProphecy->get('a_requesthandler')->willReturn(new RequestHandlerTest());
@@ -330,7 +330,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals('1', RequestHandlerTest::$CalledCount);
     }
 
-    public function testMiddlewareObjPsrRequestHandlerClassInContainer()
+    public function testMiddlewareObjPsrRequestHandlerClassInContainer(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('a_requesthandler is not resolvable');
@@ -344,7 +344,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveMiddleware('a_requesthandler');
     }
 
-    public function testResolutionToAPsrRequestHandlerClassWithCustomMethod()
+    public function testResolutionToAPsrRequestHandlerClassWithCustomMethod(): void
     {
         $resolver = new CallableResolver(); // No container injected
         $callable = $resolver->resolve(RequestHandlerTest::class . ':custom');
@@ -364,7 +364,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals('custom', $callableMiddleware[1]);
     }
 
-    public function testObjMiddlewareClass()
+    public function testObjMiddlewareClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('{} is not resolvable');
@@ -374,7 +374,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolve($obj);
     }
 
-    public function testRouteObjMiddlewareClass()
+    public function testRouteObjMiddlewareClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('{} is not resolvable');
@@ -384,7 +384,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveRoute($obj);
     }
 
-    public function testMiddlewareObjMiddlewareClass()
+    public function testMiddlewareObjMiddlewareClass(): void
     {
         $obj = new MiddlewareTest();
         $request = $this->createServerRequest('/', 'GET');
@@ -394,7 +394,7 @@ class CallableResolverTest extends TestCase
         $this->assertEquals('1', MiddlewareTest::$CalledCount);
     }
 
-    public function testNotObjectInContainerThrowException()
+    public function testNotObjectInContainerThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('callable_service container entry is not an object');
@@ -408,7 +408,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolve('callable_service');
     }
 
-    public function testMethodNotFoundThrowException()
+    public function testMethodNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('callable_service:notFound is not resolvable');
@@ -422,7 +422,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolve('callable_service:notFound');
     }
 
-    public function testRouteMethodNotFoundThrowException()
+    public function testRouteMethodNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('callable_service:notFound is not resolvable');
@@ -436,7 +436,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveRoute('callable_service:notFound');
     }
 
-    public function testMiddlewareMethodNotFoundThrowException()
+    public function testMiddlewareMethodNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('callable_service:notFound is not resolvable');
@@ -450,7 +450,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveMiddleware('callable_service:notFound');
     }
 
-    public function testFunctionNotFoundThrowException()
+    public function testFunctionNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable notFound does not exist');
@@ -461,7 +461,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolve('notFound');
     }
 
-    public function testRouteFunctionNotFoundThrowException()
+    public function testRouteFunctionNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable notFound does not exist');
@@ -472,7 +472,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveRoute('notFound');
     }
 
-    public function testMiddlewareFunctionNotFoundThrowException()
+    public function testMiddlewareFunctionNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable notFound does not exist');
@@ -483,7 +483,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveMiddleware('notFound');
     }
 
-    public function testClassNotFoundThrowException()
+    public function testClassNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
@@ -494,7 +494,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolve('Unknown:notFound');
     }
 
-    public function testRouteClassNotFoundThrowException()
+    public function testRouteClassNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
@@ -505,7 +505,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveRoute('Unknown:notFound');
     }
 
-    public function testMiddlewareClassNotFoundThrowException()
+    public function testMiddlewareClassNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
@@ -516,7 +516,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveMiddleware('Unknown:notFound');
     }
 
-    public function testCallableClassNotFoundThrowException()
+    public function testCallableClassNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
@@ -527,7 +527,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolve(['Unknown', 'notFound']);
     }
 
-    public function testRouteCallableClassNotFoundThrowException()
+    public function testRouteCallableClassNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');
@@ -538,7 +538,7 @@ class CallableResolverTest extends TestCase
         $resolver->resolveRoute(['Unknown', 'notFound']);
     }
 
-    public function testMiddlewareCallableClassNotFoundThrowException()
+    public function testMiddlewareCallableClassNotFoundThrowException(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Callable Unknown::notFound() does not exist');

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -138,7 +138,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertEquals(1, $handler->getCalledCount());
     }
 
-    public function deferredCallableProvider()
+    public function deferredCallableProvider(): array
     {
         return [
             [MockMiddlewareSlimCallable::class . ':custom', new MockMiddlewareSlimCallable()],

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -35,7 +35,7 @@ class MiddlewareDispatcherTest extends TestCase
         }
     }
 
-    public function testAddMiddleware()
+    public function testAddMiddleware(): void
     {
         $responseFactory = $this->getResponseFactory();
         $callable = function ($request, $handler) use ($responseFactory) {
@@ -52,7 +52,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertInstanceOf(ResponseInterface::class, $response);
     }
 
-    public function testNamedFunctionIsResolved()
+    public function testNamedFunctionIsResolved(): void
     {
         $handler = new MockRequestHandler();
 
@@ -65,7 +65,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertEquals(1, $handler->getCalledCount());
     }
 
-    public function testDeferredResolvedCallable()
+    public function testDeferredResolvedCallable(): void
     {
         $callable = function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
             return $handler->handle($request);
@@ -94,7 +94,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertEquals(1, $handler->getCalledCount());
     }
 
-    public function testDeferredResolvedCallableWithoutContainerAndNonAdvancedCallableResolver()
+    public function testDeferredResolvedCallableWithoutContainerAndNonAdvancedCallableResolver(): void
     {
         $callable = function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
             return $handler->handle($request);
@@ -118,7 +118,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertEquals(1, $handler->getCalledCount());
     }
 
-    public function testDeferredResolvedCallableWithDirectConstructorCall()
+    public function testDeferredResolvedCallableWithDirectConstructorCall(): void
     {
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
 
@@ -160,7 +160,7 @@ class MiddlewareDispatcherTest extends TestCase
     public function testDeferredResolvedCallableWithContainerAndNonAdvancedCallableResolverUnableToResolveCallable(
         $callable,
         $result
-    ) {
+    ): void {
         if ($callable === 'MiddlewareInterfaceNotImplemented') {
             $this->expectException(RuntimeException::class);
             $this->expectExceptionMessage('Middleware MiddlewareInterfaceNotImplemented is not resolvable');
@@ -200,7 +200,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertEquals(1, $handler->getCalledCount());
     }
 
-    public function testDeferredResolvedSlimCallable()
+    public function testDeferredResolvedSlimCallable(): void
     {
         $handler = new MockRequestHandler();
         $middlewareDispatcher = $this->createMiddlewareDispatcher($handler, null);
@@ -212,7 +212,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertEquals(1, $handler->getCalledCount());
     }
 
-    public function testDeferredResolvedClosureIsBoundToContainer()
+    public function testDeferredResolvedClosureIsBoundToContainer(): void
     {
         $containerProphecy = $this->prophesize(ContainerInterface::class);
 
@@ -236,7 +236,7 @@ class MiddlewareDispatcherTest extends TestCase
         $middlewareDispatcher->handle($request);
     }
 
-    public function testAddCallableBindsClosureToContainer()
+    public function testAddCallableBindsClosureToContainer(): void
     {
         $containerProphecy = $this->prophesize(ContainerInterface::class);
 
@@ -260,7 +260,7 @@ class MiddlewareDispatcherTest extends TestCase
         $middlewareDispatcher->handle($request);
     }
 
-    public function testResolvableReturnsInstantiatedObject()
+    public function testResolvableReturnsInstantiatedObject(): void
     {
         MockMiddlewareWithoutConstructor::$CalledCount = 0;
 
@@ -275,7 +275,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertEquals(1, $handler->getCalledCount());
     }
 
-    public function testResolveThrowsExceptionWhenResolvableDoesNotImplementMiddlewareInterface()
+    public function testResolveThrowsExceptionWhenResolvableDoesNotImplementMiddlewareInterface(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('MiddlewareInterfaceNotImplemented is not resolvable');
@@ -300,7 +300,7 @@ class MiddlewareDispatcherTest extends TestCase
         $middlewareDispatcher->handle($request);
     }
 
-    public function testResolveThrowsExceptionWithoutContainerAndUnresolvableClass()
+    public function testResolveThrowsExceptionWithoutContainerAndUnresolvableClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/(Middleware|Callable) Unresolvable::class does not exist/');
@@ -313,7 +313,7 @@ class MiddlewareDispatcherTest extends TestCase
         $middlewareDispatcher->handle($request);
     }
 
-    public function testResolveThrowsExceptionWithoutContainerNonAdvancedCallableResolverAndUnresolvableClass()
+    public function testResolveThrowsExceptionWithoutContainerNonAdvancedCallableResolverAndUnresolvableClass(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageMatches('/(Middleware|Callable) Unresolvable::class does not exist/');
@@ -335,7 +335,7 @@ class MiddlewareDispatcherTest extends TestCase
         $middlewareDispatcher->handle($request);
     }
 
-    public function testExecutesKernelWithEmptyMiddlewareStack()
+    public function testExecutesKernelWithEmptyMiddlewareStack(): void
     {
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -352,7 +352,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertEquals($responseProphecy->reveal(), $response);
     }
 
-    public function testExecutesMiddlewareLastInFirstOut()
+    public function testExecutesMiddlewareLastInFirstOut(): void
     {
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $requestProphecy->getHeader(Argument::type('string'))->willReturn([]);
@@ -444,7 +444,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertSame(204, $response->getStatusCode());
     }
 
-    public function testDoesNotInstantiateDeferredMiddlewareInCaseOfAnEarlyReturningOuterMiddleware()
+    public function testDoesNotInstantiateDeferredMiddlewareInCaseOfAnEarlyReturningOuterMiddleware(): void
     {
         $kernelProphecy = $this->prophesize(RequestHandlerInterface::class);
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
@@ -466,7 +466,7 @@ class MiddlewareDispatcherTest extends TestCase
         $kernelProphecy->handle(Argument::type(ServerRequestInterface::class))->shouldNotHaveBeenCalled();
     }
 
-    public function testThrowsExceptionForDeferredNonMiddlewareInterfaceClasses()
+    public function testThrowsExceptionForDeferredNonMiddlewareInterfaceClasses(): void
     {
         $this->expectException(RuntimeException::class);
 
@@ -482,7 +482,7 @@ class MiddlewareDispatcherTest extends TestCase
         $kernelProphecy->handle(Argument::type(ServerRequestInterface::class))->shouldNotHaveBeenCalled();
     }
 
-    public function testCanBeExcutedMultipleTimes()
+    public function testCanBeExecutedMultipleTimes(): void
     {
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -503,7 +503,7 @@ class MiddlewareDispatcherTest extends TestCase
         $kernelProphecy->handle(Argument::type(ServerRequestInterface::class))->shouldNotHaveBeenCalled();
     }
 
-    public function testCanBeReExecutedRecursivelyDuringDispatch()
+    public function testCanBeReExecutedRecursivelyDuringDispatch(): void
     {
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -552,7 +552,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->assertSame(['nested', 'outer'], $response->getHeader('X-TRACE'));
     }
 
-    public function testFetchesMiddlewareFromContainer()
+    public function testFetchesMiddlewareFromContainer(): void
     {
         $kernelProphecy = $this->prophesize(RequestHandlerInterface::class);
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);
@@ -576,7 +576,7 @@ class MiddlewareDispatcherTest extends TestCase
         $kernelProphecy->handle(Argument::type(ServerRequestInterface::class))->shouldNotHaveBeenCalled();
     }
 
-    public function testMiddlewareGetsInstantiatedWithContainer()
+    public function testMiddlewareGetsInstantiatedWithContainer(): void
     {
         $kernelProphecy = $this->prophesize(RequestHandlerInterface::class);
         $requestProphecy = $this->prophesize(ServerRequestInterface::class);

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -47,7 +47,7 @@ class ResponseEmitterTest extends TestCase
         HeaderStack::reset();
     }
 
-    public function testRespond()
+    public function testRespond(): void
     {
         $response = $this->createResponse();
         $response->getBody()->write('Hello');
@@ -58,7 +58,7 @@ class ResponseEmitterTest extends TestCase
         $this->expectOutputString('Hello');
     }
 
-    public function testRespondWithPaddedStreamFilterOutput()
+    public function testRespondWithPaddedStreamFilterOutput(): void
     {
         $availableFilter = stream_get_filters();
 
@@ -103,7 +103,7 @@ class ResponseEmitterTest extends TestCase
         }
     }
 
-    public function testRespondIndeterminateLength()
+    public function testRespondIndeterminateLength(): void
     {
         $stream = fopen('php://temp', 'r+');
         fwrite($stream, 'Hello');
@@ -123,7 +123,7 @@ class ResponseEmitterTest extends TestCase
         $this->expectOutputString('Hello');
     }
 
-    public function testResponseWithStreamReadYieldingLessBytesThanAsked()
+    public function testResponseWithStreamReadYieldingLessBytesThanAsked(): void
     {
         $body = new SmallChunksStream();
         $response = $this->createResponse()->withBody($body);
@@ -134,7 +134,7 @@ class ResponseEmitterTest extends TestCase
         $this->expectOutputString(str_repeat('.', $body->getSize()));
     }
 
-    public function testResponseReplacesPreviouslySetHeaders()
+    public function testResponseReplacesPreviouslySetHeaders(): void
     {
         $response = $this
             ->createResponse(200, 'OK')
@@ -152,7 +152,7 @@ class ResponseEmitterTest extends TestCase
         $this->assertSame($expectedStack, HeaderStack::stack());
     }
 
-    public function testResponseDoesNotReplacePreviouslySetSetCookieHeaders()
+    public function testResponseDoesNotReplacePreviouslySetSetCookieHeaders(): void
     {
         $response = $this
             ->createResponse(200, 'OK')
@@ -170,7 +170,7 @@ class ResponseEmitterTest extends TestCase
         $this->assertSame($expectedStack, HeaderStack::stack());
     }
 
-    public function testIsResponseEmptyWithNonEmptyBodyAndTriggeringStatusCode()
+    public function testIsResponseEmptyWithNonEmptyBodyAndTriggeringStatusCode(): void
     {
         $body = $this->createStream('Hello');
         $response = $this
@@ -181,7 +181,7 @@ class ResponseEmitterTest extends TestCase
         $this->assertTrue($responseEmitter->isResponseEmpty($response));
     }
 
-    public function testIsResponseEmptyDoesNotReadAllDataFromNonEmptySeekableResponse()
+    public function testIsResponseEmptyDoesNotReadAllDataFromNonEmptySeekableResponse(): void
     {
         $body = $this->createStream('Hello');
         $response = $this
@@ -195,7 +195,7 @@ class ResponseEmitterTest extends TestCase
         $this->assertFalse($body->eof());
     }
 
-    public function testIsResponseEmptyDoesNotDrainNonSeekableResponseWithContent()
+    public function testIsResponseEmptyDoesNotDrainNonSeekableResponseWithContent(): void
     {
         $resource = popen('echo 12', 'r');
         $body = $this->getStreamFactory()->createStreamFromResource($resource);
@@ -208,7 +208,7 @@ class ResponseEmitterTest extends TestCase
         $this->assertSame('12', trim((string) $body));
     }
 
-    public function testAvoidReadFromSlowStreamAccordingToStatus()
+    public function testAvoidReadFromSlowStreamAccordingToStatus(): void
     {
         $body = new SlowPokeStream();
         $response = $this
@@ -222,7 +222,7 @@ class ResponseEmitterTest extends TestCase
         $this->expectOutputString('');
     }
 
-    public function testIsResponseEmptyWithEmptyBody()
+    public function testIsResponseEmptyWithEmptyBody(): void
     {
         $response = $this->createResponse(200);
         $responseEmitter = new ResponseEmitter();
@@ -230,7 +230,7 @@ class ResponseEmitterTest extends TestCase
         $this->assertTrue($responseEmitter->isResponseEmpty($response));
     }
 
-    public function testIsResponseEmptyWithZeroAsBody()
+    public function testIsResponseEmptyWithZeroAsBody(): void
     {
         $body = $this->createStream('0');
         $response = $this
@@ -241,7 +241,7 @@ class ResponseEmitterTest extends TestCase
         $this->assertFalse($responseEmitter->isResponseEmpty($response));
     }
 
-    public function testWillHandleInvalidConnectionStatusWithADeterminateBody()
+    public function testWillHandleInvalidConnectionStatusWithADeterminateBody(): void
     {
         $body = $this->getStreamFactory()->createStreamFromResource(fopen('php://temp', 'r+'));
         $body->write('Hello!' . "\n");
@@ -264,7 +264,7 @@ class ResponseEmitterTest extends TestCase
         unset($GLOBALS['connection_status_return']);
     }
 
-    public function testWillHandleInvalidConnectionStatusWithAnIndeterminateBody()
+    public function testWillHandleInvalidConnectionStatusWithAnIndeterminateBody(): void
     {
         $body = $this->getStreamFactory()->createStreamFromResource(fopen('php://input', 'r+'));
 


### PR DESCRIPTION
This PR adds type declarations to the following classes:
- [`App`](https://github.com/slimphp/Slim/blob/4.x/Slim/App.php), [`AppTest`](https://github.com/slimphp/Slim/blob/4.x/tests/AppTest.php)
- [`CallableResolver`](https://github.com/slimphp/Slim/blob/4.x/Slim/CallableResolver.php), [`CallableResolverTest`](https://github.com/slimphp/Slim/blob/4.x/tests/CallableResolverTest.php)
- [`MiddlewareDispatcher`](https://github.com/slimphp/Slim/blob/4.x/Slim/MiddlewareDispatcher.php), [`MiddlewareDispatcherTest`](https://github.com/slimphp/Slim/blob/4.x/tests/MiddlewareDispatcherTest.php)
- [`ResponseEmitter`](https://github.com/slimphp/Slim/blob/4.x/Slim/ResponseEmitter.php), [`ResponseEmitterTest`](https://github.com/slimphp/Slim/blob/4.x/tests/ResponseEmitterTest.php)