### PR TITLE
Fix tests for PHP 8.3

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1684,7 +1684,7 @@ class AppTest extends TestCase
         });
         $streamProphecy->eof()->willReturn(false);
         $streamProphecy->isSeekable()->willReturn(true);
-        $streamProphecy->rewind();
+        $streamProphecy->rewind()->shouldBeCalled();
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
         $responseProphecy->getBody()->willReturn($streamProphecy->reveal());
@@ -1731,13 +1731,13 @@ class AppTest extends TestCase
             return 0;
         });
         $streamProphecy->read(1)->willReturn('_');
-        $streamProphecy->read('11')->will(function () {
+        $streamProphecy->read(11)->will(function () {
             $this->eof()->willReturn(true);
             return $this->reveal()->__toString();
         });
         $streamProphecy->eof()->willReturn(false);
         $streamProphecy->isSeekable()->willReturn(true);
-        $streamProphecy->rewind();
+        $streamProphecy->rewind()->shouldBeCalled();;
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
         $responseProphecy->getBody()->willReturn($streamProphecy->reveal());

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1143,6 +1143,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1183,6 +1184,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1223,6 +1225,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1263,6 +1266,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1308,6 +1312,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1352,6 +1357,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1494,6 +1500,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1538,6 +1545,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1584,6 +1592,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1624,6 +1633,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1665,6 +1675,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
         $streamProphecy->read(1)->willReturn('_');
         $streamProphecy->read('11')->will(function () {
@@ -1673,7 +1684,7 @@ class AppTest extends TestCase
         });
         $streamProphecy->eof()->willReturn(false);
         $streamProphecy->isSeekable()->willReturn(true);
-        $streamProphecy->rewind()->willReturn(true);
+        $streamProphecy->rewind();
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
         $responseProphecy->getBody()->willReturn($streamProphecy->reveal());
@@ -1717,6 +1728,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
         $streamProphecy->read(1)->willReturn('_');
         $streamProphecy->read('11')->will(function () {
@@ -1725,7 +1737,7 @@ class AppTest extends TestCase
         });
         $streamProphecy->eof()->willReturn(false);
         $streamProphecy->isSeekable()->willReturn(true);
-        $streamProphecy->rewind()->willReturn(true);
+        $streamProphecy->rewind();
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
         $responseProphecy->getBody()->willReturn($streamProphecy->reveal());
@@ -1757,6 +1769,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -1813,6 +1826,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseHeaders = [];
@@ -1978,6 +1992,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -2032,6 +2047,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
@@ -2086,6 +2102,7 @@ class AppTest extends TestCase
             $body = $this->reveal()->__toString();
             $body .= $args[0];
             $this->__toString()->willReturn($body);
+            return 0;
         });
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -1737,7 +1737,7 @@ class AppTest extends TestCase
         });
         $streamProphecy->eof()->willReturn(false);
         $streamProphecy->isSeekable()->willReturn(true);
-        $streamProphecy->rewind()->shouldBeCalled();;
+        $streamProphecy->rewind()->shouldBeCalled();
 
         $responseProphecy = $this->prophesize(ResponseInterface::class);
         $responseProphecy->getBody()->willReturn($streamProphecy->reveal());

--- a/tests/Mocks/SlowPokeStream.php
+++ b/tests/Mocks/SlowPokeStream.php
@@ -34,7 +34,7 @@ class SlowPokeStream implements StreamInterface
         $this->amountToRead = self::SIZE;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $content = '';
         while (!$this->eof()) {
@@ -43,7 +43,7 @@ class SlowPokeStream implements StreamInterface
         return $content;
     }
 
-    public function close()
+    public function close(): void
     {
     }
 
@@ -52,12 +52,12 @@ class SlowPokeStream implements StreamInterface
         throw new Exception('not implemented');
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return $this->amountToRead === 0;
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         throw new Exception('not implemented');
     }
@@ -67,27 +67,27 @@ class SlowPokeStream implements StreamInterface
         throw new Exception('not implemented');
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return null;
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         usleep(1);
         $size = min($this->amountToRead, self::CHUNK_SIZE, $length);
