### PR TITLE
Handlers types

### DIFF
--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -61,7 +61,7 @@ class ErrorHandler implements ErrorHandlerInterface
     /**
      * @var array<string|callable>
      */
-    protected $errorRenderers = [
+    protected array $errorRenderers = [
         'application/json' => JsonErrorRenderer::class,
         'application/xml' => XmlErrorRenderer::class,
         'text/xml' => XmlErrorRenderer::class,

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -46,10 +46,7 @@ use function preg_match;
  */
 class ErrorHandler implements ErrorHandlerInterface
 {
-    /**
-     * @var string
-     */
-    protected $defaultErrorRendererContentType = 'text/html';
+    protected string $defaultErrorRendererContentType = 'text/html';
 
     /**
      * @var ErrorRendererInterface|string|callable
@@ -72,60 +69,27 @@ class ErrorHandler implements ErrorHandlerInterface
         'text/plain' => PlainTextErrorRenderer::class,
     ];
 
-    /**
-     * @var bool
-     */
-    protected $displayErrorDetails;
+    protected bool $displayErrorDetails = false;
 
-    /**
-     * @var bool
-     */
-    protected $logErrors;
+    protected bool $logErrors;
 
-    /**
-     * @var bool
-     */
-    protected $logErrorDetails;
+    protected bool $logErrorDetails = false;
 
-    /**
-     * @var string|null
-     */
-    protected $contentType;
+    protected ?string $contentType = null;
 
-    /**
-     * @var string
-     */
-    protected $method;
+    protected ?string $method = null;
 
-    /**
-     * @var ServerRequestInterface
-     */
-    protected $request;
+    protected ServerRequestInterface $request;
 
-    /**
-     * @var Throwable
-     */
-    protected $exception;
+    protected Throwable $exception;
 
-    /**
-     * @var int
-     */
-    protected $statusCode;
+    protected int $statusCode;
 
-    /**
-     * @var CallableResolverInterface
-     */
-    protected $callableResolver;
+    protected CallableResolverInterface $callableResolver;
 
-    /**
-     * @var ResponseFactoryInterface
-     */
-    protected $responseFactory;
+    protected ResponseFactoryInterface $responseFactory;
 
-    /**
-     * @var LoggerInterface
-     */
-    protected $logger;
+    protected LoggerInterface $logger;
 
     /**
      * @param CallableResolverInterface $callableResolver

--- a/Slim/Handlers/Strategies/RequestHandler.php
+++ b/Slim/Handlers/Strategies/RequestHandler.php
@@ -19,10 +19,7 @@ use Slim\Interfaces\RequestHandlerInvocationStrategyInterface;
  */
 class RequestHandler implements RequestHandlerInvocationStrategyInterface
 {
-    /**
-     * @var bool
-     */
-    protected $appendRouteArgumentsToRequestAttributes;
+    protected bool $appendRouteArgumentsToRequestAttributes;
 
     /**
      * @param bool $appendRouteArgumentsToRequestAttributes


### PR DESCRIPTION
Some more property type hints! This time for `Handlers`

A few notes on the changes made to `ErrorHandler`:

- The `method` property was being accessed before init, so I've switched it to be a nullable string with a default of null
- Both the `logErrorDetails` and `displayErrorDetails` properties were being accessed before init, so I've given them both default values of false

If there is a more sensible solution for the above, please let me know!



