### PR TITLE
fix: Append route arguments to request attributes

### DIFF
--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -351,7 +351,7 @@ class Route implements RouteInterface, RequestHandlerInterface
             && $callable[0] instanceof RequestHandlerInterface
             && !in_array(RequestHandlerInvocationStrategyInterface::class, $strategyImplements)
         ) {
-            $strategy = new RequestHandler();
+            $strategy = new RequestHandler(true);
         }
 
         $response = $this->responseFactory->createResponse();


### PR DESCRIPTION
When using RequestHandlerInterface, the values of the attributes were not available in any form.