### PR TITLE
Using assertSame to let assert equal be restricted

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
@@ -27,7 +27,7 @@ jobs:
           coverage: xdebug
 
       - name: Install dependencies with Composer
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Coding standards
         if: matrix.analysis

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -201,7 +201,7 @@ class AppTest extends TestCase
         });
         $response = $app->handle($requestProphecy->reveal());
 
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testAnyRoute(): void
@@ -236,7 +236,7 @@ class AppTest extends TestCase
 
             $response = $app->handle($requestProphecy->reveal());
 
-            $this->assertEquals('Hello World', (string) $response->getBody());
+            $this->assertSame('Hello World', (string) $response->getBody());
         }
     }
 
@@ -290,7 +290,7 @@ class AppTest extends TestCase
         });
         $response = $app->handle($requestProphecy->reveal());
 
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testRedirectRoute(): void
@@ -333,8 +333,8 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $responseFactoryProphecy->createResponse(301)->shouldHaveBeenCalled();
-        $this->assertEquals(301, $response->getStatusCode());
-        $this->assertEquals($to, $response->getHeaderLine('Location'));
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertSame($to, $response->getHeaderLine('Location'));
     }
 
     public function testRouteWithInternationalCharacters(): void
@@ -369,7 +369,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     /********************************************************************************
@@ -402,7 +402,7 @@ class AppTest extends TestCase
         $routeCollector = $app->getRouteCollector();
         $route = $routeCollector->lookupRoute('route0');
 
-        $this->assertEquals($pattern, $route->getPattern());
+        $this->assertSame($pattern, $route->getPattern());
     }
 
     /********************************************************************************
@@ -566,7 +566,7 @@ class AppTest extends TestCase
         $routeCollector = $app->getRouteCollector();
         $route = $routeCollector->lookupRoute('route0');
 
-        $this->assertEquals($expectedPath, $route->getPattern());
+        $this->assertSame($expectedPath, $route->getPattern());
     }
 
     public function testRouteGroupPattern(): void
@@ -579,7 +579,7 @@ class AppTest extends TestCase
         $group = $app->group('/foo', function () {
         });
 
-        $this->assertEquals('/foo', $group->getPattern());
+        $this->assertSame('/foo', $group->getPattern());
     }
 
     /********************************************************************************
@@ -855,7 +855,7 @@ class AppTest extends TestCase
 
         $app->handle($requestProphecy->reveal());
 
-        $this->assertEquals('In2In1CenterOut1Out2', $output);
+        $this->assertSame('In2In1CenterOut1Out2', $output);
     }
 
     public function testAddMiddlewareOnRouteGroup(): void
@@ -937,7 +937,7 @@ class AppTest extends TestCase
 
         $app->handle($requestProphecy->reveal());
 
-        $this->assertEquals('In2In1CenterOut1Out2', $output);
+        $this->assertSame('In2In1CenterOut1Out2', $output);
     }
 
     public function testAddMiddlewareOnTwoRouteGroup(): void
@@ -1057,7 +1057,7 @@ class AppTest extends TestCase
 
         $app->handle($requestProphecy->reveal());
 
-        $this->assertEquals('In1In2In3CenterOut3Out2Out1', $output);
+        $this->assertSame('In1In2In3CenterOut3Out2Out1', $output);
     }
 
     public function testAddMiddlewareAsStringNotImplementingInterfaceThrowsException(): void
@@ -1132,7 +1132,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testInvokeWithMatchingRouteWithSetArgument(): void
@@ -1172,7 +1172,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testInvokeWithMatchingRouteWithSetArguments(): void
@@ -1212,7 +1212,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseStrategy(): void
@@ -1252,7 +1252,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseArgStrategy(): void
@@ -1293,7 +1293,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseNamedArgsStrategy(): void
@@ -1341,7 +1341,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testInvokeWithMatchingRouteWithNamedParameterOverwritesSetArgument(): void
@@ -1381,7 +1381,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testInvokeWithoutMatchingRoute(): void
@@ -1447,7 +1447,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testInvokeWithNonExistentMethodOnCallableRegisteredInContainer(): void
@@ -1527,7 +1527,7 @@ class AppTest extends TestCase
 
         $expectedPayload = json_encode(['name' => 'foo', 'arguments' => []]);
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals($expectedPayload, (string) $response->getBody());
+        $this->assertSame($expectedPayload, (string) $response->getBody());
     }
 
     public function testInvokeFunctionName(): void
@@ -1573,7 +1573,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testCurrentRequestAttributesAreNotLostWhenAddingRouteArguments(): void
@@ -1613,7 +1613,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal()->withAttribute('greeting', 'Hello'));
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testCurrentRequestAttributesAreNotLostWhenAddingRouteArgumentsRequestResponseArg(): void
@@ -1654,7 +1654,7 @@ class AppTest extends TestCase
         $response = $app->handle($requestProphecy->reveal()->withAttribute('greeting', 'Hello'));
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testRun(): void
@@ -1801,7 +1801,7 @@ class AppTest extends TestCase
 
         $response = $app->handle($requestProphecy->reveal());
 
-        $this->assertEquals(1, $called);
+        $this->assertSame(1, $called);
         $this->assertEmpty((string) $response->getBody());
     }
 
@@ -1917,7 +1917,7 @@ class AppTest extends TestCase
 
         $this->assertSame(204, $response->getStatusCode());
         $this->assertSame(['nested', 'outer'], $response->getHeader('X-TRACE'));
-        $this->assertEquals('11', (string) $response->getBody());
+        $this->assertSame('11', (string) $response->getBody());
     }
 
     // TODO: Re-add testUnsupportedMethodWithoutRoute
@@ -1959,7 +1959,7 @@ class AppTest extends TestCase
 
         $response = $app->handle($requestProphecy->reveal());
 
-        $this->assertEquals('Hello World', (string) $response->getBody());
+        $this->assertSame('Hello World', (string) $response->getBody());
     }
 
     public function testAppIsARequestHandler(): void
@@ -2005,7 +2005,7 @@ class AppTest extends TestCase
         });
 
         $response = $app->handle($requestProphecy->reveal());
-        $this->assertEquals('1', (string) $response->getBody());
+        $this->assertSame('1', (string) $response->getBody());
 
         $uriProphecy2 = $this->prophesize(UriInterface::class);
         $uriProphecy2->getPath()->willReturn('/Hello');
@@ -2021,7 +2021,7 @@ class AppTest extends TestCase
 
         $streamProphecy->__toString()->willReturn('');
         $response = $app->handle($requestProphecy2->reveal());
-        $this->assertEquals('0', (string) $response->getBody());
+        $this->assertSame('0', (string) $response->getBody());
     }
 
     public function testInvokeSequentialProcessToAPathWithOptionalArgsAndWithoutOptionalArgsAndKeepSetedArgs(): void
@@ -2059,7 +2059,7 @@ class AppTest extends TestCase
         });
 
         $response = $app->handle($requestProphecy->reveal());
-        $this->assertEquals('2', (string) $response->getBody());
+        $this->assertSame('2', (string) $response->getBody());
 
         $uriProphecy2 = $this->prophesize(UriInterface::class);
         $uriProphecy2->getPath()->willReturn('/Hello');
@@ -2075,7 +2075,7 @@ class AppTest extends TestCase
 
         $streamProphecy->__toString()->willReturn('');
         $response = $app->handle($requestProphecy2->reveal());
-        $this->assertEquals('1', (string) $response->getBody());
+        $this->assertSame('1', (string) $response->getBody());
     }
 
     public function testInvokeSequentialProcessAfterAddingAnotherRouteArgument(): void
@@ -2118,12 +2118,12 @@ class AppTest extends TestCase
         });
 
         $response = $app->handle($requestProphecy->reveal());
-        $this->assertEquals('2', (string) $response->getBody());
+        $this->assertSame('2', (string) $response->getBody());
 
         $route->setArgument('extra2', 'value2');
 
         $streamProphecy->__toString()->willReturn('');
         $response = $app->handle($requestProphecy->reveal());
-        $this->assertEquals('3', (string) $response->getBody());
+        $this->assertSame('3', (string) $response->getBody());
     }
 }

--- a/tests/CallableResolverTest.php
+++ b/tests/CallableResolverTest.php
@@ -78,9 +78,9 @@ class CallableResolverTest extends TestCase
         $callableRoute = $resolver->resolveRoute($test);
         $callableMiddleware = $resolver->resolveMiddleware($test);
 
-        $this->assertEquals(42, $callable());
-        $this->assertEquals(42, $callableRoute());
-        $this->assertEquals(42, $callableMiddleware());
+        $this->assertSame(42, $callable());
+        $this->assertSame(42, $callableRoute());
+        $this->assertSame(42, $callableMiddleware());
     }
 
     public function testFunctionName(): void
@@ -104,13 +104,13 @@ class CallableResolverTest extends TestCase
         $callableMiddleware = $resolver->resolveMiddleware([$obj, 'toCall']);
 
         $callable();
-        $this->assertEquals(1, CallableTest::$CalledCount);
+        $this->assertSame(1, CallableTest::$CalledCount);
 
         $callableRoute();
-        $this->assertEquals(2, CallableTest::$CalledCount);
+        $this->assertSame(2, CallableTest::$CalledCount);
 
         $callableMiddleware();
-        $this->assertEquals(3, CallableTest::$CalledCount);
+        $this->assertSame(3, CallableTest::$CalledCount);
     }
 
     public function testSlimCallable(): void
@@ -121,13 +121,13 @@ class CallableResolverTest extends TestCase
         $callableMiddleware = $resolver->resolveMiddleware('Slim\Tests\Mocks\CallableTest:toCall');
 
         $callable();
-        $this->assertEquals(1, CallableTest::$CalledCount);
+        $this->assertSame(1, CallableTest::$CalledCount);
 
         $callableRoute();
-        $this->assertEquals(2, CallableTest::$CalledCount);
+        $this->assertSame(2, CallableTest::$CalledCount);
 
         $callableMiddleware();
-        $this->assertEquals(3, CallableTest::$CalledCount);
+        $this->assertSame(3, CallableTest::$CalledCount);
     }
 
     public function testSlimCallableAsArray(): void
@@ -138,13 +138,13 @@ class CallableResolverTest extends TestCase
         $callableMiddleware = $resolver->resolveMiddleware([CallableTest::class, 'toCall']);
 
         $callable();
-        $this->assertEquals(1, CallableTest::$CalledCount);
+        $this->assertSame(1, CallableTest::$CalledCount);
 
         $callableRoute();
-        $this->assertEquals(2, CallableTest::$CalledCount);
+        $this->assertSame(2, CallableTest::$CalledCount);
 
         $callableMiddleware();
-        $this->assertEquals(3, CallableTest::$CalledCount);
+        $this->assertSame(3, CallableTest::$CalledCount);
     }
 
     public function testSlimCallableContainer(): void
@@ -153,15 +153,15 @@ class CallableResolverTest extends TestCase
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);
         $resolver->resolve('Slim\Tests\Mocks\CallableTest:toCall');
-        $this->assertEquals($container, CallableTest::$CalledContainer);
+        $this->assertSame($container, CallableTest::$CalledContainer);
 
         CallableTest::$CalledContainer = null;
         $resolver->resolveRoute('Slim\Tests\Mocks\CallableTest:toCall');
-        $this->assertEquals($container, CallableTest::$CalledContainer);
+        $this->assertSame($container, CallableTest::$CalledContainer);
 
         CallableTest::$CalledContainer = null;
         $resolver->resolveMiddleware('Slim\Tests\Mocks\CallableTest:toCall');
-        $this->assertEquals($container, CallableTest::$CalledContainer);
+        $this->assertSame($container, CallableTest::$CalledContainer);
     }
 
     public function testSlimCallableAsArrayContainer(): void
@@ -170,15 +170,15 @@ class CallableResolverTest extends TestCase
         $container = $this->containerProphecy->reveal();
         $resolver = new CallableResolver($container);
         $resolver->resolve([CallableTest::class, 'toCall']);
-        $this->assertEquals($container, CallableTest::$CalledContainer);
+        $this->assertSame($container, CallableTest::$CalledContainer);
 
         CallableTest::$CalledContainer = null;
         $resolver->resolveRoute([CallableTest::class, 'toCall']);
-        $this->assertEquals($container, CallableTest::$CalledContainer);
+        $this->assertSame($container, CallableTest::$CalledContainer);
 
         CallableTest::$CalledContainer = null;
         $resolver->resolveMiddleware([CallableTest::class ,'toCall']);
-        $this->assertEquals($container, CallableTest::$CalledContainer);
+        $this->assertSame($container, CallableTest::$CalledContainer);
     }
 
     public function testContainer(): void
@@ -195,13 +195,13 @@ class CallableResolverTest extends TestCase
         $callableMiddleware = $resolver->resolveMiddleware('callable_service:toCall');
 
         $callable();
-        $this->assertEquals(1, CallableTest::$CalledCount);
+        $this->assertSame(1, CallableTest::$CalledCount);
 
         $callableRoute();
-        $this->assertEquals(2, CallableTest::$CalledCount);
+        $this->assertSame(2, CallableTest::$CalledCount);
 
         $callableMiddleware();
-        $this->assertEquals(3, CallableTest::$CalledCount);
+        $this->assertSame(3, CallableTest::$CalledCount);
     }
 
     public function testResolutionToAnInvokableClassInContainer(): void
@@ -218,13 +218,13 @@ class CallableResolverTest extends TestCase
         $callableMiddleware = $resolver->resolveMiddleware('an_invokable');
 
         $callable();
-        $this->assertEquals(1, InvokableTest::$CalledCount);
+        $this->assertSame(1, InvokableTest::$CalledCount);
 
         $callableRoute();
-        $this->assertEquals(2, InvokableTest::$CalledCount);
+        $this->assertSame(2, InvokableTest::$CalledCount);
 
         $callableMiddleware();
-        $this->assertEquals(3, InvokableTest::$CalledCount);
+        $this->assertSame(3, InvokableTest::$CalledCount);
     }
 
     public function testResolutionToAnInvokableClass(): void
@@ -235,13 +235,13 @@ class CallableResolverTest extends TestCase
         $callableMiddleware = $resolver->resolveMiddleware('Slim\Tests\Mocks\InvokableTest');
 
         $callable();
-        $this->assertEquals(1, InvokableTest::$CalledCount);
+        $this->assertSame(1, InvokableTest::$CalledCount);
 
         $callableRoute();
-        $this->assertEquals(2, InvokableTest::$CalledCount);
+        $this->assertSame(2, InvokableTest::$CalledCount);
 
         $callableMiddleware();
-        $this->assertEquals(3, InvokableTest::$CalledCount);
+        $this->assertSame(3, InvokableTest::$CalledCount);
     }
 
     public function testResolutionToAPsrRequestHandlerClass(): void
@@ -259,7 +259,7 @@ class CallableResolverTest extends TestCase
         $resolver = new CallableResolver(); // No container injected
         $callableRoute = $resolver->resolveRoute(RequestHandlerTest::class);
         $callableRoute($request);
-        $this->assertEquals('1', RequestHandlerTest::$CalledCount);
+        $this->assertSame(1, RequestHandlerTest::$CalledCount);
     }
 
     public function testMiddlewareResolutionToAPsrRequestHandlerClass(): void
@@ -288,7 +288,7 @@ class CallableResolverTest extends TestCase
         $resolver = new CallableResolver(); // No container injected
         $callableRoute = $resolver->resolveRoute($obj);
         $callableRoute($request);
-        $this->assertEquals('1', RequestHandlerTest::$CalledCount);
+        $this->assertSame(1, RequestHandlerTest::$CalledCount);
     }
 
     public function testMiddlewareObjPsrRequestHandlerClass(): void
@@ -327,7 +327,7 @@ class CallableResolverTest extends TestCase
         $callable = $resolver->resolveRoute('a_requesthandler');
         $callable($request);
 
-        $this->assertEquals('1', RequestHandlerTest::$CalledCount);
+        $this->assertSame(1, RequestHandlerTest::$CalledCount);
     }
 
     public function testMiddlewareObjPsrRequestHandlerClassInContainer(): void
@@ -353,15 +353,15 @@ class CallableResolverTest extends TestCase
 
         $this->assertIsArray($callable);
         $this->assertInstanceOf(RequestHandlerTest::class, $callable[0]);
-        $this->assertEquals('custom', $callable[1]);
+        $this->assertSame('custom', $callable[1]);
 
         $this->assertIsArray($callableRoute);
         $this->assertInstanceOf(RequestHandlerTest::class, $callableRoute[0]);
-        $this->assertEquals('custom', $callableRoute[1]);
+        $this->assertSame('custom', $callableRoute[1]);
 
         $this->assertIsArray($callableMiddleware);
         $this->assertInstanceOf(RequestHandlerTest::class, $callableMiddleware[0]);
-        $this->assertEquals('custom', $callableMiddleware[1]);
+        $this->assertSame('custom', $callableMiddleware[1]);
     }
 
     public function testObjMiddlewareClass(): void
@@ -391,7 +391,7 @@ class CallableResolverTest extends TestCase
         $resolver = new CallableResolver(); // No container injected
         $callableRouteMiddleware = $resolver->resolveMiddleware($obj);
         $callableRouteMiddleware($request, $this->createMock(RequestHandlerInterface::class));
-        $this->assertEquals('1', MiddlewareTest::$CalledCount);
+        $this->assertSame(1, MiddlewareTest::$CalledCount);
     }
 
     public function testNotObjectInContainerThrowException(): void

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -107,7 +107,7 @@ class AbstractErrorRendererTest extends TestCase
         $output = json_encode(json_decode($renderer->__invoke($exception, true)));
         $expectedString = json_encode(['message' => 'Slim Application Error', 'exception' => [$fragment]]);
 
-        $this->assertEquals($output, $expectedString);
+        $this->assertSame($output, $expectedString);
     }
 
     public function testJSONErrorRendererDoesNotDisplayErrorDetails()
@@ -117,7 +117,7 @@ class AbstractErrorRendererTest extends TestCase
         $renderer = new JsonErrorRenderer();
         $output = json_encode(json_decode($renderer->__invoke($exception, false)));
 
-        $this->assertEquals($output, json_encode(['message' => 'Slim Application Error']));
+        $this->assertSame($output, json_encode(['message' => 'Slim Application Error']));
     }
 
     public function testJSONErrorRendererDisplaysPreviousError()
@@ -139,7 +139,7 @@ class AbstractErrorRendererTest extends TestCase
 
         $expectedString = json_encode(['message' => 'Slim Application Error', 'exception' => $fragments]);
 
-        $this->assertEquals($output, $expectedString);
+        $this->assertSame($output, $expectedString);
     }
 
     public function testJSONErrorRendererRenderHttpException()
@@ -156,7 +156,7 @@ class AbstractErrorRendererTest extends TestCase
         $renderer = new JsonErrorRenderer();
         $output = json_encode(json_decode($renderer->__invoke($httpExceptionProphecy->reveal(), false)));
 
-        $this->assertEquals(
+        $this->assertSame(
             $output,
             json_encode(['message' => $exceptionTitle]),
             'Should contain http exception title'
@@ -174,11 +174,11 @@ class AbstractErrorRendererTest extends TestCase
         /** @var stdClass $output */
         $output = simplexml_load_string($renderer->__invoke($exception, true));
 
