### PR TITLE
Static lambda

### DIFF
--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -177,7 +177,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     {
         $responseFactory = $this->responseFactory;
 
-        $handler = function () use ($to, $status, $responseFactory) {
+        $handler = static function () use ($to, $status, $responseFactory) {
             $response = $responseFactory->createResponse($status);
             return $response->withHeader('Location', (string) $to);
         };


### PR DESCRIPTION
Lambdas not (indirect) referencing $this must be declared static.