### PR TITLE
Remove redundant docblock types

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -44,14 +44,6 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
 
     protected MiddlewareDispatcherInterface $middlewareDispatcher;
 
-    /**
-     * @param ResponseFactoryInterface              $responseFactory
-     * @param ContainerInterface|null               $container
-     * @param CallableResolverInterface|null        $callableResolver
-     * @param RouteCollectorInterface|null          $routeCollector
-     * @param RouteResolverInterface|null           $routeResolver
-     * @param MiddlewareDispatcherInterface|null    $middlewareDispatcher
-     */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
         ?ContainerInterface $container = null,
@@ -97,7 +89,6 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
 
     /**
      * @param MiddlewareInterface|string|callable $middleware
-     * @return self
      */
     public function add($middleware): self
     {
@@ -107,7 +98,6 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
 
     /**
      * @param MiddlewareInterface $middleware
-     * @return self
      */
     public function addMiddleware(MiddlewareInterface $middleware): self
     {

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -32,9 +32,6 @@ final class CallableResolver implements AdvancedCallableResolverInterface
 
     private ?ContainerInterface $container;
 
-    /**
-     * @param ContainerInterface|null $container
-     */
     public function __construct(?ContainerInterface $container = null)
     {
         $this->container = $container;
@@ -76,12 +73,8 @@ final class CallableResolver implements AdvancedCallableResolverInterface
 
     /**
      * @param string|callable $toResolve
-     * @param callable        $predicate
-     * @param string          $defaultMethod
      *
      * @throws RuntimeException
-     *
-     * @return callable
      */
     private function resolveByPredicate($toResolve, callable $predicate, string $defaultMethod): callable
     {
@@ -106,8 +99,6 @@ final class CallableResolver implements AdvancedCallableResolverInterface
 
     /**
      * @param mixed $toResolve
-     *
-     * @return bool
      */
     private function isRoute($toResolve): bool
     {
@@ -116,8 +107,6 @@ final class CallableResolver implements AdvancedCallableResolverInterface
 
     /**
      * @param mixed $toResolve
-     *
-     * @return bool
      */
     private function isMiddleware($toResolve): bool
     {
@@ -125,8 +114,6 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     }
 
     /**
-     * @param string $toResolve
-     *
      * @throws RuntimeException
      *
      * @return array{object, string|null} [Instance, Method Name]
@@ -160,8 +147,6 @@ final class CallableResolver implements AdvancedCallableResolverInterface
      * @param mixed $toResolve
      *
      * @throws RuntimeException
-     *
-     * @return callable
      */
     private function assertCallable($resolved, $toResolve): callable
     {
@@ -176,11 +161,6 @@ final class CallableResolver implements AdvancedCallableResolverInterface
         return $resolved;
     }
 
-    /**
-     * @param callable $callable
-     *
-     * @return callable
-     */
     private function bindToContainer(callable $callable): callable
     {
         if (is_array($callable) && $callable[0] instanceof Closure) {

--- a/Slim/Error/AbstractErrorRenderer.php
+++ b/Slim/Error/AbstractErrorRenderer.php
@@ -26,10 +26,6 @@ abstract class AbstractErrorRenderer implements ErrorRendererInterface
 
     protected string $defaultErrorDescription = 'A website error has occurred. Sorry for the temporary inconvenience.';
 
-    /**
-     * @param Throwable $exception
-     * @return string
-     */
     protected function getErrorTitle(Throwable $exception): string
     {
         if ($exception instanceof HttpException) {
@@ -39,10 +35,6 @@ abstract class AbstractErrorRenderer implements ErrorRendererInterface
         return $this->defaultErrorTitle;
     }
 
-    /**
-     * @param Throwable $exception
-     * @return string
-     */
     protected function getErrorDescription(Throwable $exception): string
     {
         if ($exception instanceof HttpException) {

--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -22,11 +22,6 @@ use function sprintf;
  */
 class HtmlErrorRenderer extends AbstractErrorRenderer
 {
-    /**
-     * @param Throwable $exception
-     * @param bool      $displayErrorDetails
-     * @return string
-     */
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
         if ($displayErrorDetails) {
@@ -40,10 +35,6 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
         return $this->renderHtmlBody($this->getErrorTitle($exception), $html);
     }
 
-    /**
-     * @param Throwable $exception
-     * @return string
-     */
     private function renderExceptionFragment(Throwable $exception): string
     {
         $html = sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
@@ -64,11 +55,6 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
         return $html;
     }
 
-    /**
-     * @param string $title
-     * @param string $html
-     * @return string
-     */
     public function renderHtmlBody(string $title = '', string $html = ''): string
     {
         return sprintf(

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -24,11 +24,6 @@ use const JSON_UNESCAPED_SLASHES;
  */
 class JsonErrorRenderer extends AbstractErrorRenderer
 {
-    /**
-     * @param Throwable $exception
-     * @param bool      $displayErrorDetails
-     * @return string
-     */
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
         $error = ['message' => $this->getErrorTitle($exception)];
@@ -44,7 +39,6 @@ class JsonErrorRenderer extends AbstractErrorRenderer
     }
 
     /**
-     * @param Throwable $exception
      * @return array<string|int>
      */
     private function formatExceptionFragment(Throwable $exception): array

--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -22,11 +22,6 @@ use function sprintf;
  */
 class PlainTextErrorRenderer extends AbstractErrorRenderer
 {
-    /**
-     * @param Throwable $exception
-     * @param bool      $displayErrorDetails
-     * @return string
-     */
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
         $text = "{$this->getErrorTitle($exception)}\n";
@@ -43,10 +38,6 @@ class PlainTextErrorRenderer extends AbstractErrorRenderer
         return $text;
     }
 
-    /**
-     * @param Throwable $exception
-     * @return string
-     */
     private function formatExceptionFragment(Throwable $exception): string
     {
         $text = sprintf("Type: %s\n", get_class($exception));

--- a/Slim/Error/Renderers/XmlErrorRenderer.php
+++ b/Slim/Error/Renderers/XmlErrorRenderer.php
@@ -22,11 +22,6 @@ use function str_replace;
  */
 class XmlErrorRenderer extends AbstractErrorRenderer
 {
-    /**
-     * @param Throwable $exception
-     * @param bool      $displayErrorDetails
-     * @return string
-     */
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
         $xml = '<' . '?xml version="1.0" encoding="UTF-8" standalone="yes"?' . ">\n";
@@ -51,9 +46,6 @@ class XmlErrorRenderer extends AbstractErrorRenderer
 
     /**
      * Returns a CDATA section with the given content.
-     *
-     * @param  string $content
-     * @return string
      */
     private function createCdataSection(string $content): string
     {

--- a/Slim/Exception/HttpException.php
+++ b/Slim/Exception/HttpException.php
@@ -25,12 +25,6 @@ class HttpException extends RuntimeException
 
     protected string $description = '';
 
-    /**
-     * @param ServerRequestInterface $request
-     * @param string                 $message
-     * @param int                    $code
-     * @param Throwable|null         $previous
-     */
     public function __construct(
         ServerRequestInterface $request,
         string $message = '',
@@ -41,44 +35,27 @@ class HttpException extends RuntimeException
         $this->request = $request;
     }
 
-    /**
-     * @return ServerRequestInterface
-     */
     public function getRequest(): ServerRequestInterface
     {
         return $this->request;
     }
 
-    /**
-     * @return string
-     */
     public function getTitle(): string
     {
         return $this->title;
     }
 
-    /**
-     * @param string $title
-     * @return self
-     */
     public function setTitle(string $title): self
     {
         $this->title = $title;
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * @param string $description
-     * @return self
-     */
     public function setDescription(string $description): self
     {
         $this->description = $description;

--- a/Slim/Exception/HttpMethodNotAllowedException.php
+++ b/Slim/Exception/HttpMethodNotAllowedException.php
@@ -17,7 +17,7 @@ class HttpMethodNotAllowedException extends HttpSpecializedException
     /**
      * @var string[]
      */
-    protected $allowedMethods = [];
+    protected array $allowedMethods = [];
 
     /**
      * @var int
@@ -42,9 +42,8 @@ class HttpMethodNotAllowedException extends HttpSpecializedException
 
     /**
      * @param string[] $methods
-     * @return self
      */
-    public function setAllowedMethods(array $methods): HttpMethodNotAllowedException
+    public function setAllowedMethods(array $methods): self
     {
         $this->allowedMethods = $methods;
         $this->message = 'Method not allowed. Must be one of: ' . implode(', ', $methods);

--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -44,15 +44,6 @@ class AppFactory
 
     protected static bool $slimHttpDecoratorsAutomaticDetectionEnabled = true;
 
-    /**
-     * @param ResponseFactoryInterface|null         $responseFactory
-     * @param ContainerInterface|null               $container
-     * @param CallableResolverInterface|null        $callableResolver
-     * @param RouteCollectorInterface|null          $routeCollector
-     * @param RouteResolverInterface|null           $routeResolver
-     * @param MiddlewareDispatcherInterface|null    $middlewareDispatcher
-     * @return App
-     */
     public static function create(
         ?ResponseFactoryInterface $responseFactory = null,
         ?ContainerInterface $container = null,
@@ -72,10 +63,6 @@ class AppFactory
         );
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return App
-     */
     public static function createFromContainer(ContainerInterface $container): App
     {
         $responseFactory = $container->has(ResponseFactoryInterface::class)
@@ -124,7 +111,6 @@ class AppFactory
     }
 
     /**
-     * @return ResponseFactoryInterface
      * @throws RuntimeException
      */
     public static function determineResponseFactory(): ResponseFactoryInterface
@@ -159,11 +145,6 @@ class AppFactory
         );
     }
 
-    /**
-     * @param ResponseFactoryInterface $responseFactory
-     * @param StreamFactoryInterface   $streamFactory
-     * @return ResponseFactoryInterface
-     */
     protected static function attemptResponseFactoryDecoration(
         ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory
@@ -178,73 +159,46 @@ class AppFactory
         return $responseFactory;
     }
 
-    /**
-     * @param Psr17FactoryProviderInterface $psr17FactoryProvider
-     */
     public static function setPsr17FactoryProvider(Psr17FactoryProviderInterface $psr17FactoryProvider): void
     {
         static::$psr17FactoryProvider = $psr17FactoryProvider;
     }
 
-    /**
-     * @param ResponseFactoryInterface $responseFactory
-     */
     public static function setResponseFactory(ResponseFactoryInterface $responseFactory): void
     {
         static::$responseFactory = $responseFactory;
     }
 
-    /**
-     * @param StreamFactoryInterface $streamFactory
-     */
     public static function setStreamFactory(StreamFactoryInterface $streamFactory): void
     {
         static::$streamFactory = $streamFactory;
     }
 
-    /**
-     * @param ContainerInterface $container
-     */
     public static function setContainer(ContainerInterface $container): void
     {
         static::$container = $container;
     }
 
-    /**
-     * @param CallableResolverInterface $callableResolver
-     */
     public static function setCallableResolver(CallableResolverInterface $callableResolver): void
     {
         static::$callableResolver = $callableResolver;
     }
 
-    /**
-     * @param RouteCollectorInterface $routeCollector
-     */
     public static function setRouteCollector(RouteCollectorInterface $routeCollector): void
     {
         static::$routeCollector = $routeCollector;
     }
 
-    /**
-     * @param RouteResolverInterface $routeResolver
-     */
     public static function setRouteResolver(RouteResolverInterface $routeResolver): void
     {
         static::$routeResolver = $routeResolver;
     }
 
-    /**
-     * @param MiddlewareDispatcherInterface $middlewareDispatcher
-     */
     public static function setMiddlewareDispatcher(MiddlewareDispatcherInterface $middlewareDispatcher): void
     {
         static::$middlewareDispatcher = $middlewareDispatcher;
     }
 
-    /**
-     * @param bool $enabled
-     */
     public static function setSlimHttpDecoratorsAutomaticDetection(bool $enabled): void
     {
         static::$slimHttpDecoratorsAutomaticDetectionEnabled = $enabled;

--- a/Slim/Factory/Psr17/ServerRequestCreator.php
+++ b/Slim/Factory/Psr17/ServerRequestCreator.php
@@ -25,7 +25,6 @@ class ServerRequestCreator implements ServerRequestCreatorInterface
 
     /**
      * @param object|string $serverRequestCreator
-     * @param string        $serverRequestCreatorMethod
      */
     public function __construct($serverRequestCreator, string $serverRequestCreatorMethod)
     {

--- a/Slim/Factory/Psr17/SlimHttpPsr17Factory.php
+++ b/Slim/Factory/Psr17/SlimHttpPsr17Factory.php
@@ -19,10 +19,6 @@ class SlimHttpPsr17Factory extends Psr17Factory
     protected static string $responseFactoryClass = 'Slim\Http\Factory\DecoratedResponseFactory';
 
     /**
-     * @param ResponseFactoryInterface $responseFactory
-     * @param StreamFactoryInterface   $streamFactory
-     * @return ResponseFactoryInterface
-     *
      * @throws RuntimeException when the factory could not be instantiated
      */
     public static function createDecoratedResponseFactory(

--- a/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
+++ b/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
@@ -22,9 +22,6 @@ class SlimHttpServerRequestCreator implements ServerRequestCreatorInterface
 
     protected static string $serverRequestDecoratorClass = 'Slim\Http\ServerRequest';
 
-    /**
-     * @param ServerRequestCreatorInterface $serverRequestCreator
-     */
     public function __construct(ServerRequestCreatorInterface $serverRequestCreator)
     {
         $this->serverRequestCreator = $serverRequestCreator;
@@ -52,9 +49,6 @@ class SlimHttpServerRequestCreator implements ServerRequestCreatorInterface
         return $decoratedServerRequest;
     }
 
-    /**
-     * @return bool
-     */
     public static function isServerRequestDecoratorAvailable(): bool
     {
         return class_exists(static::$serverRequestDecoratorClass);

--- a/Slim/Factory/ServerRequestCreatorFactory.php
+++ b/Slim/Factory/ServerRequestCreatorFactory.php
@@ -25,16 +25,12 @@ class ServerRequestCreatorFactory
 
     protected static bool $slimHttpDecoratorsAutomaticDetectionEnabled = true;
 
-    /**
-     * @return ServerRequestCreatorInterface
-     */
     public static function create(): ServerRequestCreatorInterface
     {
         return static::determineServerRequestCreator();
     }
 
     /**
-     * @return ServerRequestCreatorInterface
      * @throws RuntimeException
      */
     public static function determineServerRequestCreator(): ServerRequestCreatorInterface
@@ -61,10 +57,6 @@ class ServerRequestCreatorFactory
         );
     }
 
-    /**
-     * @param ServerRequestCreatorInterface $serverRequestCreator
-     * @return ServerRequestCreatorInterface
-     */
     protected static function attemptServerRequestCreatorDecoration(
         ServerRequestCreatorInterface $serverRequestCreator
     ): ServerRequestCreatorInterface {
@@ -78,25 +70,16 @@ class ServerRequestCreatorFactory
         return $serverRequestCreator;
     }
 
-    /**
-     * @param Psr17FactoryProviderInterface $psr17FactoryProvider
-     */
     public static function setPsr17FactoryProvider(Psr17FactoryProviderInterface $psr17FactoryProvider): void
     {
         static::$psr17FactoryProvider = $psr17FactoryProvider;
     }
 
-    /**
-     * @param ServerRequestCreatorInterface $serverRequestCreator
-     */
     public static function setServerRequestCreator(ServerRequestCreatorInterface $serverRequestCreator): void
     {
         self::$serverRequestCreator = $serverRequestCreator;
     }
 
-    /**
-     * @param bool $enabled
-     */
     public static function setSlimHttpDecoratorsAutomaticDetection(bool $enabled): void
     {
         static::$slimHttpDecoratorsAutomaticDetectionEnabled = $enabled;

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -91,11 +91,6 @@ class ErrorHandler implements ErrorHandlerInterface
 
     protected LoggerInterface $logger;
 
-    /**
-     * @param CallableResolverInterface $callableResolver
-     * @param ResponseFactoryInterface  $responseFactory
-     * @param LoggerInterface|null      $logger
-     */
     public function __construct(
         CallableResolverInterface $callableResolver,
         ResponseFactoryInterface $responseFactory,
@@ -114,8 +109,6 @@ class ErrorHandler implements ErrorHandlerInterface
      * @param bool                   $displayErrorDetails Whether or not to display the error details
      * @param bool                   $logErrors           Whether or not to log errors
      * @param bool                   $logErrorDetails     Whether or not to log error details
-     *
-     * @return ResponseInterface
      */
     public function __invoke(
         ServerRequestInterface $request,
@@ -152,9 +145,6 @@ class ErrorHandler implements ErrorHandlerInterface
         $this->contentType = $contentType;
     }
 
-    /**
-     * @return int
-     */
     protected function determineStatusCode(): int
     {
         if ($this->method === 'OPTIONS') {
@@ -174,9 +164,6 @@ class ErrorHandler implements ErrorHandlerInterface
      * Note: This method is a bare-bones implementation designed specifically for
      * Slim's error handling requirements. Consider a fully-feature solution such
      * as willdurand/negotiation for any other situation.
-     *
-     * @param ServerRequestInterface $request
-     * @return string|null
      */
     protected function determineContentType(ServerRequestInterface $request): ?string
     {
@@ -218,8 +205,6 @@ class ErrorHandler implements ErrorHandlerInterface
 
     /**
      * Determine which renderer to use based on content type
-     *
-     * @return callable
      *
      * @throws RuntimeException
      */
@@ -269,8 +254,6 @@ class ErrorHandler implements ErrorHandlerInterface
 
     /**
      * Write to the error log if $logErrors has been set to true
-     *
-     * @return void
      */
     protected function writeToErrorLog(): void
     {
@@ -285,9 +268,6 @@ class ErrorHandler implements ErrorHandlerInterface
 
     /**
      * Wraps the error_log function so that this can be easily tested
-     *
-     * @param string $error
-     * @return void
      */
     protected function logError(string $error): void
     {
@@ -296,17 +276,12 @@ class ErrorHandler implements ErrorHandlerInterface
 
     /**
      * Returns a default logger implementation.
-     *
-     * @return LoggerInterface
      */
     protected function getDefaultLogger(): LoggerInterface
     {
         return new Logger();
     }
 
-    /**
-     * @return ResponseInterface
-     */
     protected function respond(): ResponseInterface
     {
         $response = $this->responseFactory->createResponse($this->statusCode);

--- a/Slim/Handlers/Strategies/RequestHandler.php
+++ b/Slim/Handlers/Strategies/RequestHandler.php
@@ -21,9 +21,6 @@ class RequestHandler implements RequestHandlerInvocationStrategyInterface
 {
     protected bool $appendRouteArgumentsToRequestAttributes;
 
-    /**
-     * @param bool $appendRouteArgumentsToRequestAttributes
-     */
     public function __construct(bool $appendRouteArgumentsToRequestAttributes = false)
     {
         $this->appendRouteArgumentsToRequestAttributes = $appendRouteArgumentsToRequestAttributes;
@@ -32,12 +29,7 @@ class RequestHandler implements RequestHandlerInvocationStrategyInterface
     /**
      * Invoke a route callable that implements RequestHandlerInterface
      *
-     * @param callable               $callable
-     * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
      * @param array<string, string>  $routeArguments
-     *
-     * @return ResponseInterface
      */
     public function __invoke(
         callable $callable,

--- a/Slim/Handlers/Strategies/RequestResponse.php
+++ b/Slim/Handlers/Strategies/RequestResponse.php
@@ -23,12 +23,7 @@ class RequestResponse implements InvocationStrategyInterface
      * Invoke a route callable with request, response, and all route parameters
      * as an array of arguments.
      *
-     * @param callable               $callable
-     * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
      * @param array<string, string>  $routeArguments
-     *
-     * @return ResponseInterface
      */
     public function __invoke(
         callable $callable,

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -25,12 +25,7 @@ class RequestResponseArgs implements InvocationStrategyInterface
      * Invoke a route callable with request, response and all route parameters
      * as individual arguments.
      *
-     * @param callable               $callable
-     * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
      * @param array<string, string>  $routeArguments
-     *
-     * @return ResponseInterface
      */
     public function __invoke(
         callable $callable,

--- a/Slim/Handlers/Strategies/RequestResponseNamedArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseNamedArgs.php
@@ -31,12 +31,7 @@ class RequestResponseNamedArgs implements InvocationStrategyInterface
      * Invoke a route callable with request, response and all route parameters
      * as individual arguments.
      *
-     * @param callable               $callable
-     * @param ServerRequestInterface $request
-     * @param ResponseInterface      $response
      * @param array<string, string>  $routeArguments
-     *
-     * @return ResponseInterface
      */
     public function __invoke(
         callable $callable,

--- a/Slim/Interfaces/AdvancedCallableResolverInterface.php
+++ b/Slim/Interfaces/AdvancedCallableResolverInterface.php
@@ -16,8 +16,6 @@ interface AdvancedCallableResolverInterface extends CallableResolverInterface
      * Resolve $toResolve into a callable
      *
      * @param string|callable $toResolve
-     *
-     * @return callable
      */
     public function resolveRoute($toResolve): callable;
 
@@ -25,8 +23,6 @@ interface AdvancedCallableResolverInterface extends CallableResolverInterface
      * Resolve $toResolve into a callable
      *
      * @param string|callable $toResolve
-     *
-     * @return callable
      */
     public function resolveMiddleware($toResolve): callable;
 }

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -16,7 +16,6 @@ interface CallableResolverInterface
      * Resolve $toResolve into a callable
      *
      * @param string|callable $toResolve
-     * @return callable
      */
     public function resolve($toResolve): callable;
 }

--- a/Slim/Interfaces/DispatcherInterface.php
+++ b/Slim/Interfaces/DispatcherInterface.php
@@ -16,17 +16,12 @@ interface DispatcherInterface
 {
     /**
      * Get routing results for a given request method and uri
-     *
-     * @param string $method
-     * @param string $uri
-     * @return RoutingResults
      */
     public function dispatch(string $method, string $uri): RoutingResults;
 
     /**
      * Get allowed methods for a given uri
      *
-     * @param string $uri
      * @return string[]
      */
     public function getAllowedMethods(string $uri): array;

--- a/Slim/Interfaces/ErrorHandlerInterface.php
+++ b/Slim/Interfaces/ErrorHandlerInterface.php
@@ -16,14 +16,6 @@ use Throwable;
 
 interface ErrorHandlerInterface
 {
-    /**
-     * @param ServerRequestInterface $request
-     * @param Throwable              $exception
-     * @param bool                   $displayErrorDetails
-     * @param bool                   $logErrors
-     * @param bool                   $logErrorDetails
-     * @return ResponseInterface
-     */
     public function __invoke(
         ServerRequestInterface $request,
         Throwable $exception,

--- a/Slim/Interfaces/ErrorRendererInterface.php
+++ b/Slim/Interfaces/ErrorRendererInterface.php
@@ -14,10 +14,5 @@ use Throwable;
 
 interface ErrorRendererInterface
 {
-    /**
-     * @param Throwable $exception
-     * @param bool      $displayErrorDetails
-     * @return string
-     */
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string;
 }

--- a/Slim/Interfaces/MiddlewareDispatcherInterface.php
+++ b/Slim/Interfaces/MiddlewareDispatcherInterface.php
@@ -23,7 +23,6 @@ interface MiddlewareDispatcherInterface extends RequestHandlerInterface
      * added one (last in, first out).
      *
      * @param MiddlewareInterface|string|callable $middleware
-     * @return self
      */
     public function add($middleware): self;
 
@@ -33,17 +32,11 @@ interface MiddlewareDispatcherInterface extends RequestHandlerInterface
      * Middleware are organized as a stack. That means middleware
      * that have been added before will be executed after the newly
      * added one (last in, first out).
-     *
-     * @param MiddlewareInterface $middleware
-     * @return self
      */
     public function addMiddleware(MiddlewareInterface $middleware): self;
 
     /**
      * Seed the middleware stack with the inner request handler
-     *
-     * @param RequestHandlerInterface $kernel
-     * @return void
      */
     public function seedMiddlewareStack(RequestHandlerInterface $kernel): void;
 }

--- a/Slim/Interfaces/Psr17FactoryInterface.php
+++ b/Slim/Interfaces/Psr17FactoryInterface.php
@@ -17,44 +17,32 @@ use RuntimeException;
 interface Psr17FactoryInterface
 {
     /**
-     * @return ResponseFactoryInterface
-     *
      * @throws RuntimeException when the factory could not be instantiated
      */
     public static function getResponseFactory(): ResponseFactoryInterface;
 
     /**
-     * @return StreamFactoryInterface
-     *
      * @throws RuntimeException when the factory could not be instantiated
      */
     public static function getStreamFactory(): StreamFactoryInterface;
 
     /**
-     * @return ServerRequestCreatorInterface
-     *
      * @throws RuntimeException when the factory could not be instantiated
      */
     public static function getServerRequestCreator(): ServerRequestCreatorInterface;
 
     /**
      * Is the PSR-17 ResponseFactory available
-     *
-     * @return bool
      */
     public static function isResponseFactoryAvailable(): bool;
 
     /**
      * Is the PSR-17 StreamFactory available
-     *
-     * @return bool
      */
     public static function isStreamFactoryAvailable(): bool;
 
     /**
      * Is the ServerRequest creator available
-     *
-     * @return bool
      */
     public static function isServerRequestCreatorAvailable(): bool;
 }

--- a/Slim/Interfaces/Psr17FactoryProviderInterface.php
+++ b/Slim/Interfaces/Psr17FactoryProviderInterface.php
@@ -22,9 +22,5 @@ interface Psr17FactoryProviderInterface
      */
     public static function setFactories(array $factories): void;
 
-    /**
-     * @param string $factory
-     * @return void
-     */
     public static function addFactory(string $factory): void;
 }

--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -17,38 +17,26 @@ interface RouteCollectorInterface
 {
     /**
      * Get the route parser
-     *
-     * @return RouteParserInterface
      */
     public function getRouteParser(): RouteParserInterface;
 
     /**
      * Get default route invocation strategy
-     *
-     * @return InvocationStrategyInterface
      */
     public function getDefaultInvocationStrategy(): InvocationStrategyInterface;
 
     /**
      * Set default route invocation strategy
-     *
-     * @param InvocationStrategyInterface $strategy
-     * @return RouteCollectorInterface
      */
     public function setDefaultInvocationStrategy(InvocationStrategyInterface $strategy): RouteCollectorInterface;
 
     /**
      * Get path to FastRoute cache file
-     *
-     * @return null|string
      */
     public function getCacheFile(): ?string;
 
     /**
      * Set path to FastRoute cache file
-     *
-     * @param string $cacheFile
-     * @return RouteCollectorInterface
      *
      * @throws InvalidArgumentException
      * @throws RuntimeException
@@ -57,16 +45,11 @@ interface RouteCollectorInterface
 
     /**
      * Get the base path used in pathFor()
-     *
-     * @return string
      */
     public function getBasePath(): string;
 
     /**
      * Set the base path used in pathFor()
-     *
-     * @param string $basePath
-     * @return RouteCollectorInterface
      */
     public function setBasePath(string $basePath): RouteCollectorInterface;
 
@@ -82,8 +65,6 @@ interface RouteCollectorInterface
      *
      * @param string $name Route name
      *
-     * @return RouteInterface
-     *
      * @throws RuntimeException   If named route does not exist
      */
     public function getNamedRoute(string $name): RouteInterface;
@@ -92,7 +73,6 @@ interface RouteCollectorInterface
      * Remove named route
      *
      * @param string $name Route name
-     * @return RouteCollectorInterface
      *
      * @throws RuntimeException   If named route does not exist
      */
@@ -101,20 +81,13 @@ interface RouteCollectorInterface
     /**
      * Lookup a route via the route's unique identifier
      *
-     * @param string $identifier
-     *
-     * @return RouteInterface
-     *
      * @throws RuntimeException   If route of identifier does not exist
      */
     public function lookupRoute(string $identifier): RouteInterface;
 
     /**
      * Add route group
-     *
-     * @param string          $pattern
      * @param string|callable $callable
-     * @return RouteGroupInterface
      */
     public function group(string $pattern, $callable): RouteGroupInterface;
 
@@ -124,8 +97,6 @@ interface RouteCollectorInterface
      * @param string[]        $methods Array of HTTP methods
      * @param string          $pattern The route pattern
      * @param callable|string $handler The route callable
-     *
-     * @return RouteInterface
      */
     public function map(array $methods, string $pattern, $handler): RouteInterface;
 }

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -16,39 +16,21 @@ use Psr\Http\Message\UriInterface;
 
 interface RouteCollectorProxyInterface
 {
-    /**
-     * @return ResponseFactoryInterface
-     */
     public function getResponseFactory(): ResponseFactoryInterface;
 
-    /**
-     * @return CallableResolverInterface
-     */
     public function getCallableResolver(): CallableResolverInterface;
 
-    /**
-     * @return ContainerInterface|null
-     */
     public function getContainer(): ?ContainerInterface;
 
-    /**
-     * @return RouteCollectorInterface
-     */
     public function getRouteCollector(): RouteCollectorInterface;
 
     /**
      * Get the RouteCollectorProxy's base path
-     *
-     * @return string
      */
     public function getBasePath(): string;
 
     /**
      * Set the RouteCollectorProxy's base path
-     *
-     * @param string $basePath
-     *
-     * @return RouteCollectorProxyInterface
      */
     public function setBasePath(string $basePath): RouteCollectorProxyInterface;
 
@@ -57,8 +39,6 @@ interface RouteCollectorProxyInterface
      *
      * @param  string          $pattern  The route URI pattern
      * @param  callable|string $callable The route callback routine
-     *
-     * @return RouteInterface
      */
     public function get(string $pattern, $callable): RouteInterface;
 
@@ -67,8 +47,6 @@ interface RouteCollectorProxyInterface
      *
      * @param  string          $pattern  The route URI pattern
      * @param  callable|string $callable The route callback routine
-     *
-     * @return RouteInterface
      */
     public function post(string $pattern, $callable): RouteInterface;
 
@@ -77,8 +55,6 @@ interface RouteCollectorProxyInterface
      *
      * @param  string          $pattern  The route URI pattern
      * @param  callable|string $callable The route callback routine
-     *
-     * @return RouteInterface
      */
     public function put(string $pattern, $callable): RouteInterface;
 
@@ -87,8 +63,6 @@ interface RouteCollectorProxyInterface
      *
      * @param  string          $pattern  The route URI pattern
      * @param  callable|string $callable The route callback routine
-     *
-     * @return RouteInterface
      */
     public function patch(string $pattern, $callable): RouteInterface;
 
@@ -97,8 +71,6 @@ interface RouteCollectorProxyInterface
      *
      * @param  string          $pattern  The route URI pattern
      * @param  callable|string $callable The route callback routine
-     *
-     * @return RouteInterface
      */
     public function delete(string $pattern, $callable): RouteInterface;
 
@@ -107,8 +79,6 @@ interface RouteCollectorProxyInterface
      *
      * @param  string          $pattern  The route URI pattern
      * @param  callable|string $callable The route callback routine
-     *
-     * @return RouteInterface
      */
     public function options(string $pattern, $callable): RouteInterface;
 
@@ -117,8 +87,6 @@ interface RouteCollectorProxyInterface
      *
      * @param  string          $pattern  The route URI pattern
      * @param  callable|string $callable The route callback routine
-     *
-     * @return RouteInterface
      */
     public function any(string $pattern, $callable): RouteInterface;
 
@@ -128,8 +96,6 @@ interface RouteCollectorProxyInterface
      * @param  string[]        $methods  Numeric array of HTTP method names
      * @param  string          $pattern  The route URI pattern
      * @param  callable|string $callable The route callback routine
-     *
-     * @return RouteInterface
      */
     public function map(array $methods, string $pattern, $callable): RouteInterface;
 
@@ -139,22 +105,14 @@ interface RouteCollectorProxyInterface
      * This method accepts a route pattern and a callback. All route
      * declarations in the callback will be prepended by the group(s)
      * that it is in.
-     *
-     * @param string          $pattern
      * @param string|callable $callable
-     *
-     * @return RouteGroupInterface
      */
     public function group(string $pattern, $callable): RouteGroupInterface;
 
     /**
      * Add a route that sends an HTTP redirect
      *
-     * @param string              $from
      * @param string|UriInterface $to
-     * @param int                 $status
-     *
-     * @return RouteInterface
      */
     public function redirect(string $from, $to, int $status = 302): RouteInterface;
 }

--- a/Slim/Interfaces/RouteGroupInterface.php
+++ b/Slim/Interfaces/RouteGroupInterface.php
@@ -15,39 +15,27 @@ use Slim\MiddlewareDispatcher;
 
 interface RouteGroupInterface
 {
-    /**
-     * @return RouteGroupInterface
-     */
     public function collectRoutes(): RouteGroupInterface;
 
     /**
      * Add middleware to the route group
      *
      * @param MiddlewareInterface|string|callable $middleware
-     * @return RouteGroupInterface
      */
     public function add($middleware): RouteGroupInterface;
 
     /**
      * Add middleware to the route group
-     *
-     * @param MiddlewareInterface $middleware
-     * @return RouteGroupInterface
      */
     public function addMiddleware(MiddlewareInterface $middleware): RouteGroupInterface;
 
     /**
      * Append the group's middleware to the MiddlewareDispatcher
-     *
-     * @param MiddlewareDispatcher $dispatcher
-     * @return RouteGroupInterface
      */
     public function appendMiddlewareToDispatcher(MiddlewareDispatcher $dispatcher): RouteGroupInterface;
 
     /**
      * Get the RouteGroup's pattern
-     *
-     * @return string
      */
     public function getPattern(): string;
 }

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -18,16 +18,11 @@ interface RouteInterface
 {
     /**
      * Get route invocation strategy
-     *
-     * @return InvocationStrategyInterface
      */
     public function getInvocationStrategy(): InvocationStrategyInterface;
 
     /**
      * Set route invocation strategy
-     *
-     * @param InvocationStrategyInterface $invocationStrategy
-     * @return RouteInterface
      */
     public function setInvocationStrategy(InvocationStrategyInterface $invocationStrategy): RouteInterface;
 
@@ -40,16 +35,11 @@ interface RouteInterface
 
     /**
      * Get route pattern
-     *
-     * @return string
      */
     public function getPattern(): string;
 
     /**
      * Set route pattern
-     *
-     * @param string $pattern
-     * @return RouteInterface
      */
     public function setPattern(string $pattern): RouteInterface;
 
@@ -64,21 +54,16 @@ interface RouteInterface
      * Set route callable
      *
      * @param callable|string $callable
-     * @return RouteInterface
      */
     public function setCallable($callable): RouteInterface;
 
     /**
      * Get route name
-     *
-     * @return null|string
      */
     public function getName(): ?string;
 
     /**
      * Set route name
-     *
-     * @param string $name
      *
      * @return static
      */
@@ -86,18 +71,11 @@ interface RouteInterface
 
     /**
      * Get the route's unique identifier
-     *
-     * @return string
      */
     public function getIdentifier(): string;
 
     /**
      * Retrieve a specific route argument
-     *
-     * @param string      $name
-     * @param string|null $default
-     *
-     * @return string|null
      */
     public function getArgument(string $name, ?string $default = null): ?string;
 
@@ -110,11 +88,6 @@ interface RouteInterface
 
     /**
      * Set a route argument
-     *
-     * @param string $name
-     * @param string $value
-     *
-     * @return self
      */
     public function setArgument(string $name, string $value): RouteInterface;
 
@@ -122,30 +95,22 @@ interface RouteInterface
      * Replace route arguments
      *
      * @param array<string, string> $arguments
-     *
-     * @return self
      */
-    public function setArguments(array $arguments): RouteInterface;
+    public function setArguments(array $arguments): self;
 
     /**
      * @param MiddlewareInterface|string|callable $middleware
-     * @return RouteInterface
      */
-    public function add($middleware): RouteInterface;
+    public function add($middleware): self;
 
-    /**
-     * @param MiddlewareInterface $middleware
-     * @return RouteInterface
-     */
-    public function addMiddleware(MiddlewareInterface $middleware): RouteInterface;
+    public function addMiddleware(MiddlewareInterface $middleware): self;
 
     /**
      * Prepare the route for use
      *
      * @param array<string, string> $arguments
-     * @return RouteInterface
      */
-    public function prepare(array $arguments): RouteInterface;
+    public function prepare(array $arguments): self;
 
     /**
      * Run route
@@ -153,9 +118,6 @@ interface RouteInterface
      * This method traverses the middleware stack, including the route's callable
      * and captures the resultant HTTP response object. It then sends the response
      * back to the Application.
-     *
-     * @param ServerRequestInterface $request
-     * @return ResponseInterface
      */
     public function run(ServerRequestInterface $request): ResponseInterface;
 }

--- a/Slim/Interfaces/RouteParserInterface.php
+++ b/Slim/Interfaces/RouteParserInterface.php
@@ -23,8 +23,6 @@ interface RouteParserInterface
      * @param array<string, string> $data        Named argument replacement data
      * @param array<string, string> $queryParams Optional query string parameters
      *
-     * @return string
-     *
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
      */
@@ -36,8 +34,6 @@ interface RouteParserInterface
      * @param string                $routeName   Route name
      * @param array<string, string> $data        Named argument replacement data
      * @param array<string, string> $queryParams Optional query string parameters
-     *
-     * @return string
      *
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
@@ -51,8 +47,6 @@ interface RouteParserInterface
      * @param string                    $routeName   Route name
      * @param array<string, string>     $data        Named argument replacement data
      * @param array<string, string>     $queryParams Optional query string parameters
-     *
-     * @return string
      */
     public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string;
 }

--- a/Slim/Interfaces/RouteResolverInterface.php
+++ b/Slim/Interfaces/RouteResolverInterface.php
@@ -10,14 +10,8 @@ interface RouteResolverInterface
 {
     /**
      * @param string $uri Should be ServerRequestInterface::getUri()->getPath()
-     * @param string $method
-     * @return RoutingResults
      */
     public function computeRoutingResults(string $uri, string $method): RoutingResults;
 
-    /**
-     * @param string $identifier
-     * @return RouteInterface
-     */
     public function resolveRoute(string $identifier): RouteInterface;
 }

--- a/Slim/Interfaces/ServerRequestCreatorInterface.php
+++ b/Slim/Interfaces/ServerRequestCreatorInterface.php
@@ -14,8 +14,5 @@ use Psr\Http\Message\ServerRequestInterface;
 
 interface ServerRequestCreatorInterface
 {
-    /**
-     * @return ServerRequestInterface
-     */
     public function createServerRequestFromGlobals(): ServerRequestInterface;
 }

--- a/Slim/Logger.php
+++ b/Slim/Logger.php
@@ -23,8 +23,6 @@ class Logger extends AbstractLogger
      * @param string|Stringable $message
      * @param array<mixed>      $context
      *
-     * @return void
-     *
      * @throws InvalidArgumentException
      */
     public function log($level, $message, array $context = []): void

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -52,11 +52,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
         }
     }
 
-    /**
-     * @param ServerRequestInterface  $request
-     * @param RequestHandlerInterface $handler
-     * @return ResponseInterface
-     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $parsedBody = $request->getParsedBody();
@@ -71,7 +66,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
     /**
      * @param string   $mediaType A HTTP media type (excluding content-type params).
      * @param callable $callable  A callable that returns parsed contents for media type.
-     * @return self
      */
     public function registerBodyParser(string $mediaType, callable $callable): self
     {
@@ -81,7 +75,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
 
     /**
      * @param string   $mediaType A HTTP media type (excluding content-type params).
-     * @return boolean
      */
     public function hasBodyParser(string $mediaType): bool
     {
@@ -90,7 +83,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
 
     /**
      * @param string    $mediaType A HTTP media type (excluding content-type params).
-     * @return callable
      * @throws RuntimeException
      */
     public function getBodyParser(string $mediaType): callable
@@ -100,7 +92,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
         }
         return $this->bodyParsers[$mediaType];
     }
-
 
     protected function registerDefaultBodyParsers(): void
     {
@@ -140,7 +131,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
     }
 
     /**
-     * @param ServerRequestInterface $request
      * @return null|array<mixed>|object
      */
     protected function parseBody(ServerRequestInterface $request)
@@ -176,7 +166,6 @@ class BodyParsingMiddleware implements MiddlewareInterface
     }
 
     /**
-     * @param ServerRequestInterface $request
      * @return string|null The serverRequest media type, minus content-type params
      */
     protected function getMediaType(ServerRequestInterface $request): ?string

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -55,7 +55,8 @@ class BodyParsingMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $parsedBody = $request->getParsedBody();
-        if ($parsedBody === null || empty($parsedBody)) {
+
+        if (empty($parsedBody)) {
             $parsedBody = $this->parseBody($request);
             $request = $request->withParsedBody($parsedBody);
         }

--- a/Slim/Middleware/ContentLengthMiddleware.php
+++ b/Slim/Middleware/ContentLengthMiddleware.php
@@ -17,11 +17,6 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class ContentLengthMiddleware implements MiddlewareInterface
 {
-    /**
-     * @param ServerRequestInterface  $request
-     * @param RequestHandlerInterface $handler
-     * @return ResponseInterface
-     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -54,14 +54,6 @@ class ErrorMiddleware implements MiddlewareInterface
      */
     protected $defaultErrorHandler;
 
-    /**
-     * @param CallableResolverInterface $callableResolver
-     * @param ResponseFactoryInterface  $responseFactory
-     * @param bool                      $displayErrorDetails
-     * @param bool                      $logErrors
-     * @param bool                      $logErrorDetails
-     * @param LoggerInterface|null      $logger
-     */
     public function __construct(
         CallableResolverInterface $callableResolver,
         ResponseFactoryInterface $responseFactory,
@@ -78,11 +70,6 @@ class ErrorMiddleware implements MiddlewareInterface
         $this->logger = $logger;
     }
 
-    /**
-     * @param ServerRequestInterface  $request
-     * @param RequestHandlerInterface $handler
-     * @return ResponseInterface
-     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         try {
@@ -92,11 +79,6 @@ class ErrorMiddleware implements MiddlewareInterface
         }
     }
 
-    /**
-     * @param ServerRequestInterface $request
-     * @param Throwable              $exception
-     * @return ResponseInterface
-     */
     public function handleException(ServerRequestInterface $request, Throwable $exception): ResponseInterface
     {
         if ($exception instanceof HttpException) {
@@ -170,7 +152,6 @@ class ErrorMiddleware implements MiddlewareInterface
      * \Psr\Http\Message\ResponseInterface.
      *
      * @param string|callable|ErrorHandler $handler
-     * @return self
      */
     public function setDefaultErrorHandler($handler): self
     {
@@ -202,8 +183,6 @@ class ErrorMiddleware implements MiddlewareInterface
      * ie: RuntimeException::class or an array of classes
      * ie: [HttpNotFoundException::class, HttpMethodNotAllowedException::class]
      * @param string|callable|ErrorHandlerInterface $handler
-     * @param bool $handleSubclasses
-     * @return self
      */
     public function setErrorHandler($typeOrTypes, $handler, bool $handleSubclasses = false): self
     {
@@ -220,10 +199,7 @@ class ErrorMiddleware implements MiddlewareInterface
 
     /**
      * Used internally to avoid code repetition when passing multiple exceptions to setErrorHandler().
-     * @param string $type
      * @param string|callable|ErrorHandlerInterface $handler
-     * @param bool   $handleSubclasses
-     * @return void
      */
     private function addErrorHandler(string $type, $handler, bool $handleSubclasses): void
     {

--- a/Slim/Middleware/MethodOverrideMiddleware.php
+++ b/Slim/Middleware/MethodOverrideMiddleware.php
@@ -20,11 +20,6 @@ use function strtoupper;
 
 class MethodOverrideMiddleware implements MiddlewareInterface
 {
-    /**
-     * @param ServerRequestInterface  $request
-     * @param RequestHandlerInterface $handler
-     * @return ResponseInterface
-     */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $methodHeader = $request->getHeaderLine('X-Http-Method-Override');

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -33,8 +33,7 @@ class OutputBufferingMiddleware implements MiddlewareInterface
     protected string $style;
 
     /**
-     * @param StreamFactoryInterface $streamFactory
-     * @param string                 $style Either "append" or "prepend"
+     * @param string $style Either "append" or "prepend"
      */
     public function __construct(StreamFactoryInterface $streamFactory, string $style = 'append')
     {
@@ -47,9 +46,6 @@ class OutputBufferingMiddleware implements MiddlewareInterface
     }
 
     /**
-     * @param ServerRequestInterface  $request
-     * @param RequestHandlerInterface $handler
-     * @return ResponseInterface
      * @throws Throwable
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -28,10 +28,6 @@ class RoutingMiddleware implements MiddlewareInterface
 
     protected RouteParserInterface $routeParser;
 
-    /**
-     * @param RouteResolverInterface $routeResolver
-     * @param RouteParserInterface   $routeParser
-     */
     public function __construct(RouteResolverInterface $routeResolver, RouteParserInterface $routeParser)
     {
         $this->routeResolver = $routeResolver;
@@ -39,10 +35,6 @@ class RoutingMiddleware implements MiddlewareInterface
     }
 
     /**
-     * @param ServerRequestInterface  $request
-     * @param RequestHandlerInterface $handler
-     * @return ResponseInterface
-     *
      * @throws HttpNotFoundException
      * @throws HttpMethodNotAllowedException
      * @throws RuntimeException
@@ -57,7 +49,6 @@ class RoutingMiddleware implements MiddlewareInterface
      * Perform routing
      *
      * @param  ServerRequestInterface $request PSR7 Server Request
-     * @return ServerRequestInterface
      *
      * @throws HttpNotFoundException
      * @throws HttpMethodNotAllowedException
@@ -96,9 +87,6 @@ class RoutingMiddleware implements MiddlewareInterface
 
     /**
      * Resolves the route from the given request
-     *
-     * @param  ServerRequestInterface $request
-     * @return RoutingResults
      */
     protected function resolveRoutingResultsFromRequest(ServerRequestInterface $request): RoutingResults
     {

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -39,11 +39,6 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
 
     protected ?ContainerInterface $container;
 
-    /**
-     * @param RequestHandlerInterface        $kernel
-     * @param CallableResolverInterface|null $callableResolver
-     * @param ContainerInterface|null        $container
-     */
     public function __construct(
         RequestHandlerInterface $kernel,
         ?CallableResolverInterface $callableResolver = null,
@@ -64,9 +59,6 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
 
     /**
      * Invoke the middleware stack
-     *
-     * @param ServerRequestInterface $request
-     * @return ResponseInterface
      */
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
@@ -81,7 +73,6 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
      * added one (last in, first out).
      *
      * @param MiddlewareInterface|string|callable $middleware
-     * @return MiddlewareDispatcherInterface
      */
     public function add($middleware): MiddlewareDispatcherInterface
     {
@@ -110,23 +101,14 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
      * Middleware are organized as a stack. That means middleware
      * that have been added before will be executed after the newly
      * added one (last in, first out).
-     *
-     * @param MiddlewareInterface $middleware
-     * @return MiddlewareDispatcherInterface
      */
     public function addMiddleware(MiddlewareInterface $middleware): MiddlewareDispatcherInterface
     {
         $next = $this->tip;
         $this->tip = new class ($middleware, $next) implements RequestHandlerInterface {
-            /**
-             * @var MiddlewareInterface
-             */
-            private $middleware;
+            private MiddlewareInterface $middleware;
 
-            /**
-             * @var RequestHandlerInterface
-             */
-            private $next;
+            private RequestHandlerInterface $next;
 
             public function __construct(MiddlewareInterface $middleware, RequestHandlerInterface $next)
             {
@@ -149,9 +131,6 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
      * Middleware are organized as a stack. That means middleware
      * that have been added before will be executed after the newly
      * added one (last in, first out).
-     *
-     * @param string $middleware
-     * @return self
      */
     public function addDeferred(string $middleware): self
     {
@@ -253,14 +232,11 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
     }
 
     /**
-     * Add a (non standard) callable middleware to the stack
+     * Add a (non-standard) callable middleware to the stack
      *
      * Middleware are organized as a stack. That means middleware
      * that have been added before will be executed after the newly
      * added one (last in, first out).
-     *
-     * @param callable $middleware
-     * @return self
      */
     public function addCallable(callable $middleware): self
     {

--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -27,9 +27,6 @@ class ResponseEmitter
 {
     private int $responseChunkSize;
 
-    /**
-     * @param int $responseChunkSize
-     */
     public function __construct(int $responseChunkSize = 4096)
     {
         $this->responseChunkSize = $responseChunkSize;
@@ -37,9 +34,6 @@ class ResponseEmitter
 
     /**
      * Send the response the client
-     *
-     * @param ResponseInterface $response
-     * @return void
      */
     public function emit(ResponseInterface $response): void
     {
@@ -60,8 +54,6 @@ class ResponseEmitter
 
     /**
      * Emit Response Headers
-     *
-     * @param ResponseInterface $response
      */
     private function emitHeaders(ResponseInterface $response): void
     {
@@ -77,8 +69,6 @@ class ResponseEmitter
 
     /**
      * Emit Status Line
-     *
-     * @param ResponseInterface $response
      */
     private function emitStatusLine(ResponseInterface $response): void
     {
@@ -93,8 +83,6 @@ class ResponseEmitter
 
     /**
      * Emit Body
-     *
-     * @param ResponseInterface $response
      */
     private function emitBody(ResponseInterface $response): void
     {
@@ -132,9 +120,6 @@ class ResponseEmitter
 
     /**
      * Asserts response body is empty or status code is 204, 205 or 304
-     *
-     * @param ResponseInterface $response
-     * @return bool
      */
     public function isResponseEmpty(ResponseInterface $response): bool
     {

--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -16,17 +16,11 @@ class Dispatcher implements DispatcherInterface
 
     private ?FastRouteDispatcher $dispatcher = null;
 
-    /**
-     * @param RouteCollectorInterface $routeCollector
-     */
     public function __construct(RouteCollectorInterface $routeCollector)
     {
         $this->routeCollector = $routeCollector;
     }
 
-    /**
-     * @return FastRouteDispatcher
-     */
     protected function createDispatcher(): FastRouteDispatcher
     {
         if ($this->dispatcher) {

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -77,14 +77,9 @@ class Route implements RouteInterface, RequestHandlerInterface
 
     /**
      * Container
-     *
-     * @var ContainerInterface|null
      */
     protected ?ContainerInterface $container = null;
 
-    /**
-     * @var MiddlewareDispatcher
-     */
     protected MiddlewareDispatcher $middlewareDispatcher;
 
     /**
@@ -139,9 +134,6 @@ class Route implements RouteInterface, RequestHandlerInterface
         $this->middlewareDispatcher = new MiddlewareDispatcher($this, $callableResolver, $container);
     }
 
-    /**
-     * @return CallableResolverInterface
-     */
     public function getCallableResolver(): CallableResolverInterface
     {
         return $this->callableResolver;

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -73,14 +73,6 @@ class RouteCollector implements RouteCollectorInterface
 
     protected ResponseFactoryInterface $responseFactory;
 
-    /**
-     * @param ResponseFactoryInterface         $responseFactory
-     * @param CallableResolverInterface        $callableResolver
-     * @param ContainerInterface|null          $container
-     * @param InvocationStrategyInterface|null $defaultInvocationStrategy
-     * @param RouteParserInterface|null        $routeParser
-     * @param string|null                      $cacheFile
-     */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
         CallableResolverInterface $callableResolver,
@@ -100,9 +92,6 @@ class RouteCollector implements RouteCollectorInterface
         }
     }
 
-    /**
-     * @return RouteParserInterface
-     */
     public function getRouteParser(): RouteParserInterface
     {
         return $this->routeParser;
@@ -110,18 +99,12 @@ class RouteCollector implements RouteCollectorInterface
 
     /**
      * Get default route invocation strategy
-     *
-     * @return InvocationStrategyInterface
      */
     public function getDefaultInvocationStrategy(): InvocationStrategyInterface
     {
         return $this->defaultInvocationStrategy;
     }
 
-    /**
-     * @param InvocationStrategyInterface $strategy
-     * @return self
-     */
     public function setDefaultInvocationStrategy(InvocationStrategyInterface $strategy): RouteCollectorInterface
     {
         $this->defaultInvocationStrategy = $strategy;
@@ -167,10 +150,6 @@ class RouteCollector implements RouteCollectorInterface
 
     /**
      * Set the base path used in urlFor()
-     *
-     * @param string $basePath
-     *
-     * @return self
      */
     public function setBasePath(string $basePath): RouteCollectorInterface
     {
@@ -257,10 +236,7 @@ class RouteCollector implements RouteCollectorInterface
 
     /**
      * @param string[]        $methods
-     * @param string          $pattern
      * @param callable|string $callable
-     *
-     * @return RouteInterface
      */
     protected function createRoute(array $methods, string $pattern, $callable): RouteInterface
     {

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -30,13 +30,6 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
 
     protected string $groupPattern;
 
-    /**
-     * @param ResponseFactoryInterface     $responseFactory
-     * @param CallableResolverInterface    $callableResolver
-     * @param RouteCollectorInterface|null $routeCollector
-     * @param ContainerInterface|null      $container
-     * @param string                       $groupPattern
-     */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
         CallableResolverInterface $callableResolver,

--- a/Slim/Routing/RouteContext.php
+++ b/Slim/Routing/RouteContext.php
@@ -25,10 +25,6 @@ final class RouteContext
 
     public const BASE_PATH = '__basePath__';
 
-    /**
-     * @param ServerRequestInterface $serverRequest
-     * @return RouteContext
-     */
     public static function fromRequest(ServerRequestInterface $serverRequest): self
     {
         $route = $serverRequest->getAttribute(self::ROUTE);
@@ -55,12 +51,6 @@ final class RouteContext
 
     private ?string $basePath;
 
-    /**
-     * @param RouteInterface|null  $route
-     * @param RouteParserInterface $routeParser
-     * @param RoutingResults       $routingResults
-     * @param string|null          $basePath
-     */
     private function __construct(
         ?RouteInterface $route,
         RouteParserInterface $routeParser,
@@ -73,33 +63,21 @@ final class RouteContext
         $this->basePath = $basePath;
     }
 
-    /**
-     * @return RouteInterface|null
-     */
     public function getRoute(): ?RouteInterface
     {
         return $this->route;
     }
 
-    /**
-     * @return RouteParserInterface
-     */
     public function getRouteParser(): RouteParserInterface
     {
         return $this->routeParser;
     }
 
-    /**
-     * @return RoutingResults
-     */
     public function getRoutingResults(): RoutingResults
     {
         return $this->routingResults;
     }
 
-    /**
-     * @return string
-     */
     public function getBasePath(): string
     {
         if ($this->basePath === null) {

--- a/Slim/Routing/RouteGroup.php
+++ b/Slim/Routing/RouteGroup.php
@@ -36,10 +36,7 @@ class RouteGroup implements RouteGroupInterface
     protected string $pattern;
 
     /**
-     * @param string                       $pattern
      * @param callable|string              $callable
-     * @param CallableResolverInterface    $callableResolver
-     * @param RouteCollectorProxyInterface $routeCollectorProxy
      */
     public function __construct(
         string $pattern,

--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -28,9 +28,6 @@ class RouteParser implements RouteParserInterface
 
     private Std $routeParser;
 
-    /**
-     * @param RouteCollectorInterface $routeCollector
-     */
     public function __construct(RouteCollectorInterface $routeCollector)
     {
         $this->routeCollector = $routeCollector;

--- a/Slim/Routing/RouteResolver.php
+++ b/Slim/Routing/RouteResolver.php
@@ -26,15 +26,8 @@ class RouteResolver implements RouteResolverInterface
 {
     protected RouteCollectorInterface $routeCollector;
 
-    /**
-     * @var DispatcherInterface
-     */
-    private $dispatcher;
+    private DispatcherInterface $dispatcher;
 
-    /**
-     * @param RouteCollectorInterface  $routeCollector
-     * @param DispatcherInterface|null $dispatcher
-     */
     public function __construct(RouteCollectorInterface $routeCollector, ?DispatcherInterface $dispatcher = null)
     {
         $this->routeCollector = $routeCollector;
@@ -43,8 +36,6 @@ class RouteResolver implements RouteResolverInterface
 
     /**
      * @param string $uri Should be $request->getUri()->getPath()
-     * @param string $method
-     * @return RoutingResults
      */
     public function computeRoutingResults(string $uri, string $method): RoutingResults
     {
@@ -56,8 +47,6 @@ class RouteResolver implements RouteResolverInterface
     }
 
     /**
-     * @param string $identifier
-     * @return RouteInterface
      * @throws RuntimeException
      */
     public function resolveRoute(string $identifier): RouteInterface

--- a/Slim/Routing/RouteRunner.php
+++ b/Slim/Routing/RouteRunner.php
@@ -28,11 +28,6 @@ class RouteRunner implements RequestHandlerInterface
 
     private ?RouteCollectorProxyInterface $routeCollectorProxy;
 
-    /**
-     * @param RouteResolverInterface            $routeResolver
-     * @param RouteParserInterface              $routeParser
-     * @param RouteCollectorProxyInterface|null $routeCollectorProxy
-     */
     public function __construct(
         RouteResolverInterface $routeResolver,
         RouteParserInterface $routeParser,
@@ -50,8 +45,6 @@ class RouteRunner implements RequestHandlerInterface
      * defined middleware stack. In the event that the user did not perform routing
      * it is done here
      *
-     * @param ServerRequestInterface $request
-     * @return ResponseInterface
      * @throws HttpNotFoundException
      * @throws HttpMethodNotAllowedException
      */

--- a/Slim/Routing/RoutingResults.php
+++ b/Slim/Routing/RoutingResults.php
@@ -42,11 +42,6 @@ class RoutingResults
     protected array $routeArguments;
 
     /**
-     * @param DispatcherInterface   $dispatcher
-     * @param string                $method
-     * @param string                $uri
-     * @param int                   $routeStatus
-     * @param string|null           $routeIdentifier
      * @param array<string, string> $routeArguments
      */
     public function __construct(
@@ -65,48 +60,32 @@ class RoutingResults
         $this->routeArguments = $routeArguments;
     }
 
-    /**
-     * @return DispatcherInterface
-     */
     public function getDispatcher(): DispatcherInterface
     {
         return $this->dispatcher;
     }
 
-    /**
-     * @return string
-     */
     public function getMethod(): string
     {
         return $this->method;
     }
 
-    /**
-     * @return string
-     */
     public function getUri(): string
     {
         return $this->uri;
     }
 
-    /**
-     * @return int
-     */
     public function getRouteStatus(): int
     {
         return $this->routeStatus;
     }
 
-    /**
-     * @return null|string
-     */
     public function getRouteIdentifier(): ?string
     {
         return $this->routeIdentifier;
     }
 
     /**
-     * @param bool $urlDecode
      * @return array<string, string>
      */
     public function getRouteArguments(bool $urlDecode = true): array


### PR DESCRIPTION
This will make it easier to read and refactor the code going forward.

Also added a couple missing property types and removed a redundant null check.