-        $this->assertEquals($output->message[0], 'Slim Application Error');
-        $this->assertEquals((string) $output->exception[0]->type, 'Exception');
-        $this->assertEquals((string) $output->exception[0]->message, 'Ooops...');
-        $this->assertEquals((string) $output->exception[1]->type, 'RuntimeException');
-        $this->assertEquals((string) $output->exception[1]->message, 'Oops..');
+        $this->assertSame((string) $output->message[0], 'Slim Application Error');
+        $this->assertSame((string) $output->exception[0]->type, 'Exception');
+        $this->assertSame((string) $output->exception[0]->message, 'Ooops...');
+        $this->assertSame((string) $output->exception[1]->type, 'RuntimeException');
+        $this->assertSame((string) $output->exception[1]->message, 'Oops..');
     }
 
     public function testXMLErrorRendererRenderHttpException()
@@ -197,7 +197,7 @@ class AbstractErrorRendererTest extends TestCase
         /** @var stdClass $output */
         $output = simplexml_load_string($renderer->__invoke($httpExceptionProphecy->reveal(), true));
 
-        $this->assertEquals($output->message[0], $exceptionTitle, 'Should contain http exception title');
+        $this->assertSame((string) $output->message[0], $exceptionTitle, 'Should contain http exception title');
     }
 
     public function testPlainTextErrorRendererFormatFragmentMethod()
