### PR TITLE
Do not HTML entity encode in PlainTextErrorRenderer

### DIFF
--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -46,7 +46,7 @@ class PlainTextErrorRenderer extends AbstractErrorRenderer
         /** @var int|string $code */
         $text .= sprintf("Code: %s\n", $code);
 
-        $text .= sprintf("Message: %s\n", htmlentities($exception->getMessage()));
+        $text .= sprintf("Message: %s\n", $exception->getMessage());
 
         $text .= sprintf("File: %s\n", $exception->getFile());
 

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -202,19 +202,24 @@ class AbstractErrorRendererTest extends TestCase
 
     public function testPlainTextErrorRendererFormatFragmentMethod()
     {
-        $exception = new Exception('Oops..', 500);
+        $message = 'Oops.. <br>';
+        $exception = new Exception($message, 500);
         $renderer = new PlainTextErrorRenderer();
         $reflectionRenderer = new ReflectionClass(PlainTextErrorRenderer::class);
 
         $method = $reflectionRenderer->getMethod('formatExceptionFragment');
         $method->setAccessible(true);
         $output = $method->invoke($renderer, $exception);
+        $this->assertIsString($output);
 
         $this->assertMatchesRegularExpression('/.*Type:*/', $output);
         $this->assertMatchesRegularExpression('/.*Code:*/', $output);
         $this->assertMatchesRegularExpression('/.*Message*/', $output);
         $this->assertMatchesRegularExpression('/.*File*/', $output);
         $this->assertMatchesRegularExpression('/.*Line*/', $output);
+
+        // ensure the renderer doesn't reformat the message
+        $this->assertMatchesRegularExpression("/.*$message/", $output);
     }
 
     public function testPlainTextErrorRendererDisplaysErrorDetails()


### PR DESCRIPTION
The `PlainTextErrorRenderer` should not encode exception messages as that's not required for plain text in the same way that it is not required for the `JsonErrorRenderer`.

Closes #3298
