### PR TITLE
Void return

### DIFF
--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -27,7 +27,7 @@ class Dispatcher implements DispatcherInterface
             return $this->dispatcher;
         }
 
-        $routeDefinitionCallback = function (FastRouteCollector $r) {
+        $routeDefinitionCallback = function (FastRouteCollector $r): void {
             $basePath = $this->routeCollector->getBasePath();
 
             foreach ($this->routeCollector->getRoutes() as $route) {


### PR DESCRIPTION
Add void return type to functions with missing or empty return statements, but priority is given to @return annotations.