### PR TITLE
Fix PHP 8.1 incompatibilities

### DIFF
--- a/Slim/Collection.php
+++ b/Slim/Collection.php
@@ -109,6 +109,7 @@ class Collection implements CollectionInterface
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return $this->has($key);
@@ -121,6 +122,7 @@ class Collection implements CollectionInterface
      *
      * @return mixed The key's value, or the default value
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->get($key);
@@ -132,6 +134,7 @@ class Collection implements CollectionInterface
      * @param string $key   The data key
      * @param mixed  $value The data value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->set($key, $value);
@@ -142,6 +145,7 @@ class Collection implements CollectionInterface
      *
      * @param string $key The data key
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         $this->remove($key);
@@ -152,6 +156,7 @@ class Collection implements CollectionInterface
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);
@@ -162,6 +167,7 @@ class Collection implements CollectionInterface
      *
      * @return ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->data);

--- a/Slim/Http/Uri.php
+++ b/Slim/Http/Uri.php
@@ -718,7 +718,7 @@ class Uri implements UriInterface
             function ($match) {
                 return rawurlencode($match[0]);
             },
-            $query
+            is_null($query) ? "" : $query
         );
     }
 


### PR DESCRIPTION
While migrating to PHP 8.1 I got fatal errors in the two files changed in this commit. Both changes were suggested by the PHP interpreters diagnostic message and when I fixed them my applicaton worked as before (barring an unrelated dependency or two). It has been running under PHP 7.3 and PHP 7.4 before this.

The first change suggested simply adds the #[\ReturnTypeWillChange] attribute to the methods derived from the ArrayAccess class.

The second change relates to type safety since the preg_replace_callback no longer accepts a $subject that is NULL due to changes in PHP 8.1 (as I understood it).

I made sure the existing tests passed when using PHP 5.6 and PHP 7.4 (I didn't manage to install PHP 5.5 though, but I hope that's OK).
The tests won't run in PHP 8.1 due to incompatibilities with the PHPUnit version, and I tried to upgrade to PHPUnit 8.5 and even PHPUnit 9 with no luck.