@@ -236,7 +236,7 @@ class AbstractErrorRendererTest extends TestCase
         $renderer = new PlainTextErrorRenderer();
         $output = $renderer->__invoke($exception, false);
 
-        $this->assertEquals("Slim Application Error\n", $output, 'Should show only one string');
+        $this->assertSame("Slim Application Error\n", $output, 'Should show only one string');
     }
 
     public function testPlainTextErrorRendererRenderHttpException()

--- a/tests/Exception/HttpExceptionTest.php
+++ b/tests/Exception/HttpExceptionTest.php
@@ -33,8 +33,8 @@ class HttpExceptionTest extends TestCase
         $exception->setTitle('Title');
         $exception->setDescription('Description');
 
-        $this->assertEquals('Title', $exception->getTitle());
-        $this->assertEquals('Description', $exception->getDescription());
+        $this->assertSame('Title', $exception->getTitle());
+        $this->assertSame('Description', $exception->getDescription());
     }
 
     public function testHttpNotAllowedExceptionGetAllowedMethods()
@@ -43,11 +43,11 @@ class HttpExceptionTest extends TestCase
 
         $exception = new HttpMethodNotAllowedException($request);
         $exception->setAllowedMethods(['GET']);
-        $this->assertEquals(['GET'], $exception->getAllowedMethods());
-        $this->assertEquals('Method not allowed. Must be one of: GET', $exception->getMessage());
+        $this->assertSame(['GET'], $exception->getAllowedMethods());
+        $this->assertSame('Method not allowed. Must be one of: GET', $exception->getMessage());
 
         $exception = new HttpMethodNotAllowedException($request);
