### PR TITLE
Add template generics for PSR-11 implementations in PHPStan and Psalm

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -32,6 +32,7 @@ use Slim\Routing\RouteRunner;
 use function strtoupper;
 
 /**
+ * @api
  * @template TContainerInterface of (ContainerInterface|null)
  * @template-extends RouteCollectorProxy<TContainerInterface>
  */

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -30,6 +30,7 @@ use Slim\Routing\RouteResolver;
 use Slim\Routing\RouteRunner;
 
 use function strtoupper;
+
 /**
  * @template TContainerInterface of (ContainerInterface|null)
  * @template-extends RouteCollectorProxy<TContainerInterface>

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -30,7 +30,10 @@ use Slim\Routing\RouteResolver;
 use Slim\Routing\RouteRunner;
 
 use function strtoupper;
-
+/**
+ * @psalm-template TContainerInterface of (ContainerInterface|null)
+ * @template-extends RouteCollectorProxy<TContainerInterface>
+ */
 class App extends RouteCollectorProxy implements RequestHandlerInterface
 {
     /**
@@ -44,6 +47,9 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
 
     protected MiddlewareDispatcherInterface $middlewareDispatcher;
 
+    /**
+     * @psalm-param TContainerInterface $container
+     */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
         ?ContainerInterface $container = null,

--- a/Slim/App.php
+++ b/Slim/App.php
@@ -31,7 +31,7 @@ use Slim\Routing\RouteRunner;
 
 use function strtoupper;
 /**
- * @psalm-template TContainerInterface of (ContainerInterface|null)
+ * @template TContainerInterface of (ContainerInterface|null)
  * @template-extends RouteCollectorProxy<TContainerInterface>
  */
 class App extends RouteCollectorProxy implements RequestHandlerInterface
@@ -48,7 +48,7 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
     protected MiddlewareDispatcherInterface $middlewareDispatcher;
 
     /**
-     * @psalm-param TContainerInterface $container
+     * @param TContainerInterface $container
      */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
@@ -95,6 +95,7 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
 
     /**
      * @param MiddlewareInterface|string|callable $middleware
+     * @return App<TContainerInterface>
      */
     public function add($middleware): self
     {
@@ -104,6 +105,7 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
 
     /**
      * @param MiddlewareInterface $middleware
+     * @return App<TContainerInterface>
      */
     public function addMiddleware(MiddlewareInterface $middleware): self
     {

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -120,8 +120,10 @@ final class CallableResolver implements AdvancedCallableResolverInterface
      */
     private function resolveSlimNotation(string $toResolve): array
     {
-        if(!CallableResolver::$callablePattern) {
-            throw new RuntimeException("CallableResolver::\$callablePattern was modified to an invalid value");
+        if (!CallableResolver::$callablePattern) {
+            throw new RuntimeException(
+                "CallableResolver::\$callablePattern was modified to an invalid value"
+            );
         }
         preg_match(CallableResolver::$callablePattern, $toResolve, $matches);
         [$class, $method] = $matches ? [$matches[1], $matches[2]] : [$toResolve, null];

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -120,11 +120,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
      */
     private function resolveSlimNotation(string $toResolve): array
     {
-        if (!CallableResolver::$callablePattern) {
-            throw new RuntimeException(
-                "CallableResolver::\$callablePattern was modified to an invalid value"
-            );
-        }
+        /** @psalm-suppress ArgumentTypeCoercion */
         preg_match(CallableResolver::$callablePattern, $toResolve, $matches);
         [$class, $method] = $matches ? [$matches[1], $matches[2]] : [$toResolve, null];
 

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -131,8 +131,6 @@ final class CallableResolver implements AdvancedCallableResolverInterface
         preg_match(CallableResolver::$callablePattern, $toResolve, $matches);
         [$class, $method] = $matches ? [$matches[1], $matches[2]] : [$toResolve, null];
 
-        /** @var string $class */
-        /** @var string|null $method */
         if ($this->container && $this->container->has($class)) {
             $instance = $this->container->get($class);
             if (!is_object($instance)) {

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -26,12 +26,19 @@ use function json_encode;
 use function preg_match;
 use function sprintf;
 
+/**
+ * @template TContainerInterface of (ContainerInterface|null)
+ */
 final class CallableResolver implements AdvancedCallableResolverInterface
 {
     public static string $callablePattern = '!^([^\:]+)\:([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)$!';
 
+    /** @var TContainerInterface $container */
     private ?ContainerInterface $container;
 
+    /**
+     * @param TContainerInterface $container
+     */
     public function __construct(?ContainerInterface $container = null)
     {
         $this->container = $container;

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -120,6 +120,9 @@ final class CallableResolver implements AdvancedCallableResolverInterface
      */
     private function resolveSlimNotation(string $toResolve): array
     {
+        if(!CallableResolver::$callablePattern) {
+            throw new RuntimeException("CallableResolver::\$callablePattern was modified to an invalid value");
+        }
         preg_match(CallableResolver::$callablePattern, $toResolve, $matches);
         [$class, $method] = $matches ? [$matches[1], $matches[2]] : [$toResolve, null];
 

--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -39,7 +39,6 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
     {
         $html = sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
 
-        /** @var int|string $code */
         $code = $exception->getCode();
         $html .= sprintf('<div><strong>Code:</strong> %s</div>', $code);
 

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -43,7 +43,6 @@ class JsonErrorRenderer extends AbstractErrorRenderer
      */
     private function formatExceptionFragment(Throwable $exception): array
     {
-        /** @var int|string $code */
         $code = $exception->getCode();
         return [
             'type' => get_class($exception),

--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -43,7 +43,7 @@ class PlainTextErrorRenderer extends AbstractErrorRenderer
         $text = sprintf("Type: %s\n", get_class($exception));
 
         $code = $exception->getCode();
-        /** @var int|string $code */
+
         $text .= sprintf("Code: %s\n", $code);
 
         $text .= sprintf("Message: %s\n", $exception->getMessage());

--- a/Slim/Exception/HttpBadRequestException.php
+++ b/Slim/Exception/HttpBadRequestException.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Exception;
 
+/** @api */
 class HttpBadRequestException extends HttpSpecializedException
 {
     /**

--- a/Slim/Exception/HttpException.php
+++ b/Slim/Exception/HttpException.php
@@ -15,6 +15,7 @@ use RuntimeException;
 use Throwable;
 
 /**
+ * @api
  * @method int getCode()
  */
 class HttpException extends RuntimeException

--- a/Slim/Exception/HttpForbiddenException.php
+++ b/Slim/Exception/HttpForbiddenException.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Exception;
 
+/** @api */
 class HttpForbiddenException extends HttpSpecializedException
 {
     /**

--- a/Slim/Exception/HttpGoneException.php
+++ b/Slim/Exception/HttpGoneException.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Exception;
 
+/** @api */
 class HttpGoneException extends HttpSpecializedException
 {
     /**

--- a/Slim/Exception/HttpInternalServerErrorException.php
+++ b/Slim/Exception/HttpInternalServerErrorException.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Exception;
 
+/** @api */
 class HttpInternalServerErrorException extends HttpSpecializedException
 {
     /**

--- a/Slim/Exception/HttpNotImplementedException.php
+++ b/Slim/Exception/HttpNotImplementedException.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Exception;
 
+/** @api */
 class HttpNotImplementedException extends HttpSpecializedException
 {
     /**

--- a/Slim/Exception/HttpTooManyRequestsException.php
+++ b/Slim/Exception/HttpTooManyRequestsException.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Exception;
 
+/** @api */
 class HttpTooManyRequestsException extends HttpSpecializedException
 {
     /**

--- a/Slim/Exception/HttpUnauthorizedException.php
+++ b/Slim/Exception/HttpUnauthorizedException.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Exception;
 
+/** @api */
 class HttpUnauthorizedException extends HttpSpecializedException
 {
     /**

--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -44,6 +44,11 @@ class AppFactory
 
     protected static bool $slimHttpDecoratorsAutomaticDetectionEnabled = true;
 
+    /**
+     * @template TContainerInterface of (ContainerInterface|null)
+     * @param TContainerInterface $container
+     * @return (App<TContainerInterface>|App<ContainerInterface|null>)
+     */
     public static function create(
         ?ResponseFactoryInterface $responseFactory = null,
         ?ContainerInterface $container = null,
@@ -63,6 +68,11 @@ class AppFactory
         );
     }
 
+    /**
+     * @template TContainerInterface of (ContainerInterface)
+     * @param TContainerInterface $container
+     * @return App<TContainerInterface>
+     */
     public static function createFromContainer(ContainerInterface $container): App
     {
         $responseFactory = $container->has(ResponseFactoryInterface::class)

--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -24,6 +24,7 @@ use Slim\Interfaces\Psr17FactoryProviderInterface;
 use Slim\Interfaces\RouteCollectorInterface;
 use Slim\Interfaces\RouteResolverInterface;
 
+/** @api */
 class AppFactory
 {
     protected static ?Psr17FactoryProviderInterface $psr17FactoryProvider = null;

--- a/Slim/Factory/AppFactory.php
+++ b/Slim/Factory/AppFactory.php
@@ -47,7 +47,7 @@ class AppFactory
     /**
      * @template TContainerInterface of (ContainerInterface|null)
      * @param TContainerInterface $container
-     * @return (App<TContainerInterface>|App<ContainerInterface|null>)
+     * @return (TContainerInterface is ContainerInterface ? App<TContainerInterface> : App<ContainerInterface|null>)
      */
     public static function create(
         ?ResponseFactoryInterface $responseFactory = null,

--- a/Slim/Factory/ServerRequestCreatorFactory.php
+++ b/Slim/Factory/ServerRequestCreatorFactory.php
@@ -17,6 +17,7 @@ use Slim\Factory\Psr17\SlimHttpServerRequestCreator;
 use Slim\Interfaces\Psr17FactoryProviderInterface;
 use Slim\Interfaces\ServerRequestCreatorInterface;
 
+/** @api */
 class ServerRequestCreatorFactory
 {
     protected static ?Psr17FactoryProviderInterface $psr17FactoryProvider = null;

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -43,6 +43,7 @@ use function preg_match;
  *
  * It outputs the error message and diagnostic information in one of the following formats:
  * JSON, XML, Plain Text or HTML based on the Accept header.
+ * @api
  */
 class ErrorHandler implements ErrorHandlerInterface
 {

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -18,6 +18,7 @@ use function array_values;
 
 /**
  * Route callback strategy with route parameters as individual arguments.
+ * @api
  */
 class RequestResponseArgs implements InvocationStrategyInterface
 {

--- a/Slim/Handlers/Strategies/RequestResponseNamedArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseNamedArgs.php
@@ -17,6 +17,7 @@ use RuntimeException;
 
 /**
  * Route callback strategy with route parameters as individual arguments.
+ * @api
  */
 class RequestResponseNamedArgs implements InvocationStrategyInterface
 {

--- a/Slim/Interfaces/MiddlewareDispatcherInterface.php
+++ b/Slim/Interfaces/MiddlewareDispatcherInterface.php
@@ -13,6 +13,7 @@ namespace Slim\Interfaces;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/** @api */
 interface MiddlewareDispatcherInterface extends RequestHandlerInterface
 {
     /**

--- a/Slim/Interfaces/Psr17FactoryProviderInterface.php
+++ b/Slim/Interfaces/Psr17FactoryProviderInterface.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Interfaces;
 
+/** @api */
 interface Psr17FactoryProviderInterface
 {
     /**

--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -13,6 +13,7 @@ namespace Slim\Interfaces;
 use InvalidArgumentException;
 use RuntimeException;
 
+/** @api */
 interface RouteCollectorInterface
 {
     /**

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -15,7 +15,7 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
- * @psalm-template TContainerInterface of (ContainerInterface|null)
+ * @template TContainerInterface of (ContainerInterface|null)
  */
 interface RouteCollectorProxyInterface
 {
@@ -24,7 +24,7 @@ interface RouteCollectorProxyInterface
     public function getCallableResolver(): CallableResolverInterface;
 
     /**
-     * @psalm-return TContainerInterface
+     * @return TContainerInterface
      */
     public function getContainer(): ?ContainerInterface;
 
@@ -37,6 +37,7 @@ interface RouteCollectorProxyInterface
 
     /**
      * Set the RouteCollectorProxy's base path
+     * @return RouteCollectorProxyInterface<TContainerInterface>
      */
     public function setBasePath(string $basePath): RouteCollectorProxyInterface;
 

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
 /**
+ * @api
  * @template TContainerInterface of (ContainerInterface|null)
  */
 interface RouteCollectorProxyInterface

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -14,12 +14,18 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\UriInterface;
 
+/**
+ * @psalm-template TContainerInterface of (ContainerInterface|null)
+ */
 interface RouteCollectorProxyInterface
 {
     public function getResponseFactory(): ResponseFactoryInterface;
 
     public function getCallableResolver(): CallableResolverInterface;
 
+    /**
+     * @psalm-return TContainerInterface
+     */
     public function getContainer(): ?ContainerInterface;
 
     public function getRouteCollector(): RouteCollectorInterface;

--- a/Slim/Interfaces/RouteGroupInterface.php
+++ b/Slim/Interfaces/RouteGroupInterface.php
@@ -13,6 +13,7 @@ namespace Slim\Interfaces;
 use Psr\Http\Server\MiddlewareInterface;
 use Slim\MiddlewareDispatcher;
 
+/** @api */
 interface RouteGroupInterface
 {
     public function collectRoutes(): RouteGroupInterface;

--- a/Slim/Interfaces/RouteGroupInterface.php
+++ b/Slim/Interfaces/RouteGroupInterface.php
@@ -31,6 +31,7 @@ interface RouteGroupInterface
 
     /**
      * Append the group's middleware to the MiddlewareDispatcher
+     * @param MiddlewareDispatcher<\Psr\Container\ContainerInterface|null> $dispatcher
      */
     public function appendMiddlewareToDispatcher(MiddlewareDispatcher $dispatcher): RouteGroupInterface;
 

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 
+/** @api */
 interface RouteInterface
 {
     /**

--- a/Slim/Interfaces/RouteParserInterface.php
+++ b/Slim/Interfaces/RouteParserInterface.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
 use RuntimeException;
 
+/** @api */
 interface RouteParserInterface
 {
     /**

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -33,6 +33,7 @@ use function trim;
 
 use const LIBXML_VERSION;
 
+/** @api */
 class BodyParsingMiddleware implements MiddlewareInterface
 {
     /**

--- a/Slim/Middleware/ContentLengthMiddleware.php
+++ b/Slim/Middleware/ContentLengthMiddleware.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/** @api */
 class ContentLengthMiddleware implements MiddlewareInterface
 {
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -25,6 +25,7 @@ use Throwable;
 use function get_class;
 use function is_subclass_of;
 
+/** @api */
 class ErrorMiddleware implements MiddlewareInterface
 {
     protected CallableResolverInterface $callableResolver;

--- a/Slim/Middleware/MethodOverrideMiddleware.php
+++ b/Slim/Middleware/MethodOverrideMiddleware.php
@@ -18,6 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 use function is_array;
 use function strtoupper;
 
+/** @api */
 class MethodOverrideMiddleware implements MiddlewareInterface
 {
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -23,6 +23,7 @@ use function ob_end_clean;
 use function ob_get_clean;
 use function ob_start;
 
+/** @api */
 class OutputBufferingMiddleware implements MiddlewareInterface
 {
     public const APPEND = 'append';

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -29,6 +29,7 @@ use function preg_match;
 use function sprintf;
 
 /**
+ * @api
  * @template TContainerInterface of (ContainerInterface|null)
  */
 class MiddlewareDispatcher implements MiddlewareDispatcherInterface

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -183,8 +183,10 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
                     $instance = null;
                     $method = null;
 
-                    if(!CallableResolver::$callablePattern) {
-                        throw new RuntimeException("CallableResolver::\$callablePattern was modified to an invalid value");
+                    if (!CallableResolver::$callablePattern) {
+                        throw new RuntimeException(
+                            "CallableResolver::\$callablePattern was modified to an invalid value"
+                        );
                     }
                     // Check for Slim callable as `class:method`
                     if (preg_match(CallableResolver::$callablePattern, $resolved, $matches)) {

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -183,6 +183,9 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
                     $instance = null;
                     $method = null;
 
+                    if(!CallableResolver::$callablePattern) {
+                        throw new RuntimeException("CallableResolver::\$callablePattern was modified to an invalid value");
+                    }
                     // Check for Slim callable as `class:method`
                     if (preg_match(CallableResolver::$callablePattern, $resolved, $matches)) {
                         $resolved = $matches[1];

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -183,11 +183,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
                     $instance = null;
                     $method = null;
 
-                    if (!CallableResolver::$callablePattern) {
-                        throw new RuntimeException(
-                            "CallableResolver::\$callablePattern was modified to an invalid value"
-                        );
-                    }
+                    /** @psalm-suppress ArgumentTypeCoercion */
                     // Check for Slim callable as `class:method`
                     if (preg_match(CallableResolver::$callablePattern, $resolved, $matches)) {
                         $resolved = $matches[1];

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -28,6 +28,9 @@ use function is_string;
 use function preg_match;
 use function sprintf;
 
+/**
+ * @template TContainerInterface of (ContainerInterface|null)
+ */
 class MiddlewareDispatcher implements MiddlewareDispatcherInterface
 {
     /**
@@ -37,8 +40,12 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
 
     protected ?CallableResolverInterface $callableResolver;
 
+    /** @var TContainerInterface $container */
     protected ?ContainerInterface $container;
 
+    /**
+     * @param TContainerInterface $container
+     */
     public function __construct(
         RequestHandlerInterface $kernel,
         ?CallableResolverInterface $callableResolver = null,
@@ -131,6 +138,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
      * Middleware are organized as a stack. That means middleware
      * that have been added before will be executed after the newly
      * added one (last in, first out).
+     * @return MiddlewareDispatcher<TContainerInterface>
      */
     public function addDeferred(string $middleware): self
     {
@@ -238,6 +246,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
      * Middleware are organized as a stack. That means middleware
      * that have been added before will be executed after the newly
      * added one (last in, first out).
+     * @return MiddlewareDispatcher<TContainerInterface>
      */
     public function addCallable(callable $middleware): self
     {

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -34,6 +34,7 @@ use function in_array;
 use function is_array;
 
 /**
+ * @api
  * @template TContainerInterface of (ContainerInterface|null)
  */
 class Route implements RouteInterface, RequestHandlerInterface
@@ -328,7 +329,6 @@ class Route implements RouteInterface, RequestHandlerInterface
         $inner = $this->middlewareDispatcher;
         $this->middlewareDispatcher = new MiddlewareDispatcher($inner, $this->callableResolver, $this->container);
 
-        /** @var RouteGroupInterface $group */
         foreach (array_reverse($this->groups) as $group) {
             $group->appendMiddlewareToDispatcher($this->middlewareDispatcher);
         }

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -33,6 +33,9 @@ use function class_implements;
 use function in_array;
 use function is_array;
 
+/**
+ * @template TContainerInterface of (ContainerInterface|null)
+ */
 class Route implements RouteInterface, RequestHandlerInterface
 {
     /**
@@ -77,9 +80,11 @@ class Route implements RouteInterface, RequestHandlerInterface
 
     /**
      * Container
+     * @var TContainerInterface $container
      */
     protected ?ContainerInterface $container = null;
 
+    /** @var MiddlewareDispatcher<TContainerInterface> $middlewareDispatcher */
     protected MiddlewareDispatcher $middlewareDispatcher;
 
     /**
@@ -106,7 +111,7 @@ class Route implements RouteInterface, RequestHandlerInterface
      * @param callable|string                  $callable   The route callable
      * @param ResponseFactoryInterface         $responseFactory
      * @param CallableResolverInterface        $callableResolver
-     * @param ContainerInterface|null          $container
+     * @param TContainerInterface              $container
      * @param InvocationStrategyInterface|null $invocationStrategy
      * @param RouteGroupInterface[]            $groups     The parent route groups
      * @param int                              $identifier The route identifier

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -32,6 +32,7 @@ use function is_writable;
 /**
  * RouteCollector is used to collect routes and route groups
  * as well as generate paths and URLs relative to its environment
+ * @template TContainerInterface of (ContainerInterface|null)
  */
 class RouteCollector implements RouteCollectorInterface
 {
@@ -81,6 +82,9 @@ class RouteCollector implements RouteCollectorInterface
 
     protected ResponseFactoryInterface $responseFactory;
 
+    /**
+     * @param TContainerInterface $container
+     */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
         CallableResolverInterface $callableResolver,
@@ -245,10 +249,11 @@ class RouteCollector implements RouteCollectorInterface
     }
 
     /**
-     * @return RouteCollectorProxyInterface<ContainerInterface|null>
+     * @return RouteCollectorProxyInterface<TContainerInterface>
      */
     protected function createProxy(string $pattern): RouteCollectorProxyInterface
     {
+        /** @var RouteCollectorProxyInterface<TContainerInterface> */
         return new RouteCollectorProxy(
             $this->responseFactory,
             $this->callableResolver,

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -244,6 +244,9 @@ class RouteCollector implements RouteCollectorInterface
         return new RouteGroup($pattern, $callable, $this->callableResolver, $routeCollectorProxy);
     }
 
+    /**
+     * @return RouteCollectorProxyInterface<ContainerInterface|null>
+     */
     protected function createProxy(string $pattern): RouteCollectorProxyInterface
     {
         return new RouteCollectorProxy(

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -181,6 +181,7 @@ class RouteCollector implements RouteCollectorInterface
     {
         $route = $this->getNamedRoute($name);
 
+        /** @psalm-suppress PossiblyNullArrayOffset */
         unset($this->routesByName[$route->getName()], $this->routes[$route->getIdentifier()]);
         return $this;
     }

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -18,18 +18,26 @@ use Slim\Interfaces\RouteCollectorProxyInterface;
 use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;
 
+/**
+ * @psalm-template TContainerInterface of (ContainerInterface|null)
+ * @template-implements RouteCollectorProxyInterface<TContainerInterface>
+ */
 class RouteCollectorProxy implements RouteCollectorProxyInterface
 {
     protected ResponseFactoryInterface $responseFactory;
 
     protected CallableResolverInterface $callableResolver;
 
+    /** @psalm-var TContainerInterface */
     protected ?ContainerInterface $container = null;
 
     protected RouteCollectorInterface $routeCollector;
 
     protected string $groupPattern;
 
+    /**
+     * @psalm-param TContainerInterface $container
+     */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
         CallableResolverInterface $callableResolver,
@@ -62,6 +70,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
 
     /**
      * {@inheritdoc}
+     * @psalm-return TContainerInterface
      */
     public function getContainer(): ?ContainerInterface
     {

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -19,7 +19,7 @@ use Slim\Interfaces\RouteGroupInterface;
 use Slim\Interfaces\RouteInterface;
 
 /**
- * @psalm-template TContainerInterface of (ContainerInterface|null)
+ * @template TContainerInterface of (ContainerInterface|null)
  * @template-implements RouteCollectorProxyInterface<TContainerInterface>
  */
 class RouteCollectorProxy implements RouteCollectorProxyInterface
@@ -28,7 +28,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
 
     protected CallableResolverInterface $callableResolver;
 
-    /** @psalm-var TContainerInterface */
+    /** @var TContainerInterface */
     protected ?ContainerInterface $container = null;
 
     protected RouteCollectorInterface $routeCollector;
@@ -36,7 +36,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     protected string $groupPattern;
 
     /**
-     * @psalm-param TContainerInterface $container
+     * @param TContainerInterface $container
      */
     public function __construct(
         ResponseFactoryInterface $responseFactory,
@@ -70,7 +70,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
 
     /**
      * {@inheritdoc}
-     * @psalm-return TContainerInterface
+     * @return TContainerInterface
      */
     public function getContainer(): ?ContainerInterface
     {

--- a/Slim/Routing/RouteContext.php
+++ b/Slim/Routing/RouteContext.php
@@ -15,6 +15,7 @@ use RuntimeException;
 use Slim\Interfaces\RouteInterface;
 use Slim\Interfaces\RouteParserInterface;
 
+/** @api */
 final class RouteContext
 {
     public const ROUTE = '__route__';

--- a/Slim/Routing/RouteGroup.php
+++ b/Slim/Routing/RouteGroup.php
@@ -26,6 +26,9 @@ class RouteGroup implements RouteGroupInterface
 
     protected CallableResolverInterface $callableResolver;
 
+    /**
+     * @var RouteCollectorProxyInterface<\Psr\Container\ContainerInterface|null>
+     */
     protected RouteCollectorProxyInterface $routeCollectorProxy;
 
     /**
@@ -37,6 +40,7 @@ class RouteGroup implements RouteGroupInterface
 
     /**
      * @param callable|string              $callable
+     * @param RouteCollectorProxyInterface<\Psr\Container\ContainerInterface|null> $routeCollectorProxy
      */
     public function __construct(
         string $pattern,

--- a/Slim/Routing/RouteGroup.php
+++ b/Slim/Routing/RouteGroup.php
@@ -88,6 +88,7 @@ class RouteGroup implements RouteGroupInterface
 
     /**
      * {@inheritdoc}
+     * @param MiddlewareDispatcher<\Psr\Container\ContainerInterface|null> $dispatcher
      */
     public function appendMiddlewareToDispatcher(MiddlewareDispatcher $dispatcher): RouteGroupInterface
     {

--- a/Slim/Routing/RouteRunner.php
+++ b/Slim/Routing/RouteRunner.php
@@ -69,7 +69,7 @@ class RouteRunner implements RequestHandlerInterface
             );
         }
 
-        /** @var Route $route */
+        /** @var Route<\Psr\Container\ContainerInterface|null> $route */
         $route = $request->getAttribute(RouteContext::ROUTE);
         return $route->run($request);
     }

--- a/Slim/Routing/RouteRunner.php
+++ b/Slim/Routing/RouteRunner.php
@@ -26,8 +26,14 @@ class RouteRunner implements RequestHandlerInterface
 
     private RouteParserInterface $routeParser;
 
+    /**
+     * @var RouteCollectorProxyInterface<\Psr\Container\ContainerInterface|null>
+     */
     private ?RouteCollectorProxyInterface $routeCollectorProxy;
 
+    /**
+     * @param RouteCollectorProxyInterface<\Psr\Container\ContainerInterface|null> $routeCollectorProxy
+     */
     public function __construct(
         RouteResolverInterface $routeResolver,
         RouteParserInterface $routeParser,

--- a/Slim/Routing/RoutingResults.php
+++ b/Slim/Routing/RoutingResults.php
@@ -14,6 +14,7 @@ use Slim\Interfaces\DispatcherInterface;
 
 use function rawurldecode;
 
+/** @api */
 class RoutingResults
 {
     public const NOT_FOUND = 0;

--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,7 @@
         "phpunit": "phpunit",
         "phpcs": "phpcs",
         "phpstan": "phpstan --memory-limit=-1",
-        "psalm": "psalm"
+        "psalm": "psalm --no-cache"
     },
     "suggest": {
         "ext-simplexml": "Needed to support XML format in BodyParsingMiddleware",

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,8 @@
         "phpunit/phpunit": "^9.6",
         "slim/http": "^1.3",
         "slim/psr7": "^1.6",
-        "squizlabs/php_codesniffer": "^3.9"
+        "squizlabs/php_codesniffer": "^3.9",
+        "vimeo/psalm": "^5.24"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -85,11 +85,13 @@
         "test": [
             "@phpunit",
             "@phpcs",
-            "@phpstan"
+            "@phpstan",
+            "@psalm"
         ],
         "phpunit": "phpunit",
         "phpcs": "phpcs",
-        "phpstan": "phpstan --memory-limit=-1"
+        "phpstan": "phpstan --memory-limit=-1",
+        "psalm": "psalm"
     },
     "suggest": {
         "ext-simplexml": "Needed to support XML format in BodyParsingMiddleware",

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,7 +6,7 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     findUnusedBaselineEntry="true"
-    findUnusedCode="false"
+    findUnusedCode="true"
 >
     <projectFiles>
         <directory name="Slim" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="3"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
+>
+    <projectFiles>
+        <directory name="Slim" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>


### PR DESCRIPTION
Slim v4 abstracts out DI to PSR-11, which means given a Slim/App it is unclear what its DI container is capable of.
Psalm and PHPStan both provide mechanisms to express the types generically, allowing them to ensure that you are calling the correct [set method](https://php-di.org/doc/container.html#set) on a DI container received from [getContainer](https://github.com/slimphp/Slim/blob/4.x/Slim/Interfaces/RouteCollectorProxyInterface.php#L23C21-L23C33)