### PR TITLE
Deprecate setArgument[s]?

### DIFF
--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -89,6 +89,8 @@ interface RouteInterface
 
     /**
      * Set a route argument
+     *
+     * @deprecated 4.14.1 Use a middleware for custom route arguments now.
      */
     public function setArgument(string $name, string $value): RouteInterface;
 
@@ -96,6 +98,8 @@ interface RouteInterface
      * Replace route arguments
      *
      * @param array<string, string> $arguments
+     *
+     * @deprecated 4.14.1 Use a middleware for custom route arguments now.
      */
     public function setArguments(array $arguments): self;
 


### PR DESCRIPTION
This deprecates existing setArgument[s]? functions as noted in https://github.com/slimphp/Slim/blob/5.x/CHANGELOG.md