### PR TITLE
Adding more debug information

### DIFF
--- a/Slim/Exception/HttpMethodNotAllowedException.php
+++ b/Slim/Exception/HttpMethodNotAllowedException.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 
 namespace Slim\Exception;
 
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
 use function implode;
 
 class HttpMethodNotAllowedException extends HttpSpecializedException
@@ -33,6 +36,18 @@ class HttpMethodNotAllowedException extends HttpSpecializedException
     protected string $description = 'The request method is not supported for the requested resource.';
 
     /**
+     * @inheritdoc
+     */
+    public function __construct(ServerRequestInterface $request, ?string $message = null, ?Throwable $previous = null)
+    {
+        if ($message === null) {
+            $actualMethod = $request->getMethod();
+            $message = 'Method "' . $actualMethod . '" not allowed.';
+        }
+        parent::__construct($request, $message, $previous);
+    }
+
+    /**
      * @return string[]
      */
     public function getAllowedMethods(): array
@@ -46,7 +61,8 @@ class HttpMethodNotAllowedException extends HttpSpecializedException
     public function setAllowedMethods(array $methods): self
     {
         $this->allowedMethods = $methods;
-        $this->message = 'Method not allowed. Must be one of: ' . implode(', ', $methods);
+        $actualMethod = $this->request->getMethod();
+        $this->message = 'Method "' . $actualMethod . '" not allowed. Must be one of: ' . implode(', ', $methods);
         return $this;
     }
 }

--- a/tests/Exception/HttpExceptionTest.php
+++ b/tests/Exception/HttpExceptionTest.php
@@ -39,15 +39,15 @@ class HttpExceptionTest extends TestCase
 
     public function testHttpNotAllowedExceptionGetAllowedMethods()
     {
-        $request = $this->createServerRequest('/');
+        $request = $this->createServerRequest('/', 'POST');
 
         $exception = new HttpMethodNotAllowedException($request);
         $exception->setAllowedMethods(['GET']);
         $this->assertSame(['GET'], $exception->getAllowedMethods());
-        $this->assertSame('Method not allowed. Must be one of: GET', $exception->getMessage());
+        $this->assertSame('Method "POST" not allowed. Must be one of: GET', $exception->getMessage());
 
         $exception = new HttpMethodNotAllowedException($request);
         $this->assertSame([], $exception->getAllowedMethods());
-        $this->assertSame('Method not allowed.', $exception->getMessage());
+        $this->assertSame('Method "POST" not allowed.', $exception->getMessage());
     }
 }


### PR DESCRIPTION
## What I did

I added some more debug info to the "Bad method" exception.

I also updated the tests because the tests would return the error message `Method "GET" not allowed. Allowed methods: GET"`.

## Why
When triggering an endpoint with a wrong method it correctly throws this error and shows me what methods are actually available but not what method was used to cause the exception.