### PR TITLE
Adding property types to Middleware classes

### DIFF
--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -38,7 +38,7 @@ class BodyParsingMiddleware implements MiddlewareInterface
     /**
      * @var callable[]
      */
-    protected $bodyParsers;
+    protected array $bodyParsers;
 
     /**
      * @param callable[] $bodyParsers list of body parsers as an associative array of mediaType => callable

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -27,45 +27,27 @@ use function is_subclass_of;
 
 class ErrorMiddleware implements MiddlewareInterface
 {
-    /**
-     * @var CallableResolverInterface
-     */
-    protected $callableResolver;
+    protected CallableResolverInterface $callableResolver;
 
-    /**
-     * @var ResponseFactoryInterface
-     */
-    protected $responseFactory;
+    protected ResponseFactoryInterface $responseFactory;
 
-    /**
-     * @var bool
-     */
-    protected $displayErrorDetails;
+    protected bool $displayErrorDetails;
 
-    /**
-     * @var bool
-     */
-    protected $logErrors;
+    protected bool $logErrors;
 
-    /**
-     * @var bool
-     */
-    protected $logErrorDetails;
+    protected bool $logErrorDetails;
 
-    /**
-     * @var LoggerInterface|null
-     */
-    protected $logger;
+    protected ?LoggerInterface $logger = null;
 
     /**
      * @var ErrorHandlerInterface[]|callable[]|string[]
      */
-    protected $handlers = [];
+    protected array $handlers = [];
 
     /**
      * @var ErrorHandlerInterface[]|callable[]|string[]
      */
-    protected $subClassHandlers = [];
+    protected array $subClassHandlers = [];
 
     /**
      * @var ErrorHandlerInterface|callable|string|null

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -28,15 +28,9 @@ class OutputBufferingMiddleware implements MiddlewareInterface
     public const APPEND = 'append';
     public const PREPEND = 'prepend';
 
-    /**
-     * @var StreamFactoryInterface
-     */
-    protected $streamFactory;
+    protected StreamFactoryInterface $streamFactory;
 
-    /**
-     * @var string
-     */
-    protected $style;
+    protected string $style;
 
     /**
      * @param StreamFactoryInterface $streamFactory

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -24,15 +24,9 @@ use Slim\Routing\RoutingResults;
 
 class RoutingMiddleware implements MiddlewareInterface
 {
-    /**
-     * @var RouteResolverInterface
-     */
-    protected $routeResolver;
+    protected RouteResolverInterface $routeResolver;
 
-    /**
-     * @var RouteParserInterface
-     */
-    protected $routeParser;
+    protected RouteParserInterface $routeParser;
 
     /**
      * @param RouteResolverInterface $routeResolver


### PR DESCRIPTION
This PR adds property type declarations (where appropriate) to all classes in `Slim/Middleware`.

If this is a wanted change, let me know and I'll be more than happy to make other PRs for the rest of the codebase.