### PR TITLE
Get class to class keyword

### DIFF
--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -37,7 +37,7 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
 
     private function renderExceptionFragment(Throwable $exception): string
     {
-        $html = sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
+        $html = sprintf('<div><strong>Type:</strong> %s</div>', $exception::class);
 
         /** @var int|string $code */
         $code = $exception->getCode();

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -46,7 +46,7 @@ class JsonErrorRenderer extends AbstractErrorRenderer
         /** @var int|string $code */
         $code = $exception->getCode();
         return [
-            'type' => get_class($exception),
+            'type' => $exception::class,
             'code' => $code,
             'message' => $exception->getMessage(),
             'file' => $exception->getFile(),

--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -40,7 +40,7 @@ class PlainTextErrorRenderer extends AbstractErrorRenderer
 
     private function formatExceptionFragment(Throwable $exception): string
     {
-        $text = sprintf("Type: %s\n", get_class($exception));
+        $text = sprintf("Type: %s\n", $exception::class);
 
         $code = $exception->getCode();
         /** @var int|string $code */

--- a/Slim/Error/Renderers/XmlErrorRenderer.php
+++ b/Slim/Error/Renderers/XmlErrorRenderer.php
@@ -30,7 +30,7 @@ class XmlErrorRenderer extends AbstractErrorRenderer
         if ($displayErrorDetails) {
             do {
                 $xml .= "  <exception>\n";
-                $xml .= '    <type>' . get_class($exception) . "</type>\n";
+                $xml .= '    <type>' . $exception::class . "</type>\n";
                 $xml .= '    <code>' . $exception->getCode() . "</code>\n";
                 $xml .= '    <message>' . $this->createCdataSection($exception->getMessage()) . "</message>\n";
                 $xml .= '    <file>' . $exception->getFile() . "</file>\n";

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -85,7 +85,7 @@ class ErrorMiddleware implements MiddlewareInterface
             $request = $exception->getRequest();
         }
 
-        $exceptionType = get_class($exception);
+        $exceptionType = $exception::class;
         $handler = $this->getErrorHandler($exceptionType);
 
         return $handler($request, $exception, $this->displayErrorDetails, $this->logErrors, $this->logErrorDetails);


### PR DESCRIPTION
Replace get_class calls on object variables with class keyword syntax.