### PR TITLE
Persist routes indexed by name in RouteCollector for improved performance.

### DIFF
--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -60,6 +60,13 @@ class RouteCollector implements RouteCollectorInterface
     protected array $routes = [];
 
     /**
+     * Routes indexed by name
+     *
+     * @var RouteInterface[]
+     */
+    protected array $routesByName = [];
+
+    /**
      * Route groups
      *
      * @var RouteGroup[]
@@ -172,7 +179,8 @@ class RouteCollector implements RouteCollectorInterface
     public function removeNamedRoute(string $name): RouteCollectorInterface
     {
         $route = $this->getNamedRoute($name);
-        unset($this->routes[$route->getIdentifier()]);
+
+        unset($this->routesByName[$route->getName()], $this->routes[$route->getIdentifier()]);
         return $this;
     }
 
@@ -181,11 +189,10 @@ class RouteCollector implements RouteCollectorInterface
      */
     public function getNamedRoute(string $name): RouteInterface
     {
-        foreach ($this->routes as $route) {
-            if ($name === $route->getName()) {
-                return $route;
-            }
+        if (isset($this->routesByName[$name])) {
+            return $this->routesByName[$name];
         }
+
         throw new RuntimeException('Named route does not exist for name: ' . $name);
     }
 
@@ -229,6 +236,12 @@ class RouteCollector implements RouteCollectorInterface
     {
         $route = $this->createRoute($methods, $pattern, $handler);
         $this->routes[$route->getIdentifier()] = $route;
+
+        $routeName = $route->getName();
+        if (null !== $routeName && !isset($this->routesByName[$routeName])) {
+            $this->routesByName[$routeName] = $route;
+        }
+
         $this->routeCounter++;
 
         return $route;

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -190,7 +190,19 @@ class RouteCollector implements RouteCollectorInterface
     public function getNamedRoute(string $name): RouteInterface
     {
         if (isset($this->routesByName[$name])) {
-            return $this->routesByName[$name];
+            $route = $this->routesByName[$name];
+            if ($route->getName() === $name) {
+                return $route;
+            }
+
+            unset($this->routesByName[$name]);
+        }
+
+        foreach ($this->routes as $route) {
+            if ($name === $route->getName()) {
+                $this->routesByName[$name] = $route;
+                return $route;
+            }
         }
 
         throw new RuntimeException('Named route does not exist for name: ' . $name);
@@ -238,7 +250,7 @@ class RouteCollector implements RouteCollectorInterface
         $this->routes[$route->getIdentifier()] = $route;
 
         $routeName = $route->getName();
-        if (null !== $routeName && !isset($this->routesByName[$routeName])) {
+        if ($routeName !== null && !isset($this->routesByName[$routeName])) {
             $this->routesByName[$routeName] = $route;
         }
 

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -296,7 +296,7 @@ class ErrorHandlerTest extends TestCase
         $exception->setAllowedMethods(['POST', 'PUT']);
 
         /** @var ResponseInterface $res */
-        $res = $handler->__invoke($request, $exception, true, true, true);
+        $res = $handler->__invoke($request, $exception, true, false, true);
 
         $this->assertSame(200, $res->getStatusCode());
         $this->assertTrue($res->hasHeader('Allow'));
@@ -367,7 +367,7 @@ class ErrorHandlerTest extends TestCase
         $exception = new RuntimeException();
 
         /** @var ResponseInterface $res */
-        $res = $handler->__invoke($request, $exception, true, true, true);
+        $res = $handler->__invoke($request, $exception, true, false, true);
 
         $this->assertTrue($res->hasHeader('Content-Type'));
         $this->assertSame('text/html', $res->getHeaderLine('Content-Type'));

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -388,6 +388,10 @@ class ErrorHandlerTest extends TestCase
         $handler = new ErrorHandler($callableResolverProphecy->reveal(), $this->getResponseFactory());
         $handler->setLogErrorRenderer('logErrorRenderer');
 
+        $displayErrorDetailsProperty = new ReflectionProperty($handler, 'displayErrorDetails');
+        $displayErrorDetailsProperty->setAccessible(true);
+        $displayErrorDetailsProperty->setValue($handler, true);
+
         $exception = new RuntimeException();
         $exceptionProperty = new ReflectionProperty($handler, 'exception');
         $exceptionProperty->setAccessible(true);


### PR DESCRIPTION
In our application, we have what I think is a reasonable number of routes defined (a few dozen), and we're often calling `RouteParserInterface::relativeUrlFor` and its related functions. Under the hood, these all call `RouteCollectorInterface::getNamedRoute`, and right now, that's iterating through _every_ single route, checking the name, and returning the result if it finds it.

Individually, these calls aren't a big deal, but they add up fast. If, say, you're returning an API response with several records with several links in each row, this tends to result in a _huge_ number of calls to `RouteInterface::getName()`.

As a result of their exposed methods, the nature of the `RouteCollectorInterface` and `RouteParserInterface` means that it isn't possible to implement a lookup table like this in one's own code without reimplementing the entire `RouteParserInterface::relativeUrlFor` functionality.

However, fortunately that also means that this change can be made at the Slim level without any change to the interface. The logic here is identical to how it functions currently (the first route with a given name is returned by `getNamedRoute()`).