### PR TITLE
Adding property type declarations for Factory classes

### DIFF
--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -26,50 +26,23 @@ use Slim\Interfaces\RouteResolverInterface;
 
 class AppFactory
 {
-    /**
-     * @var Psr17FactoryProviderInterface|null
-     */
-    protected static $psr17FactoryProvider;
+    protected static ?Psr17FactoryProviderInterface $psr17FactoryProvider = null;
 
-    /**
-     * @var ResponseFactoryInterface|null
-     */
-    protected static $responseFactory;
+    protected static ?ResponseFactoryInterface $responseFactory = null;
 
-    /**
-     * @var StreamFactoryInterface|null
-     */
-    protected static $streamFactory;
+    protected static ?StreamFactoryInterface $streamFactory = null;
 
-    /**
-     * @var ContainerInterface|null
-     */
-    protected static $container;
+    protected static ?ContainerInterface $container = null;
 
-    /**
-     * @var CallableResolverInterface|null
-     */
-    protected static $callableResolver;
+    protected static ?CallableResolverInterface $callableResolver = null;
 
-    /**
-     * @var RouteCollectorInterface|null
-     */
-    protected static $routeCollector;
+    protected static ?RouteCollectorInterface $routeCollector = null;
 
-    /**
-     * @var RouteResolverInterface|null
-     */
-    protected static $routeResolver;
+    protected static ?RouteResolverInterface $routeResolver = null;
 
-    /**
-     * @var MiddlewareDispatcherInterface|null
-     */
-    protected static $middlewareDispatcher;
+    protected static ?MiddlewareDispatcherInterface $middlewareDispatcher = null;
 
-    /**
-     * @var bool
-     */
-    protected static $slimHttpDecoratorsAutomaticDetectionEnabled = true;
+    protected static bool $slimHttpDecoratorsAutomaticDetectionEnabled = true;
 
     /**
      * @param ResponseFactoryInterface|null         $responseFactory

--- a/Slim/Factory/Psr17/GuzzlePsr17Factory.php
+++ b/Slim/Factory/Psr17/GuzzlePsr17Factory.php
@@ -12,8 +12,8 @@ namespace Slim\Factory\Psr17;
 
 class GuzzlePsr17Factory extends Psr17Factory
 {
-    protected static $responseFactoryClass = 'GuzzleHttp\Psr7\HttpFactory';
-    protected static $streamFactoryClass = 'GuzzleHttp\Psr7\HttpFactory';
-    protected static $serverRequestCreatorClass = 'GuzzleHttp\Psr7\ServerRequest';
-    protected static $serverRequestCreatorMethod = 'fromGlobals';
+    protected static string $responseFactoryClass = 'GuzzleHttp\Psr7\HttpFactory';
+    protected static string $streamFactoryClass = 'GuzzleHttp\Psr7\HttpFactory';
+    protected static string $serverRequestCreatorClass = 'GuzzleHttp\Psr7\ServerRequest';
+    protected static string $serverRequestCreatorMethod = 'fromGlobals';
 }

--- a/Slim/Factory/Psr17/HttpSoftPsr17Factory.php
+++ b/Slim/Factory/Psr17/HttpSoftPsr17Factory.php
@@ -12,8 +12,8 @@ namespace Slim\Factory\Psr17;
 
 class HttpSoftPsr17Factory extends Psr17Factory
 {
-    protected static $responseFactoryClass = 'HttpSoft\Message\ResponseFactory';
-    protected static $streamFactoryClass = 'HttpSoft\Message\StreamFactory';
-    protected static $serverRequestCreatorClass = 'HttpSoft\ServerRequest\ServerRequestCreator';
-    protected static $serverRequestCreatorMethod = 'createFromGlobals';
+    protected static string $responseFactoryClass = 'HttpSoft\Message\ResponseFactory';
+    protected static string $streamFactoryClass = 'HttpSoft\Message\StreamFactory';
+    protected static string $serverRequestCreatorClass = 'HttpSoft\ServerRequest\ServerRequestCreator';
+    protected static string $serverRequestCreatorMethod = 'createFromGlobals';
 }

--- a/Slim/Factory/Psr17/LaminasDiactorosPsr17Factory.php
+++ b/Slim/Factory/Psr17/LaminasDiactorosPsr17Factory.php
@@ -12,8 +12,8 @@ namespace Slim\Factory\Psr17;
 
 class LaminasDiactorosPsr17Factory extends Psr17Factory
 {
-    protected static $responseFactoryClass = 'Laminas\Diactoros\ResponseFactory';
-    protected static $streamFactoryClass = 'Laminas\Diactoros\StreamFactory';
-    protected static $serverRequestCreatorClass = 'Laminas\Diactoros\ServerRequestFactory';
-    protected static $serverRequestCreatorMethod = 'fromGlobals';
+    protected static string $responseFactoryClass = 'Laminas\Diactoros\ResponseFactory';
+    protected static string $streamFactoryClass = 'Laminas\Diactoros\StreamFactory';
+    protected static string $serverRequestCreatorClass = 'Laminas\Diactoros\ServerRequestFactory';
+    protected static string $serverRequestCreatorMethod = 'fromGlobals';
 }

--- a/Slim/Factory/Psr17/NyholmPsr17Factory.php
+++ b/Slim/Factory/Psr17/NyholmPsr17Factory.php
@@ -8,10 +8,10 @@ use Slim\Interfaces\ServerRequestCreatorInterface;
 
 class NyholmPsr17Factory extends Psr17Factory
 {
-    protected static $responseFactoryClass = 'Nyholm\Psr7\Factory\Psr17Factory';
-    protected static $streamFactoryClass = 'Nyholm\Psr7\Factory\Psr17Factory';
-    protected static $serverRequestCreatorClass = 'Nyholm\Psr7Server\ServerRequestCreator';
-    protected static $serverRequestCreatorMethod = 'fromGlobals';
+    protected static string $responseFactoryClass = 'Nyholm\Psr7\Factory\Psr17Factory';
+    protected static string $streamFactoryClass = 'Nyholm\Psr7\Factory\Psr17Factory';
+    protected static string $serverRequestCreatorClass = 'Nyholm\Psr7Server\ServerRequestCreator';
+    protected static string $serverRequestCreatorMethod = 'fromGlobals';
 
     /**
      * {@inheritdoc}

--- a/Slim/Factory/Psr17/Psr17Factory.php
+++ b/Slim/Factory/Psr17/Psr17Factory.php
@@ -21,25 +21,13 @@ use function get_called_class;
 
 abstract class Psr17Factory implements Psr17FactoryInterface
 {
-    /**
-     * @var string
-     */
-    protected static $responseFactoryClass;
+    protected static string $responseFactoryClass;
 
-    /**
-     * @var string
-     */
-    protected static $streamFactoryClass;
+    protected static string $streamFactoryClass;
 
-    /**
-     * @var string
-     */
-    protected static $serverRequestCreatorClass;
+    protected static string $serverRequestCreatorClass;
 
-    /**
-     * @var string
-     */
-    protected static $serverRequestCreatorMethod;
+    protected static string $serverRequestCreatorMethod;
 
     /**
      * {@inheritdoc}

--- a/Slim/Factory/Psr17/Psr17FactoryProvider.php
+++ b/Slim/Factory/Psr17/Psr17FactoryProvider.php
@@ -19,7 +19,7 @@ class Psr17FactoryProvider implements Psr17FactoryProviderInterface
     /**
      * @var string[]
      */
-    protected static $factories = [
+    protected static array $factories = [
         SlimPsr17Factory::class,
         HttpSoftPsr17Factory::class,
         NyholmPsr17Factory::class,

--- a/Slim/Factory/Psr17/ServerRequestCreator.php
+++ b/Slim/Factory/Psr17/ServerRequestCreator.php
@@ -21,10 +21,7 @@ class ServerRequestCreator implements ServerRequestCreatorInterface
      */
     protected $serverRequestCreator;
 
-    /**
-     * @var string
-     */
-    protected $serverRequestCreatorMethod;
+    protected string $serverRequestCreatorMethod;
 
     /**
      * @param object|string $serverRequestCreator

--- a/Slim/Factory/Psr17/SlimHttpPsr17Factory.php
+++ b/Slim/Factory/Psr17/SlimHttpPsr17Factory.php
@@ -16,7 +16,7 @@ use RuntimeException;
 
 class SlimHttpPsr17Factory extends Psr17Factory
 {
-    protected static $responseFactoryClass = 'Slim\Http\Factory\DecoratedResponseFactory';
+    protected static string $responseFactoryClass = 'Slim\Http\Factory\DecoratedResponseFactory';
 
     /**
      * @param ResponseFactoryInterface $responseFactory

--- a/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
+++ b/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
@@ -18,15 +18,9 @@ use function class_exists;
 
 class SlimHttpServerRequestCreator implements ServerRequestCreatorInterface
 {
-    /**
-     * @var ServerRequestCreatorInterface
-     */
-    protected $serverRequestCreator;
+    protected ServerRequestCreatorInterface $serverRequestCreator;
 
-    /**
-     * @var string
-     */
-    protected static $serverRequestDecoratorClass = 'Slim\Http\ServerRequest';
+    protected static string $serverRequestDecoratorClass = 'Slim\Http\ServerRequest';
 
     /**
      * @param ServerRequestCreatorInterface $serverRequestCreator

--- a/Slim/Factory/Psr17/SlimPsr17Factory.php
+++ b/Slim/Factory/Psr17/SlimPsr17Factory.php
@@ -12,8 +12,8 @@ namespace Slim\Factory\Psr17;
 
 class SlimPsr17Factory extends Psr17Factory
 {
-    protected static $responseFactoryClass = 'Slim\Psr7\Factory\ResponseFactory';
-    protected static $streamFactoryClass = 'Slim\Psr7\Factory\StreamFactory';
-    protected static $serverRequestCreatorClass = 'Slim\Psr7\Factory\ServerRequestFactory';
-    protected static $serverRequestCreatorMethod = 'createFromGlobals';
+    protected static string $responseFactoryClass = 'Slim\Psr7\Factory\ResponseFactory';
+    protected static string $streamFactoryClass = 'Slim\Psr7\Factory\StreamFactory';
+    protected static string $serverRequestCreatorClass = 'Slim\Psr7\Factory\ServerRequestFactory';
+    protected static string $serverRequestCreatorMethod = 'createFromGlobals';
 }

--- a/Slim/Factory/ServerRequestCreatorFactory.php
+++ b/Slim/Factory/ServerRequestCreatorFactory.php
@@ -19,20 +19,11 @@ use Slim\Interfaces\ServerRequestCreatorInterface;
 
 class ServerRequestCreatorFactory
 {
-    /**
-     * @var Psr17FactoryProviderInterface|null
-     */
-    protected static $psr17FactoryProvider;
+    protected static ?Psr17FactoryProviderInterface $psr17FactoryProvider = null;
 
-    /**
-     * @var ServerRequestCreatorInterface|null
-     */
-    protected static $serverRequestCreator;
+    protected static ?ServerRequestCreatorInterface $serverRequestCreator = null;
 
-    /**
-     * @var bool
-     */
-    protected static $slimHttpDecoratorsAutomaticDetectionEnabled = true;
+    protected static bool $slimHttpDecoratorsAutomaticDetectionEnabled = true;
 
     /**
      * @return ServerRequestCreatorInterface

--- a/tests/Mocks/MockPsr17Factory.php
+++ b/tests/Mocks/MockPsr17Factory.php
@@ -14,8 +14,8 @@ use Slim\Factory\Psr17\Psr17Factory;
 
 class MockPsr17Factory extends Psr17Factory
 {
-    protected static $responseFactoryClass = '';
-    protected static $streamFactoryClass = '';
-    protected static $serverRequestCreatorClass = '';
-    protected static $serverRequestCreatorMethod = '';
+    protected static string $responseFactoryClass = '';
+    protected static string $streamFactoryClass = '';
+    protected static string $serverRequestCreatorClass = '';
+    protected static string $serverRequestCreatorMethod = '';
 }

--- a/tests/Mocks/MockPsr17FactoryWithoutStreamFactory.php
+++ b/tests/Mocks/MockPsr17FactoryWithoutStreamFactory.php
@@ -14,8 +14,8 @@ use Slim\Factory\Psr17\Psr17Factory;
 
 class MockPsr17FactoryWithoutStreamFactory extends Psr17Factory
 {
-    protected static $responseFactoryClass = 'Slim\Psr7\Factory\ResponseFactory';
-    protected static $streamFactoryClass = '';
-    protected static $serverRequestCreatorClass = '';
-    protected static $serverRequestCreatorMethod = '';
+    protected static string $responseFactoryClass = 'Slim\Psr7\Factory\ResponseFactory';
+    protected static string $streamFactoryClass = '';
+    protected static string $serverRequestCreatorClass = '';
+    protected static string $serverRequestCreatorMethod = '';
 }


### PR DESCRIPTION
Added type declarations for all properties in `Slim\Factory` classes excluding a union in `ServerRequestCreator` to preserve php7.4 compatibility