-        $this->assertEquals([], $exception->getAllowedMethods());
-        $this->assertEquals('Method not allowed.', $exception->getMessage());
+        $this->assertSame([], $exception->getAllowedMethods());
+        $this->assertSame('Method not allowed.', $exception->getMessage());
     }
 }

--- a/tests/Factory/Psr17/Psr17FactoryProviderTest.php
+++ b/tests/Factory/Psr17/Psr17FactoryProviderTest.php
@@ -22,7 +22,7 @@ class Psr17FactoryProviderTest extends TestCase
     {
         Psr17FactoryProvider::setFactories([]);
 
-        $this->assertEquals([], Psr17FactoryProvider::getFactories());
+        $this->assertSame([], Psr17FactoryProvider::getFactories());
     }
 
 
@@ -34,6 +34,6 @@ class Psr17FactoryProviderTest extends TestCase
         Psr17FactoryProvider::setFactories(['Factory 1']);
         Psr17FactoryProvider::addFactory('Factory 2');
 
-        $this->assertEquals(['Factory 2', 'Factory 1'], Psr17FactoryProvider::getFactories());
+        $this->assertSame(['Factory 2', 'Factory 1'], Psr17FactoryProvider::getFactories());
     }
 }

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -95,12 +95,12 @@ class ErrorHandlerTest extends TestCase
         $method->setAccessible(true);
 
         $statusCode = $method->invoke($handler);
-        $this->assertEquals($statusCode, 404);
+        $this->assertSame($statusCode, 404);
 
         $reflectionProperty->setValue($handler, new MockCustomException());
 
         $statusCode = $method->invoke($handler);
