### PR TITLE
Added exception for when the headers are send

### DIFF
--- a/Slim/ResponseEmitter.php
+++ b/Slim/ResponseEmitter.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace Slim;
 
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 
 use function connection_status;
 use function header;
@@ -38,13 +39,15 @@ class ResponseEmitter
     public function emit(ResponseInterface $response): void
     {
         $isEmpty = $this->isResponseEmpty($response);
-        if (headers_sent() === false) {
+        headers_sent($file, $line);
+        if (empty($file)) {
             $this->emitHeaders($response);
-
             // Set the status _after_ the headers, because of PHP's "helpful" behavior with location headers.
             // See https://github.com/slimphp/Slim/issues/1730
 
             $this->emitStatusLine($response);
+        } else {
+            throw new RuntimeException('Headers already sent in ' . $file . ' on line ' . $line); 
         }
 
         if (!$isEmpty) {


### PR DESCRIPTION
Once in a blue moon yo will put something before the php tag and then your headers break and you can spend a hour trying to figure out why the headers wont do what they are supposed to.

Especially if you don't know about php's useful behavior with the headers it can cause a headache.