### PR TITLE
prevent multiple entries of same methode in FastRouteDispatcher

### DIFF
--- a/Slim/Routing/FastRouteDispatcher.php
+++ b/Slim/Routing/FastRouteDispatcher.php
@@ -90,20 +90,20 @@ class FastRouteDispatcher extends GroupCountBased
             return $this->allowedMethods[$uri];
         }
 
-        $this->allowedMethods[$uri] = [];
+        $allowedMethods = [];
         foreach ($this->staticRouteMap as $method => $uriMap) {
             if (isset($uriMap[$uri])) {
-                $this->allowedMethods[$uri][] = $method;
+                $allowedMethods[$method] = true;
             }
         }
 
         foreach ($this->variableRouteData as $method => $routeData) {
             $result = $this->dispatchVariableRoute($routeData, $uri);
             if ($result[0] === self::FOUND) {
-                $this->allowedMethods[$uri][] = $method;
+                $allowedMethods[$method] = true;
             }
         }
 
-        return $this->allowedMethods[$uri];
+        return $this->allowedMethods[$uri] = array_keys($allowedMethods);
     }
 }


### PR DESCRIPTION
If you create two routes, one with a static path and the other one with a placeholder 
and call "getAllowedMethods" from Slim/Routing/FastRouteDispatcher.php afterwards, the same method is returned twice, because one route is set in staticRouteMap while the other one is set in variableRouteData.

Please see example below for further information

composer.json: 
```
{
    "require": {
        "slim/slim": "^4.11",
        "slim/http": "^1.3",
        "slim/psr7": "^1.6"
    }
}
```

public/index.php:
```PHP
<?php

use Psr\Http\Message\ResponseInterface as Response;
use Psr\Http\Message\ServerRequestInterface as Request;
use Slim\Factory\AppFactory;
use Slim\Routing\RouteContext;

require __DIR__ . '/../vendor/autoload.php';

$app = AppFactory::create();

$app->get('/name', function (Request $request, Response $response) {
    $rr = RouteContext::fromRequest($request)->getRoutingResults();
    var_dump($rr->getDispatcher()->getAllowedMethods($rr->getUri()));
    return $response;
});

$app->get('/{name}', function (Request $request, Response $response) {
    $rr = RouteContext::fromRequest($request)->getRoutingResults();
    var_dump($rr->getDispatcher()->getAllowedMethods($rr->getUri()));
    return $response;
});

$app->run();

```

```
php -S localhost:8000 -t public
```
Output:
```
array(2) {
    [0]=> string(3) "GET" 
    [1]=> string(3) "GET" 
} 
```