-        $this->assertEquals($statusCode, 500);
+        $this->assertSame($statusCode, 500);
     }
 
     /**
@@ -189,7 +189,7 @@ class ErrorHandlerTest extends TestCase
 
         $contentType = $method->invoke($handler, $request);
 
-        $this->assertEquals('text/xml', $contentType);
+        $this->assertSame('text/xml', $contentType);
     }
 
     public function testDetermineContentTypeApplicationJsonOrXml()
@@ -223,7 +223,7 @@ class ErrorHandlerTest extends TestCase
 
         $contentType = $method->invoke($handler, $request);
 
-        $this->assertEquals('application/xml', $contentType);
+        $this->assertSame('application/xml', $contentType);
     }
 
     /**
@@ -254,7 +254,7 @@ class ErrorHandlerTest extends TestCase
         // call determineContentType()
         $return = $method->invoke($handler, $request);
 
-        $this->assertEquals('text/html', $return);
+        $this->assertSame('text/html', $return);
     }
 
     public function testRegisterErrorRenderer()
@@ -284,8 +284,8 @@ class ErrorHandlerTest extends TestCase
         $defaultErrorRendererContentTypeProperty->setAccessible(true);
         $defaultErrorRendererContentType = $defaultErrorRendererContentTypeProperty->getValue($handler);
 
-        $this->assertEquals(PlainTextErrorRenderer::class, $defaultErrorRenderer);
-        $this->assertEquals('text/plain', $defaultErrorRendererContentType);
+        $this->assertSame(PlainTextErrorRenderer::class, $defaultErrorRenderer);
+        $this->assertSame('text/plain', $defaultErrorRendererContentType);
     }
 
     public function testOptions()
@@ -300,7 +300,7 @@ class ErrorHandlerTest extends TestCase
 
         $this->assertSame(200, $res->getStatusCode());
         $this->assertTrue($res->hasHeader('Allow'));
-        $this->assertEquals('POST, PUT', $res->getHeaderLine('Allow'));
+        $this->assertSame('POST, PUT', $res->getHeaderLine('Allow'));
     }
 
     public function testWriteToErrorLog()
@@ -370,7 +370,7 @@ class ErrorHandlerTest extends TestCase
         $res = $handler->__invoke($request, $exception, true, true, true);
 
         $this->assertTrue($res->hasHeader('Content-Type'));
-        $this->assertEquals('text/html', $res->getHeaderLine('Content-Type'));
+        $this->assertSame('text/html', $res->getHeaderLine('Content-Type'));
     }
 
     public function testLogErrorRenderer()

--- a/tests/Middleware/BodyParsingMiddlewareTest.php
+++ b/tests/Middleware/BodyParsingMiddlewareTest.php
@@ -169,7 +169,7 @@ class BodyParsingMiddlewareTest extends TestCase
         $middleware = new BodyParsingMiddleware($parsers);
         $response = $middleware->process($request, $this->createRequestHandler());
 
-        $this->assertEquals(['data' => '{"foo":"bar"}'], $response->request->getParsedBody());
+        $this->assertSame(['data' => '{"foo":"bar"}'], $response->request->getParsedBody());
     }
 
     public function testParsingFailsWhenAnInvalidTypeIsReturned()

--- a/tests/Middleware/ContentLengthMiddlewareTest.php
+++ b/tests/Middleware/ContentLengthMiddlewareTest.php
@@ -36,6 +36,6 @@ class ContentLengthMiddlewareTest extends TestCase
         $middlewareDispatcher->addMiddleware($mw2);
         $response = $middlewareDispatcher->handle($request);
 
-        $this->assertEquals(4, $response->getHeaderLine('Content-Length'));
+        $this->assertSame('4', $response->getHeaderLine('Content-Length'));
     }
 }

--- a/tests/Middleware/MethodOverrideMiddlewareTest.php
+++ b/tests/Middleware/MethodOverrideMiddlewareTest.php
@@ -22,7 +22,7 @@ class MethodOverrideMiddlewareTest extends TestCase
     {
         $responseFactory = $this->getResponseFactory();
         $mw = (function (Request $request, RequestHandler $handler) use ($responseFactory) {
-            $this->assertEquals('PUT', $request->getMethod());
+            $this->assertSame('PUT', $request->getMethod());
             return $responseFactory->createResponse();
         })->bindTo($this);
         $mw2 = new MethodOverrideMiddleware();
@@ -44,7 +44,7 @@ class MethodOverrideMiddlewareTest extends TestCase
     {
         $responseFactory = $this->getResponseFactory();
         $mw = (function (Request $request, RequestHandler $handler) use ($responseFactory) {
-            $this->assertEquals('PUT', $request->getMethod());
+            $this->assertSame('PUT', $request->getMethod());
             return $responseFactory->createResponse();
         })->bindTo($this);
 
@@ -67,7 +67,7 @@ class MethodOverrideMiddlewareTest extends TestCase
     {
         $responseFactory = $this->getResponseFactory();
         $mw = (function (Request $request, RequestHandler $handler) use ($responseFactory) {
-            $this->assertEquals('DELETE', $request->getMethod());
+            $this->assertSame('DELETE', $request->getMethod());
             return $responseFactory->createResponse();
         })->bindTo($this);
 
@@ -91,7 +91,7 @@ class MethodOverrideMiddlewareTest extends TestCase
     {
         $responseFactory = $this->getResponseFactory();
         $mw = (function (Request $request, RequestHandler $handler) use ($responseFactory) {
-            $this->assertEquals('POST', $request->getMethod());
+            $this->assertSame('POST', $request->getMethod());
             return $responseFactory->createResponse();
         })->bindTo($this);
 
@@ -112,7 +112,7 @@ class MethodOverrideMiddlewareTest extends TestCase
     {
         $responseFactory = $this->getResponseFactory();
         $mw = (function (Request $request, RequestHandler $handler) use ($responseFactory) {
-            $this->assertEquals('POST', $request->getMethod());
+            $this->assertSame('POST', $request->getMethod());
             return $responseFactory->createResponse();
         })->bindTo($this);
 

--- a/tests/Middleware/OutputBufferingMiddlewareTest.php
+++ b/tests/Middleware/OutputBufferingMiddlewareTest.php
@@ -29,7 +29,7 @@ class OutputBufferingMiddlewareTest extends TestCase
         $reflectionProperty->setAccessible(true);
         $value = $reflectionProperty->getValue($mw);
 
-        $this->assertEquals('append', $value);
+        $this->assertSame('append', $value);
     }
 
     public function testStyleCustomValid()
@@ -40,7 +40,7 @@ class OutputBufferingMiddlewareTest extends TestCase
         $reflectionProperty->setAccessible(true);
         $value = $reflectionProperty->getValue($mw);
 
-        $this->assertEquals('prepend', $value);
+        $this->assertSame('prepend', $value);
     }
 
     public function testStyleCustomInvalid()
@@ -72,7 +72,7 @@ class OutputBufferingMiddlewareTest extends TestCase
         $middlewareDispatcher->addMiddleware($mw2);
         $response = $middlewareDispatcher->handle($request);
 
-        $this->assertEquals('BodyTest', $response->getBody());
+        $this->assertSame('BodyTest', (string) $response->getBody());
     }
 
     public function testPrepend()
@@ -97,7 +97,7 @@ class OutputBufferingMiddlewareTest extends TestCase
         $middlewareDispatcher->addMiddleware($mw2);
         $response = $middlewareDispatcher->handle($request);
 
-        $this->assertEquals('TestBody', $response->getBody());
+        $this->assertSame('TestBody', (string) $response->getBody());
     }
 
     public function testOutputBufferIsCleanedWhenThrowableIsCaught()
@@ -105,7 +105,7 @@ class OutputBufferingMiddlewareTest extends TestCase
         $responseFactory = $this->getResponseFactory();
         $mw = (function ($request, $handler) {
             echo "Test";
-            $this->assertEquals('Test', ob_get_contents());
+            $this->assertSame('Test', ob_get_contents());
             throw new Exception('Oops...');
         })->bindTo($this);
         $mw2 = new OutputBufferingMiddleware($this->getStreamFactory(), 'prepend');
@@ -122,7 +122,7 @@ class OutputBufferingMiddlewareTest extends TestCase
         try {
             $middlewareDispatcher->handle($request);
         } catch (Exception $e) {
-            $this->assertEquals('', ob_get_contents());
+            $this->assertSame('', ob_get_contents());
         }
     }
 }

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -46,7 +46,7 @@ class RoutingMiddlewareTest extends TestCase
             // route is available
             $route = $request->getAttribute(RouteContext::ROUTE);
             $this->assertNotNull($route);
-            $this->assertEquals('foo', $route->getArgument('name'));
+            $this->assertSame('foo', $route->getArgument('name'));
 
             // routeParser is available
             $routeParser = $request->getAttribute(RouteContext::ROUTE_PARSER);
@@ -108,7 +108,7 @@ class RoutingMiddlewareTest extends TestCase
             // routingResults is available
             $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS);
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
-            $this->assertEquals(Dispatcher::METHOD_NOT_ALLOWED, $routingResults->getRouteStatus());
+            $this->assertSame(Dispatcher::METHOD_NOT_ALLOWED, $routingResults->getRouteStatus());
         }
     }
 
@@ -145,7 +145,7 @@ class RoutingMiddlewareTest extends TestCase
             // routingResults is available
             $routingResults = $request->getAttribute(RouteContext::ROUTING_RESULTS);
             $this->assertInstanceOf(RoutingResults::class, $routingResults);
-            $this->assertEquals(Dispatcher::NOT_FOUND, $routingResults->getRouteStatus());
+            $this->assertSame(Dispatcher::NOT_FOUND, $routingResults->getRouteStatus());
         }
     }
 

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -62,7 +62,7 @@ class MiddlewareDispatcherTest extends TestCase
         $request = $this->createServerRequest('/');
         $middlewareDispatcher->handle($request);
 
-        $this->assertEquals(1, $handler->getCalledCount());
+        $this->assertSame(1, $handler->getCalledCount());
     }
 
     public function testDeferredResolvedCallable(): void
@@ -91,7 +91,7 @@ class MiddlewareDispatcherTest extends TestCase
         $request = $this->createServerRequest('/');
         $middlewareDispatcher->handle($request);
 
-        $this->assertEquals(1, $handler->getCalledCount());
+        $this->assertSame(1, $handler->getCalledCount());
     }
 
     public function testDeferredResolvedCallableWithoutContainerAndNonAdvancedCallableResolver(): void
@@ -115,7 +115,7 @@ class MiddlewareDispatcherTest extends TestCase
         $request = $this->createServerRequest('/');
         $middlewareDispatcher->handle($request);
 
-        $this->assertEquals(1, $handler->getCalledCount());
+        $this->assertSame(1, $handler->getCalledCount());
     }
 
     public function testDeferredResolvedCallableWithDirectConstructorCall(): void
@@ -135,7 +135,7 @@ class MiddlewareDispatcherTest extends TestCase
         $request = $this->createServerRequest('/');
         $middlewareDispatcher->handle($request);
 
-        $this->assertEquals(1, $handler->getCalledCount());
+        $this->assertSame(1, $handler->getCalledCount());
     }
 
     public function deferredCallableProvider(): array
@@ -197,7 +197,7 @@ class MiddlewareDispatcherTest extends TestCase
         $request = $this->createServerRequest('/');
         $middlewareDispatcher->handle($request);
 
-        $this->assertEquals(1, $handler->getCalledCount());
+        $this->assertSame(1, $handler->getCalledCount());
     }
 
     public function testDeferredResolvedSlimCallable(): void
@@ -209,7 +209,7 @@ class MiddlewareDispatcherTest extends TestCase
         $request = $this->createServerRequest('/');
         $middlewareDispatcher->handle($request);
 
-        $this->assertEquals(1, $handler->getCalledCount());
+        $this->assertSame(1, $handler->getCalledCount());
     }
 
     public function testDeferredResolvedClosureIsBoundToContainer(): void
@@ -271,8 +271,8 @@ class MiddlewareDispatcherTest extends TestCase
         $request = $this->createServerRequest('/');
         $middlewareDispatcher->handle($request);
 
-        $this->assertEquals(1, MockMiddlewareWithoutConstructor::$CalledCount);
-        $this->assertEquals(1, $handler->getCalledCount());
+        $this->assertSame(1, MockMiddlewareWithoutConstructor::$CalledCount);
+        $this->assertSame(1, $handler->getCalledCount());
     }
 
     public function testResolveThrowsExceptionWhenResolvableDoesNotImplementMiddlewareInterface(): void
@@ -349,7 +349,7 @@ class MiddlewareDispatcherTest extends TestCase
         $response = $dispatcher->handle($requestProphecy->reveal());
 
         $kernelProphecy->handle(Argument::type(ServerRequestInterface::class))->shouldHaveBeenCalled();
-        $this->assertEquals($responseProphecy->reveal(), $response);
+        $this->assertSame($responseProphecy->reveal(), $response);
     }
 
     public function testExecutesMiddlewareLastInFirstOut(): void
@@ -462,7 +462,7 @@ class MiddlewareDispatcherTest extends TestCase
         $response = $dispatcher->handle($requestProphecy->reveal());
 
         $this->assertFalse(MockSequenceMiddleware::$hasBeenInstantiated);
-        $this->assertEquals($responseProphecy->reveal(), $response);
+        $this->assertSame($responseProphecy->reveal(), $response);
         $kernelProphecy->handle(Argument::type(ServerRequestInterface::class))->shouldNotHaveBeenCalled();
     }
 
@@ -498,8 +498,8 @@ class MiddlewareDispatcherTest extends TestCase
         $response1 = $dispatcher->handle($requestProphecy->reveal());
         $response2 = $dispatcher->handle($requestProphecy->reveal());
 
-        $this->assertEquals($responseProphecy->reveal(), $response1);
-        $this->assertEquals($responseProphecy->reveal(), $response2);
+        $this->assertSame($responseProphecy->reveal(), $response1);
+        $this->assertSame($responseProphecy->reveal(), $response2);
         $kernelProphecy->handle(Argument::type(ServerRequestInterface::class))->shouldNotHaveBeenCalled();
     }
 
@@ -572,7 +572,7 @@ class MiddlewareDispatcherTest extends TestCase
         $dispatcher->addDeferred('somemiddlewarename');
         $response = $dispatcher->handle($requestProphecy->reveal());
 
-        $this->assertEquals($responseProphecy->reveal(), $response);
+        $this->assertSame($responseProphecy->reveal(), $response);
         $kernelProphecy->handle(Argument::type(ServerRequestInterface::class))->shouldNotHaveBeenCalled();
     }
 

--- a/tests/Routing/DispatcherTest.php
+++ b/tests/Routing/DispatcherTest.php
@@ -71,7 +71,7 @@ class DispatcherTest extends TestCase
 
         /** @var RoutingResults $result */
         $result = $dispatcher2->dispatch('GET', '/');
