### PR TITLE
Add enable-log-details-tip to response body Fixes #3317

### DIFF
--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -259,10 +259,6 @@ class ErrorHandler implements ErrorHandlerInterface
     {
         $renderer = $this->callableResolver->resolve($this->logErrorRenderer);
         $error = $renderer($this->exception, $this->logErrorDetails);
-        if (!$this->displayErrorDetails) {
-            $error .= "\nTips: To display error details in HTTP response ";
-            $error .= 'set "displayErrorDetails" to true in the ErrorHandler constructor.';
-        }
         $this->logError($error);
     }
 
@@ -299,6 +295,11 @@ class ErrorHandler implements ErrorHandlerInterface
         $renderer = $this->determineRenderer();
         $body = call_user_func($renderer, $this->exception, $this->displayErrorDetails);
         if ($body !== false) {
+            if (!$this->displayErrorDetails) {
+                $error .= "\nTips: To display error details in HTTP response ";
+                $error .= 'set "displayErrorDetails" to true in the ErrorHandler constructor.';
+            }
+            
             /** @var string $body */
             $response->getBody()->write($body);
         }


### PR DESCRIPTION
We must add the tip when sending a response to the client (i.e. browser) only.