### PR TITLE
Improve types on routes

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -79,7 +79,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     }
 
     /**
-     * @param string|callable $toResolve
+     * @param callable|array<class-string, string>|string $toResolve
      *
      * @throws RuntimeException
      */
@@ -180,8 +180,8 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     }
 
     /**
-     * @param string|callable $toResolve
-     * @return string|callable
+     * @param callable|array<class-string, string>|string $toResolve
+     * @return callable|array<class-string, string>|string
      */
     private function prepareToResolve($toResolve)
     {

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -180,7 +180,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     }
 
     /**
-     * @param callable|array<class-string, string>|string $toResolve
+     * @param  callable|array<class-string, string>|string $toResolve
      * @return callable|array<class-string, string>|string
      */
     private function prepareToResolve($toResolve)

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -79,7 +79,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     }
 
     /**
-     * @param callable|array<class-string, string>|string $toResolve
+     * @param callable|array{class-string, string}|string $toResolve
      *
      * @throws RuntimeException
      */
@@ -180,8 +180,8 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     }
 
     /**
-     * @param  callable|array<class-string, string>|string $toResolve
-     * @return callable|array<class-string, string>|string
+     * @param  callable|array{string, string}|string $toResolve
+     * @return callable|array<string>|string
      */
     private function prepareToResolve($toResolve)
     {

--- a/Slim/Interfaces/AdvancedCallableResolverInterface.php
+++ b/Slim/Interfaces/AdvancedCallableResolverInterface.php
@@ -15,14 +15,14 @@ interface AdvancedCallableResolverInterface extends CallableResolverInterface
     /**
      * Resolve $toResolve into a callable
      *
-     * @param callable|array<class-string, string>|string $toResolve
+     * @param callable|array{class-string, string}|string $toResolve
      */
     public function resolveRoute($toResolve): callable;
 
     /**
      * Resolve $toResolve into a callable
      *
-     * @param callable|array<class-string, string>|string $toResolve
+     * @param callable|array{class-string, string}|string $toResolve
      */
     public function resolveMiddleware($toResolve): callable;
 }

--- a/Slim/Interfaces/AdvancedCallableResolverInterface.php
+++ b/Slim/Interfaces/AdvancedCallableResolverInterface.php
@@ -15,14 +15,14 @@ interface AdvancedCallableResolverInterface extends CallableResolverInterface
     /**
      * Resolve $toResolve into a callable
      *
-     * @param string|callable $toResolve
+     * @param callable|array<class-string, string>|string $toResolve
      */
     public function resolveRoute($toResolve): callable;
 
     /**
      * Resolve $toResolve into a callable
      *
-     * @param string|callable $toResolve
+     * @param callable|array<class-string, string>|string $toResolve
      */
     public function resolveMiddleware($toResolve): callable;
 }

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -15,7 +15,7 @@ interface CallableResolverInterface
     /**
      * Resolve $toResolve into a callable
      *
-     * @param string|callable $toResolve
+     * @param callable|array<class-string, string>|string $toResolve
      */
     public function resolve($toResolve): callable;
 }

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -15,7 +15,7 @@ interface CallableResolverInterface
     /**
      * Resolve $toResolve into a callable
      *
-     * @param callable|array<class-string, string>|string $toResolve
+     * @param callable|array{class-string, string}|string $toResolve
      */
     public function resolve($toResolve): callable;
 }

--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -95,8 +95,8 @@ interface RouteCollectorInterface
     /**
      * Add route
      *
-     * @param string[]        $methods Array of HTTP methods
-     * @param string          $pattern The route pattern
+     * @param string[]                                    $methods Array of HTTP methods
+     * @param string                                      $pattern The route pattern
      * @param callable|array<class-string, string>|string $handler The route callable
      */
     public function map(array $methods, string $pattern, $handler): RouteInterface;

--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -97,7 +97,7 @@ interface RouteCollectorInterface
      *
      * @param string[]        $methods Array of HTTP methods
      * @param string          $pattern The route pattern