-        $this->assertEquals(FastRouteDispatcher::FOUND, $result->getRouteStatus());
+        $this->assertSame(FastRouteDispatcher::FOUND, $result->getRouteStatus());
 
         unlink($cacheFile);
     }
@@ -111,7 +111,7 @@ class DispatcherTest extends TestCase
         $dispatcher = new Dispatcher($routeCollector);
         $results = $dispatcher->getAllowedMethods('/');
 
-        $this->assertEquals($methods, $results);
+        $this->assertSame($methods, $results);
     }
 
     public function testDispatch()
@@ -130,13 +130,13 @@ class DispatcherTest extends TestCase
         $dispatcher = new Dispatcher($routeCollector);
         $results = $dispatcher->dispatch('GET', '/hello/Foo%20Bar');
 
-        $this->assertEquals(RoutingResults::FOUND, $results->getRouteStatus());
-        $this->assertEquals('GET', $results->getMethod());
-        $this->assertEquals('/hello/Foo%20Bar', $results->getUri());
-        $this->assertEquals($route->getIdentifier(), $results->getRouteIdentifier());
-        $this->assertEquals(['name' => 'Foo Bar'], $results->getRouteArguments());
-        $this->assertEquals(['name' => 'Foo%20Bar'], $results->getRouteArguments(false));
-        $this->assertEquals($methods, $results->getAllowedMethods());
+        $this->assertSame(RoutingResults::FOUND, $results->getRouteStatus());
+        $this->assertSame('GET', $results->getMethod());
+        $this->assertSame('/hello/Foo%20Bar', $results->getUri());
+        $this->assertSame($route->getIdentifier(), $results->getRouteIdentifier());
+        $this->assertSame(['name' => 'Foo Bar'], $results->getRouteArguments());
+        $this->assertSame(['name' => 'Foo%20Bar'], $results->getRouteArguments(false));
+        $this->assertSame($methods, $results->getAllowedMethods());
         $this->assertSame($dispatcher, $results->getDispatcher());
     }
 }

