### PR TITLE
Update tests.yml add PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0, 8.1, 8.2, 8.3]
+        php: [7.4, 8.0, 8.1, 8.2, 8.3, 8.4]
         experimental: [false]
         include:
           - php: 8.2


### PR DESCRIPTION
~Actually show deprecated warnings with PHP 8.4~
Working OK with php-di v7

Released 21 Nov 2024.
https://www.php.net/releases/8.4/en.php
