### PR TITLE
Improve compatibility with PHP8.1

### DIFF
--- a/Slim/Collection.php
+++ b/Slim/Collection.php
@@ -109,7 +109,7 @@ class Collection implements CollectionInterface
      *
      * @return bool
      */
-    public function offsetExists($key)
+    public function offsetExists($key): bool
     {
         return $this->has($key);
     }
@@ -121,6 +121,7 @@ class Collection implements CollectionInterface
      *
      * @return mixed The key's value, or the default value
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->get($key);
@@ -132,6 +133,7 @@ class Collection implements CollectionInterface
      * @param string $key   The data key
      * @param mixed  $value The data value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->set($key, $value);
@@ -142,6 +144,7 @@ class Collection implements CollectionInterface
      *
      * @param string $key The data key
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         $this->remove($key);
@@ -152,7 +155,7 @@ class Collection implements CollectionInterface
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->data);
     }
@@ -160,9 +163,9 @@ class Collection implements CollectionInterface
     /**
      * Get collection iterator
      *
-     * @return ArrayIterator
+     * @return ArrayIterator|\Traversable
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new ArrayIterator($this->data);
     }


### PR DESCRIPTION
We are facing some compatibility issues with PHP 8.1 regarding the Collection Class and the returns types. Right now we cannot upgrade to version 4.x, but this will fix the current situation with 3.x version. Thanks!