### PR TITLE
Fix HttpBadRequestException description

### DIFF
--- a/Slim/Exception/HttpBadRequestException.php
+++ b/Slim/Exception/HttpBadRequestException.php
@@ -23,6 +23,6 @@ class HttpBadRequestException extends HttpSpecializedException
     protected $message = 'Bad request.';
 
     protected string $title = '400 Bad Request';
-    protected string $description = 'The server cannot or will not process' .
+    protected string $description = 'The server cannot or will not process ' .
         'the request due to an apparent client error.';
 }


### PR DESCRIPTION
Class `Slim\Exception\HttpBadRequestException` has a "typo" (a missing space) in `$description` variable:

https://github.com/slimphp/Slim/blob/6fbf22fe4b25672583aa94a7b8ea40d036b10c85/Slim/Exception/HttpBadRequestException.php#L26 https://github.com/slimphp/Slim/blob/6fbf22fe4b25672583aa94a7b8ea40d036b10c85/Slim/Exception/HttpBadRequestException.php#L27

Using `getDescription()` to display "generic" responses:

![image](https://user-images.githubusercontent.com/16489902/221924291-85242c9c-21f2-4a3f-9a38-ef24d778e999.png)
