### PR TITLE
Add support for psr/http-message ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "nikic/fast-route": "^1.3",
         "psr/container": "^1.0 || ^2.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.1",
+        "psr/http-message": "^2.0 || ^1.1",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0"

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "nikic/fast-route": "^1.3",
         "psr/container": "^1.0 || ^2.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^2.0 || ^1.1",
+        "psr/http-message": "^1.1 || ^2.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0"


### PR DESCRIPTION
Changed **psr/http-message** requirement to **^1.1 || ^2.0** in composer.json.

Note that in dev environment (ie. cloning this repo with this pull request merged and running the tests in PHP 7.4) **psr/http-message ^1.1** always gets pulled in by composer for PHP 7.4 users because PSR 7 implementations like **laminas/laminas-diactoros ^2.17** in the require-dev section of https://github.com/slimphp/Slim/blob/4.x/composer.json requires **psr/http-message ^1.0**. 

For users requiring **slim/slim** in their applications and using a PSR 7 implementation like **nyholm/psr7 ^1.8** which requires **psr/http-message ^1.1 || ^2.0** ( https://github.com/Nyholm/psr7/blob/1.8.1/composer.json ), **psr/http-message ^2.0** will be pulled in for those applications.

Closes https://github.com/slimphp/Slim/issues/3296