-     * @param callable|string $handler The route callable
+     * @param callable|array<class-string, string>|string $handler The route callable
      */
     public function map(array $methods, string $pattern, $handler): RouteInterface;
 }

--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -97,7 +97,7 @@ interface RouteCollectorInterface
      *
      * @param string[]                                    $methods Array of HTTP methods
      * @param string                                      $pattern The route pattern
-     * @param callable|array<class-string, string>|string $handler The route callable
+     * @param callable|array{class-string, string}|string $handler The route callable
      */
     public function map(array $methods, string $pattern, $handler): RouteInterface;
 }

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -46,7 +46,7 @@ interface RouteCollectorProxyInterface
      * Add GET route
      *
      * @param string                                      $pattern  The route URI pattern
-     * @param callable|array<class-string, string>|string $callable The route callback routine
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function get(string $pattern, $callable): RouteInterface;
 
@@ -54,7 +54,7 @@ interface RouteCollectorProxyInterface
      * Add POST route
      *
      * @param string                                      $pattern  The route URI pattern
-     * @param callable|array<class-string, string>|string $callable The route callback routine
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function post(string $pattern, $callable): RouteInterface;
 
@@ -62,7 +62,7 @@ interface RouteCollectorProxyInterface
      * Add PUT route
      *
      * @param string                                      $pattern  The route URI pattern
-     * @param callable|array<class-string, string>|string $callable The route callback routine
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function put(string $pattern, $callable): RouteInterface;
 
@@ -70,7 +70,7 @@ interface RouteCollectorProxyInterface
      * Add PATCH route
      *
      * @param string                                      $pattern  The route URI pattern
-     * @param callable|array<class-string, string>|string $callable The route callback routine
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function patch(string $pattern, $callable): RouteInterface;
 
@@ -78,7 +78,7 @@ interface RouteCollectorProxyInterface
      * Add DELETE route
      *
      * @param string                                      $pattern  The route URI pattern
-     * @param callable|array<class-string, string>|string $callable The route callback routine
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function delete(string $pattern, $callable): RouteInterface;
 
@@ -86,7 +86,7 @@ interface RouteCollectorProxyInterface
      * Add OPTIONS route
      *
      * @param string                                      $pattern  The route URI pattern
-     * @param callable|array<class-string, string>|string $callable The route callback routine
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function options(string $pattern, $callable): RouteInterface;
 
@@ -94,7 +94,7 @@ interface RouteCollectorProxyInterface
      * Add route for any HTTP method
      *
      * @param string                                      $pattern  The route URI pattern
-     * @param callable|array<class-string, string>|string $callable The route callback routine
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function any(string $pattern, $callable): RouteInterface;
 
@@ -103,7 +103,7 @@ interface RouteCollectorProxyInterface
      *
      * @param string[]                                    $methods  Numeric array of HTTP method names
      * @param string                                      $pattern  The route URI pattern
-     * @param callable|array<class-string, string>|string $callable The route callback routine
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function map(array $methods, string $pattern, $callable): RouteInterface;
 

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -46,7 +46,7 @@ interface RouteCollectorProxyInterface
      * Add GET route
      *
      * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param  callable|array<class-string, string>|string $callable The route callback routine
      */
     public function get(string $pattern, $callable): RouteInterface;
 
@@ -54,7 +54,7 @@ interface RouteCollectorProxyInterface
      * Add POST route
      *
      * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param  callable|array<class-string, string>|string $callable The route callback routine
      */
     public function post(string $pattern, $callable): RouteInterface;
 
@@ -62,7 +62,7 @@ interface RouteCollectorProxyInterface
      * Add PUT route
      *
      * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param  callable|array<class-string, string>|string $callable The route callback routine
      */
     public function put(string $pattern, $callable): RouteInterface;
 
@@ -70,7 +70,7 @@ interface RouteCollectorProxyInterface
      * Add PATCH route
      *
      * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param  callable|array<class-string, string>|string $callable The route callback routine
      */
     public function patch(string $pattern, $callable): RouteInterface;
 
@@ -78,7 +78,7 @@ interface RouteCollectorProxyInterface
      * Add DELETE route
      *
      * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param  callable|array<class-string, string>|string $callable The route callback routine
      */
     public function delete(string $pattern, $callable): RouteInterface;
 
