### PR TITLE
Php unit dedicate assert

### DIFF
--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -147,7 +147,7 @@ class RouteTest extends TestCase
     {
         $route = $this->createRoute();
 
-        $this->assertTrue(is_callable($route->getCallable()));
+        $this->assertInternalType('callable', $route->getCallable());
     }
 
     public function testGetCallableResolver()


### PR DESCRIPTION
PHPUnit assertions like assertInternalType, assertFileExists, should be used over assertTrue.