### PR TITLE
HTTP Response status line refactoring

### DIFF
--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -72,13 +72,7 @@ class ResponseEmitter
      */
     private function emitStatusLine(ResponseInterface $response): void
     {
-        $statusLine = sprintf(
-            'HTTP/%s %s %s',
-            $response->getProtocolVersion(),
-            $response->getStatusCode(),
-            $response->getReasonPhrase()
-        );
-        header($statusLine, true, $response->getStatusCode());
+        http_response_code($response->getStatusCode());
     }
 
     /**

--- a/tests/Assets/HeaderStack.php
+++ b/tests/Assets/HeaderStack.php
@@ -43,12 +43,12 @@ class HeaderStack
     /**
      * @var string[][]
      */
-    private static $data = [];
+    private static array $data = [];
 
     /**
      * Reset state
      */
-    public static function reset()
+    public static function reset(): void
     {
         self::$data = [];
     }
@@ -58,7 +58,7 @@ class HeaderStack
      *
      * @param array $header
      */
-    public static function push(array $header)
+    public static function push(array $header): void
     {
         self::$data[] = $header;
     }
@@ -68,7 +68,7 @@ class HeaderStack
      *
      * @return string[][]
      */
-    public static function stack()
+    public static function stack(): array
     {
         return self::$data;
     }
@@ -80,7 +80,7 @@ class HeaderStack
      *
      * @return bool
      */
-    public static function has($header)
+    public static function has(string $header): bool
     {
         foreach (self::$data as $item) {
             $components = explode(':', $item['header']);


### PR DESCRIPTION
Made emitStatusLine method refactoring in ResponseEmitter. Used core PHP function for returning http response status line - http_response_code()
Some strict typing was added in tests/Assets/HeaderStack.php