@@ -86,7 +86,7 @@ interface RouteCollectorProxyInterface
      * Add OPTIONS route
      *
      * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param  callable|array<class-string, string>|string $callable The route callback routine
      */
     public function options(string $pattern, $callable): RouteInterface;
 
@@ -94,7 +94,7 @@ interface RouteCollectorProxyInterface
      * Add route for any HTTP method
      *
      * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param  callable|array<class-string, string>|string $callable The route callback routine
      */
     public function any(string $pattern, $callable): RouteInterface;
 
@@ -103,7 +103,7 @@ interface RouteCollectorProxyInterface
      *
      * @param  string[]        $methods  Numeric array of HTTP method names
      * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param  callable|array<class-string, string>|string $callable The route callback routine
      */
     public function map(array $methods, string $pattern, $callable): RouteInterface;
 

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -45,65 +45,65 @@ interface RouteCollectorProxyInterface
     /**
      * Add GET route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|array<class-string, string>|string $callable The route callback routine
+     * @param string                                      $pattern  The route URI pattern
+     * @param callable|array<class-string, string>|string $callable The route callback routine
      */
     public function get(string $pattern, $callable): RouteInterface;
 
     /**
      * Add POST route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|array<class-string, string>|string $callable The route callback routine
+     * @param string                                      $pattern  The route URI pattern
+     * @param callable|array<class-string, string>|string $callable The route callback routine
      */
     public function post(string $pattern, $callable): RouteInterface;
 
     /**
      * Add PUT route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|array<class-string, string>|string $callable The route callback routine
+     * @param string                                      $pattern  The route URI pattern
+     * @param callable|array<class-string, string>|string $callable The route callback routine
      */
     public function put(string $pattern, $callable): RouteInterface;
 
     /**
      * Add PATCH route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|array<class-string, string>|string $callable The route callback routine
+     * @param string                                      $pattern  The route URI pattern
+     * @param callable|array<class-string, string>|string $callable The route callback routine
      */
     public function patch(string $pattern, $callable): RouteInterface;
 
     /**
      * Add DELETE route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|array<class-string, string>|string $callable The route callback routine
+     * @param string                                      $pattern  The route URI pattern
+     * @param callable|array<class-string, string>|string $callable The route callback routine
      */
     public function delete(string $pattern, $callable): RouteInterface;
 
     /**
      * Add OPTIONS route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|array<class-string, string>|string $callable The route callback routine
+     * @param string                                      $pattern  The route URI pattern
+     * @param callable|array<class-string, string>|string $callable The route callback routine
      */
     public function options(string $pattern, $callable): RouteInterface;
 
     /**
      * Add route for any HTTP method
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|array<class-string, string>|string $callable The route callback routine
+     * @param string                                      $pattern  The route URI pattern
+     * @param callable|array<class-string, string>|string $callable The route callback routine
      */
     public function any(string $pattern, $callable): RouteInterface;
 
     /**
      * Add route with multiple methods
      *
-     * @param  string[]        $methods  Numeric array of HTTP method names
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|array<class-string, string>|string $callable The route callback routine
+     * @param string[]                                    $methods  Numeric array of HTTP method names
+     * @param string                                      $pattern  The route URI pattern
+     * @param callable|array<class-string, string>|string $callable The route callback routine
      */
     public function map(array $methods, string $pattern, $callable): RouteInterface;
 

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -47,14 +47,14 @@ interface RouteInterface
     /**
      * Get route callable
      *
-     * @return callable|array<class-string, string>|string
+     * @return callable|array{class-string, string}|string
      */
     public function getCallable();
 
     /**
      * Set route callable
      *
-     * @param callable|array<class-string, string>|string $callable
+     * @param callable|array{class-string, string}|string $callable
      */
     public function setCallable($callable): RouteInterface;
 

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -47,14 +47,14 @@ interface RouteInterface
     /**
      * Get route callable
      *
-     * @return callable|string
+     * @return callable|array<class-string, string>|string
      */
     public function getCallable();
 
     /**
      * Set route callable
      *
-     * @param callable|string $callable
+     * @param callable|array<class-string, string>|string $callable
      */
     public function setCallable($callable): RouteInterface;
 

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -91,7 +91,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * Route callable
      *
