### PR TITLE
Allow Diactoros 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "guzzlehttp/psr7": "^2.6",
         "httpsoft/http-message": "^1.1",
         "httpsoft/http-server-request": "^1.1",
-        "laminas/laminas-diactoros": "^2.17",
+        "laminas/laminas-diactoros": "^2.17 || ^3",
         "nyholm/psr7": "^1.8",
         "nyholm/psr7-server": "^1.0",
         "phpspec/prophecy": "^1.17",


### PR DESCRIPTION
Slim is currently tested against an outdated version of the Laminas Diactoros library. This PR enables testing against the latest version.