### PR TITLE
Only render tip to error log if plain text renderer is used

### DIFF
--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -259,7 +259,7 @@ class ErrorHandler implements ErrorHandlerInterface
     {
         $renderer = $this->callableResolver->resolve($this->logErrorRenderer);
         $error = $renderer($this->exception, $this->logErrorDetails);
-        if (!$this->displayErrorDetails) {
+        if ($this->logErrorRenderer === PlainTextErrorRenderer::class && !$this->displayErrorDetails) {
             $error .= "\nTips: To display error details in HTTP response ";
             $error .= 'set "displayErrorDetails" to true in the ErrorHandler constructor.';
         }

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -353,6 +353,35 @@ class ErrorHandlerTest extends TestCase
         $handler->__invoke($request, $exception, false, true, true);
     }
 
+    public function testWriteToErrorLogDoesNotShowTipIfErrorLogRendererIsNotPlainText()
+    {
+        $request = $this
+            ->createServerRequest('/', 'GET')
+            ->withHeader('Accept', 'application/json');
+
+        $logger = $this->getMockLogger();
+
+        $handler = new ErrorHandler(
+            $this->getCallableResolver(),
+            $this->getResponseFactory(),
+            $logger
+        );
+
+        $handler->setLogErrorRenderer(HtmlErrorRenderer::class);
+
+        $logger->expects(self::once())
+            ->method('error')
+            ->willReturnCallback(static function (string $error) {
+                self::assertStringNotContainsString(
+                    'set "displayErrorDetails" to true in the ErrorHandler constructor',
+                    $error
+                );
+            });
+
+        $exception = new HttpNotFoundException($request);
+        $handler->__invoke($request, $exception, false, true, true);
+    }
+
     public function testDefaultErrorRenderer()
     {
         $request = $this


### PR DESCRIPTION
If the logErrorRenderer is not the plain text renderer then we must not render the tips message as this will break the structured format of the message that's been rendered.

Closes #3317