--- a/tests/Routing/RouteCollectorProxyTest.php
+++ b/tests/Routing/RouteCollectorProxyTest.php
@@ -111,12 +111,12 @@ class RouteCollectorProxyTest extends TestCase
 
         $routeCollectorProxy->setBasePath($basePath);
 
-        $this->assertEquals($basePath, $routeCollectorProxy->getBasePath());
+        $this->assertSame($basePath, $routeCollectorProxy->getBasePath());
 
         $newBasePath = '/new/base/path';
         $routeCollectorProxy->setBasePath('/new/base/path');
 
-        $this->assertEquals($newBasePath, $routeCollectorProxy->getBasePath());
+        $this->assertSame($newBasePath, $routeCollectorProxy->getBasePath());
     }
 
     public function testGet()
@@ -149,7 +149,7 @@ class RouteCollectorProxyTest extends TestCase
 
         $route = $routeCollectorProxy->get($pattern, $callable);
 
-        $this->assertEquals($pattern, $route->getPattern());
+        $this->assertSame($pattern, $route->getPattern());
     }
 
     public function testPost()
@@ -182,7 +182,7 @@ class RouteCollectorProxyTest extends TestCase
 
         $route = $routeCollectorProxy->post($pattern, $callable);
 
-        $this->assertEquals($pattern, $route->getPattern());
+        $this->assertSame($pattern, $route->getPattern());
     }
 
     public function testPut()
@@ -215,7 +215,7 @@ class RouteCollectorProxyTest extends TestCase
 
         $route = $routeCollectorProxy->put($pattern, $callable);
 
-        $this->assertEquals($pattern, $route->getPattern());
+        $this->assertSame($pattern, $route->getPattern());
     }
 
     public function testPatch()
@@ -248,7 +248,7 @@ class RouteCollectorProxyTest extends TestCase
 
         $route = $routeCollectorProxy->patch($pattern, $callable);
 
-        $this->assertEquals($pattern, $route->getPattern());
+        $this->assertSame($pattern, $route->getPattern());
     }
 
     public function testDelete()
@@ -281,7 +281,7 @@ class RouteCollectorProxyTest extends TestCase
 
         $route = $routeCollectorProxy->delete($pattern, $callable);
 
-        $this->assertEquals($pattern, $route->getPattern());
+        $this->assertSame($pattern, $route->getPattern());
     }
 
     public function testOptions()
@@ -314,7 +314,7 @@ class RouteCollectorProxyTest extends TestCase
 
         $route = $routeCollectorProxy->options($pattern, $callable);
 
-        $this->assertEquals($pattern, $route->getPattern());
+        $this->assertSame($pattern, $route->getPattern());
     }
 
     public function testAny()
@@ -347,7 +347,7 @@ class RouteCollectorProxyTest extends TestCase
 
         $route = $routeCollectorProxy->any($pattern, $callable);
 
-        $this->assertEquals($pattern, $route->getPattern());
+        $this->assertSame($pattern, $route->getPattern());
     }
 
     public function testMap()
@@ -381,7 +381,7 @@ class RouteCollectorProxyTest extends TestCase
 
         $route = $routeCollectorProxy->map($methods, $pattern, $callable);
 
-        $this->assertEquals($pattern, $route->getPattern());
+        $this->assertSame($pattern, $route->getPattern());
     }
 
     public function testRedirect()

--- a/tests/Routing/RouteCollectorTest.php
+++ b/tests/Routing/RouteCollectorTest.php
@@ -50,7 +50,7 @@ class RouteCollectorTest extends TestCase
         $routeCollector = new RouteCollector($responseFactoryProphecy->reveal(), $callableResolverProphecy->reveal());
         $routeCollector->setBasePath($basePath);
 
-        $this->assertEquals($basePath, $routeCollector->getBasePath());
+        $this->assertSame($basePath, $routeCollector->getBasePath());
     }
 
     public function testMap()
@@ -76,7 +76,7 @@ class RouteCollectorTest extends TestCase
             $route = $proxy->get('/test', function () {
             });
 
-            $self->assertEquals('/prefix/test', $route->getPattern());
+            $self->assertSame('/prefix/test', $route->getPattern());
         };
 
         $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
@@ -201,6 +201,6 @@ class RouteCollectorTest extends TestCase
             null,
             $cacheFile
         );
-        $this->assertEquals($cacheFile, $routeCollector->getCacheFile());
+        $this->assertSame($cacheFile, $routeCollector->getCacheFile());
     }
 }

--- a/tests/Routing/RouteParserTest.php
+++ b/tests/Routing/RouteParserTest.php
@@ -79,7 +79,7 @@ class RouteParserTest extends TestCase
         $routeParser = $routeCollector->getRouteParser();
         $results = $routeParser->relativeUrlFor('test', ['first' => 'hello', 'second' => 'world']);
 
-        $this->assertEquals('/hello/world', $results);
+        $this->assertSame('/hello/world', $results);
     }
 
     public function testBasePathIsIgnoreInRelativePathFor()
