### PR TITLE
Create HttpTooManyRequestsException.php

### DIFF
--- a/Slim/Exception/HttpTooManyRequestsException.php
+++ b/Slim/Exception/HttpTooManyRequestsException.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Exception;
+
+class HttpTooManyRequestsException extends HttpSpecializedException
+{
+    /**
+     * @var int
+     */
+    protected $code = 429;
+
+    /**
+     * @var string
+     */
+    protected $message = 'Too many requests.';
+
+    protected string $title = '429 Too Many Requests';
+    protected string $description = 'The client application has surpassed its rate limit, or number of requests they can send in a given period of time.';
+}


### PR DESCRIPTION
This PR adds a new exception class called `HttpTooManyRequestsException`, which is a subclass of `HttpSpecializedException`, and is inteded to be thrown for [429](https://www.webfx.com/web-development/glossary/http-status-codes/what-is-a-429-status-code/) HTTP errors.