### PR TITLE
RequestHandler use appendRouteArgumentsToRequestAttributes, and merge…

### DIFF
--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -351,7 +351,8 @@ class Route implements RouteInterface, RequestHandlerInterface
             && $callable[0] instanceof RequestHandlerInterface
             && !in_array(RequestHandlerInvocationStrategyInterface::class, $strategyImplements)
         ) {
-            $strategy = new RequestHandler();
+            $strategy = new RequestHandler(true);
+            $request = $request->withQueryParams($request->getQueryParams() + $this->arguments);
         }
 
         $response = $this->responseFactory->createResponse();

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1215,6 +1215,66 @@ class AppTest extends TestCase
         $this->assertSame('Hello World', (string) $response->getBody());
     }
 
+    public function testInvokeWithMatchingRouteWithSetArgumentsFromGetQueryParams(): void
+    {
+        $streamProphecy = $this->prophesize(StreamInterface::class);
+        $streamProphecy->__toString()->willReturn('');
+        $streamProphecy->write(Argument::type('string'))->will(function ($args) {
+            $body = $this->reveal()->__toString();
+            $body .= $args[0];
+            $this->__toString()->willReturn($body);
+        });
+
+        $responseProphecy = $this->prophesize(ResponseInterface::class);
+        $responseProphecy->getBody()->willReturn($streamProphecy->reveal());
+        $response = $responseProphecy->reveal();
+
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $responseFactoryProphecy->createResponse()->willReturn($response);
+
+        $class = new class ($response) implements RequestHandlerInterface {
+
+            protected ResponseInterface $response;
+
+            public function __construct(ResponseInterface $response){
+                $this->response = $response;
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $queryParams = $request->getQueryParams();
+                $fromAttr = $request->getAttribute('from');
+                $this->response->getBody()->write("{$queryParams['greeting']} {$queryParams['name']} {$fromAttr}");
+                return $this->response;
+            }
+        };
+
+        $app = new App($responseFactoryProphecy->reveal());
+        $app->get('/', $class)->setArguments(['greeting' => 'Hello', 'from' => 'it\'s me']);
+
+        $uriProphecy = $this->prophesize(UriInterface::class);
+        $uriProphecy->getPath()->willReturn('/');
+
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $requestProphecy->getMethod()->willReturn('GET');
+        $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
+        $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
+            $this->getAttribute($args[0])->willReturn($args[1]);
+            return $this;
+        });
+        $requestProphecy->getQueryParams()->willReturn(['name' => 'World']);
+        $requestProphecy->withQueryParams(Argument::type('array'))->will(function ($args) {
+            $this->getQueryParams()->willReturn($args[0]);
+            return $this;
+        });
+
+        $response = $app->handle($requestProphecy->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame('Hello World it\'s me', (string) $response->getBody());
+    }
+
     public function testInvokeWithMatchingRouteWithNamedParameterRequestResponseStrategy(): void
     {
         $streamProphecy = $this->prophesize(StreamInterface::class);


### PR DESCRIPTION
… arguments into query params

When using RequestHandlerInterface, the values of the attributes were not available in any form.

In the first step, to make it available as an attribute, I set the value of appendRouteArgumentsToRequestAttributes to true when instantiating the RequestHandler.

In the second step, only when using PSR's RequestHandlerInterface, I also passed it to the ServerRequest's QueryParams, since it is a simplified (beautified) query from the url, only with hidden keys.