@@ -97,7 +97,7 @@ class RouteParserTest extends TestCase
         $routeParser = $routeCollector->getRouteParser();
         $results = $routeParser->relativeUrlFor('test', ['first' => 'hello', 'second' => 'world']);
 
-        $this->assertEquals('/hello/world', $results);
+        $this->assertSame('/hello/world', $results);
     }
 
     /**
@@ -126,7 +126,7 @@ class RouteParserTest extends TestCase
         $routeParser = $routeCollector->getRouteParser();
         $results = $routeParser->urlFor('test', $arguments, $queryParams);
 
-        $this->assertEquals($expectedResult, $results);
+        $this->assertSame($expectedResult, $results);
     }
 
     public function testUrlForWithMissingSegmentData()
@@ -193,6 +193,6 @@ class RouteParserTest extends TestCase
         $result = $routeParser->fullUrlFor($uriProphecy->reveal(), 'test', ['token' => '123']);
 
         $expectedResult = 'http://example.com:8080/app/123';
-        $this->assertEquals($expectedResult, $result);
+        $this->assertSame($expectedResult, $result);
     }
 }

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -116,16 +116,16 @@ class RouteTest extends TestCase
         };
         $route = $this->createRoute($methods, $pattern, $callable);
 
-        $this->assertEquals($methods, $route->getMethods());
-        $this->assertEquals($pattern, $route->getPattern());
-        $this->assertEquals($callable, $route->getCallable());
+        $this->assertSame($methods, $route->getMethods());
+        $this->assertSame($pattern, $route->getPattern());
+        $this->assertSame($callable, $route->getCallable());
     }
 
     public function testGetMethodsReturnsArrayWhenConstructedWithString()
     {
         $route = $this->createRoute();
 
-        $this->assertEquals(['GET'], $route->getMethods());
+        $this->assertSame(['GET'], $route->getMethods());
     }
 
     public function testGetMethods()
@@ -133,14 +133,14 @@ class RouteTest extends TestCase
         $methods = ['GET', 'POST'];
         $route = $this->createRoute($methods);
 
-        $this->assertEquals($methods, $route->getMethods());
+        $this->assertSame($methods, $route->getMethods());
     }
 
     public function testGetPattern()
     {
         $route = $this->createRoute();
 
-        $this->assertEquals('/', $route->getPattern());
+        $this->assertSame('/', $route->getPattern());
     }
 
     public function testGetCallable()
@@ -246,7 +246,7 @@ class RouteTest extends TestCase
             $groups
         );
 
-        $this->assertEquals($groups, $route->getGroups());
+        $this->assertSame($groups, $route->getGroups());
     }
 
     public function testArgumentSetting()
@@ -385,14 +385,14 @@ class RouteTest extends TestCase
     public function testIdentifier()
     {
         $route = $this->createRoute();
-        $this->assertEquals('route0', $route->getIdentifier());
+        $this->assertSame('route0', $route->getIdentifier());
     }
 
     public function testSetName()
     {
         $route = $this->createRoute();
-        $this->assertEquals($route, $route->setName('foo'));
-        $this->assertEquals('foo', $route->getName());
+        $this->assertSame($route, $route->setName('foo'));
+        $this->assertSame('foo', $route->getName());
     }
 
     public function testControllerMethodAsStringResolvesWithoutContainer()
@@ -409,7 +409,7 @@ class RouteTest extends TestCase
         $response = $route->run($request);
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals(1, CallableTest::$CalledCount);
+        $this->assertSame(1, CallableTest::$CalledCount);
     }
 
     public function testControllerMethodAsStringResolvesWithContainer()
@@ -475,7 +475,7 @@ class RouteTest extends TestCase
         $request = $this->createServerRequest('/');
         $response = $route->run($request);
 
-        $this->assertEquals('foo', (string) $response->getBody());
+        $this->assertSame('foo', (string) $response->getBody());
     }
 
     /**
@@ -498,8 +498,8 @@ class RouteTest extends TestCase
         ob_end_clean();
 
         // Output buffer is ignored without optional middleware
-        $this->assertEquals('', (string) $response->getBody());
-        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertSame('', (string) $response->getBody());
+        $this->assertSame(201, $response->getStatusCode());
     }
 
     /**
@@ -517,7 +517,7 @@ class RouteTest extends TestCase
         $request = $this->createServerRequest('/');
         $response = $route->run($request);
 
-        $this->assertEquals('foo', (string) $response->getBody());
+        $this->assertSame('foo', (string) $response->getBody());
     }
 
     public function testInvokeWithException()
@@ -639,7 +639,7 @@ class RouteTest extends TestCase
             ->reveal()
             ->get(RequestHandlerTest::class)::$strategy;
 
-        $this->assertEquals(RequestHandler::class, $strategy);
+        $this->assertSame(RequestHandler::class, $strategy);
     }
 
     public function testInvokeUsesUserSetStrategyForRequestHandlers()
@@ -674,7 +674,7 @@ class RouteTest extends TestCase
         $request = $this->createServerRequest('/', 'GET');
         $route->run($request);
 
-        $this->assertEquals(1, $strategy::$CalledCount);
+        $this->assertSame(1, $strategy::$CalledCount);
     }
 
     public function testRequestHandlerStrategyAppendsRouteArgumentsAsAttributesToRequest()
@@ -714,8 +714,8 @@ class RouteTest extends TestCase
             $name = $args[0];
             $value = $args[1];
 
-            $self->assertEquals('id', $name);
-            $self->assertEquals(1, $value);
+            $self->assertSame('id', $name);
+            $self->assertSame(1, $value);
 
             return $this;
         })->shouldBeCalledOnce();
@@ -731,7 +731,7 @@ class RouteTest extends TestCase
         $route = $this->createRoute();
         $route->setPattern('/hola/{nombre}');
 
-        $this->assertEquals('/hola/{nombre}', $route->getPattern());
+        $this->assertSame('/hola/{nombre}', $route->getPattern());
     }
 
     /**
@@ -805,7 +805,7 @@ class RouteTest extends TestCase
         $response = $route->run($request);
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertEquals(
+        $this->assertSame(
             [$containerProphecy->reveal()->get('CallableTest2'), 'toCall'],
             InvocationStrategyTest::$LastCalledFor
         );
@@ -869,6 +869,6 @@ class RouteTest extends TestCase
         $request = $this->createServerRequest('/');
         $response = $route->run($request);
 
-        $this->assertEquals('Hello', (string) $response->getBody());
+        $this->assertSame('Hello', (string) $response->getBody());
     }
 }


### PR DESCRIPTION
# Changed log

- As title, it should use the `assertSame` to let assert equals be restricted.