@@ -95,23 +95,23 @@ class SlowPokeStream implements StreamInterface
         return str_repeat('.', $size);
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         throw new Exception('not implemented');
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         throw new Exception('not implemented');
     }
 
-    public function tell()
+    public function tell(): int
     {
         throw new Exception('not implemented');
     }
 
-    public function write($string)
+    public function write($string): int
     {
-        return $string;
+        return strlen($string);
     }
 }

--- a/tests/Mocks/SmallChunksStream.php
+++ b/tests/Mocks/SmallChunksStream.php
@@ -33,12 +33,12 @@ class SmallChunksStream implements StreamInterface
         $this->amountToRead = self::SIZE;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return str_repeat('.', self::SIZE);
     }
 
-    public function close()
+    public function close(): void
     {
     }
 
@@ -47,12 +47,12 @@ class SmallChunksStream implements StreamInterface
         throw new Exception('not implemented');
     }
 
-    public function eof()
+    public function eof(): bool
     {
         return $this->amountToRead === 0;
     }
 
-    public function getContents()
+    public function getContents(): string
     {
         throw new Exception('not implemented');
     }
@@ -62,27 +62,27 @@ class SmallChunksStream implements StreamInterface
         throw new Exception('not implemented');
     }
 
-    public function getSize()
+    public function getSize(): ?int
     {
         return self::SIZE;
     }
 
-    public function isReadable()
+    public function isReadable(): bool
     {
         return true;
     }
 
-    public function isSeekable()
+    public function isSeekable(): bool
     {
         return false;
     }
 
-    public function isWritable()
+    public function isWritable(): bool
     {
         return false;
     }
 
-    public function read($length)
+    public function read($length): string
     {
         $size = min($this->amountToRead, self::CHUNK_SIZE, $length);
         $this->amountToRead -= $size;
@@ -90,23 +90,23 @@ class SmallChunksStream implements StreamInterface
         return str_repeat('.', min($length, $size));
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         throw new Exception('not implemented');
     }
 
-    public function seek($offset, $whence = SEEK_SET)
+    public function seek($offset, $whence = SEEK_SET): void
     {
         throw new Exception('not implemented');
     }
 
-    public function tell()
+    public function tell(): int
     {
         throw new Exception('not implemented');
     }
 
-    public function write($string)
+    public function write($string): int
     {
-        return $string;
+        return strlen($string);
     }
 }

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -72,7 +72,7 @@ class RouteTest extends TestCase
             ->will(function ($args) use ($value) {
                 $value .= $args[0];
                 $this->__toString()->willReturn($value);
-                return 0;
+                return strlen($value);
             });
 
         $streamProphecy
@@ -821,7 +821,7 @@ class RouteTest extends TestCase
             ->will(function ($args) use ($value) {
                 $value .= $args[0];
                 $this->__toString()->willReturn($value);
-                return 0;
+                return strlen($value);
             });
 
         $streamProphecy

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -72,7 +72,7 @@ class RouteTest extends TestCase
             ->will(function ($args) use ($value) {
                 $value .= $args[0];
                 $this->__toString()->willReturn($value);
-                return $this->reveal();
+                return 0;
             });
 
         $streamProphecy
@@ -821,7 +821,7 @@ class RouteTest extends TestCase
             ->will(function ($args) use ($value) {
                 $value .= $args[0];
                 $this->__toString()->willReturn($value);
-                return $this->reveal();
+                return 0;
             });
 
         $streamProphecy


### PR DESCRIPTION
This PR should fix multiple compatibility issues with PHP 8.3 for test code only.

Example error message:

```
PHP Fatal error:  Declaration of Slim\Tests\Mocks\SmallChunksStream::close() 
must be compatible with Psr\Http\Message\StreamInterface::close(): void in 
/home/runner/work/Slim/Slim/tests/Mocks/SmallChunksStream.php on line 41
```

See here: https://github.com/slimphp/Slim/actions/runs/9737805348/job/26870413208

![image](https://github.com/slimphp/Slim/assets/781074/9c35fda8-5951-4c93-bbed-b666aaabb9dc)