-     * @var callable|array<class-string, string>|string
+     * @var callable|array{class-string, string}|string
      */
     protected $callable;
 
@@ -109,7 +109,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * @param string[]                                    $methods    The route HTTP methods
      * @param string                                      $pattern    The route pattern
-     * @param callable|array<class-string, string>|string $callable   The route callable
+     * @param callable|array{class-string, string}|string $callable   The route callable
      * @param ResponseFactoryInterface                    $responseFactory
      * @param CallableResolverInterface                   $callableResolver
      * @param TContainerInterface                         $container

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -107,15 +107,15 @@ class Route implements RouteInterface, RequestHandlerInterface
     protected bool $groupMiddlewareAppended = false;
 
     /**
-     * @param string[]                         $methods    The route HTTP methods
-     * @param string                           $pattern    The route pattern
-     * @param callable|array<class-string, string>|string                  $callable   The route callable
-     * @param ResponseFactoryInterface         $responseFactory
-     * @param CallableResolverInterface        $callableResolver
-     * @param TContainerInterface              $container
-     * @param InvocationStrategyInterface|null $invocationStrategy
-     * @param RouteGroupInterface[]            $groups     The parent route groups
-     * @param int                              $identifier The route identifier
+     * @param string[]                                    $methods    The route HTTP methods
+     * @param string                                      $pattern    The route pattern
+     * @param callable|array<class-string, string>|string $callable   The route callable
+     * @param ResponseFactoryInterface                    $responseFactory
+     * @param CallableResolverInterface                   $callableResolver
+     * @param TContainerInterface                         $container
+     * @param InvocationStrategyInterface|null            $invocationStrategy
+     * @param RouteGroupInterface[]                       $groups     The parent route groups
+     * @param int                                         $identifier The route identifier
      */
     public function __construct(
         array $methods,

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -91,7 +91,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * Route callable
      *
-     * @var callable|string
+     * @var callable|array<class-string, string>|string
      */
     protected $callable;
 
@@ -109,7 +109,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * @param string[]                         $methods    The route HTTP methods
      * @param string                           $pattern    The route pattern
-     * @param callable|string                  $callable   The route callable
+     * @param callable|array<class-string, string>|string                  $callable   The route callable
      * @param ResponseFactoryInterface         $responseFactory
      * @param CallableResolverInterface        $callableResolver
      * @param TContainerInterface              $container

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -282,7 +282,7 @@ class RouteCollector implements RouteCollectorInterface
     }
 
     /**
-     * @param string[]        $methods
+     * @param string[]                                    $methods
      * @param callable|array<class-string, string>|string $callable
      */
     protected function createRoute(array $methods, string $pattern, $callable): RouteInterface

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -283,7 +283,7 @@ class RouteCollector implements RouteCollectorInterface
 
     /**
      * @param string[]        $methods
-     * @param callable|string $callable
+     * @param callable|array<class-string, string>|string $callable
      */
     protected function createRoute(array $methods, string $pattern, $callable): RouteInterface
     {

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -283,7 +283,7 @@ class RouteCollector implements RouteCollectorInterface
 
     /**
      * @param string[]                                    $methods
-     * @param callable|array<class-string, string>|string $callable
+     * @param callable|array{class-string, string}|string $callable
      */
     protected function createRoute(array $methods, string $pattern, $callable): RouteInterface
     {


### PR DESCRIPTION
My routes are defined as follows: `->get('/', [HomeController::class, 'index']);`, which is a [valid](https://www.slimframework.com/docs/v4/objects/routing.html#container-resolution) route definition. However, the latest version of [Psalm](https://psalm.dev) emits the following error:

```
Argument 2 of Slim\App::get expects a public static callable, but a non-static callable provided (see https://psalm.dev/004)
```

This PR addresses this issue by adding the `array{class-string, string}` type to the route handler definition.