### PR TITLE
Fix DocBlocks for callable route handlers

### DIFF
--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -79,7 +79,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     }
 
     /**
-     * @param string|callable $toResolve
+     * @param callable|array{class-string, string}|string $toResolve
      *
      * @throws RuntimeException
      */
@@ -180,8 +180,9 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     }
 
     /**
-     * @param string|callable $toResolve
-     * @return string|callable
+     * @param callable|string|array{class-string, string}|mixed $toResolve
+     *
+     * @return callable|string|array{class-string, string}|mixed
      */
     private function prepareToResolve($toResolve)
     {

--- a/Slim/Interfaces/AdvancedCallableResolverInterface.php
+++ b/Slim/Interfaces/AdvancedCallableResolverInterface.php
@@ -15,14 +15,14 @@ interface AdvancedCallableResolverInterface extends CallableResolverInterface
     /**
      * Resolve $toResolve into a callable
      *
-     * @param string|callable $toResolve
+     * @param callable|array{class-string, string}|string $toResolve
      */
     public function resolveRoute($toResolve): callable;
 
     /**
      * Resolve $toResolve into a callable
      *
-     * @param string|callable $toResolve
+     * @param callable|array{class-string, string}|string $toResolve
      */
     public function resolveMiddleware($toResolve): callable;
 }

--- a/Slim/Interfaces/CallableResolverInterface.php
+++ b/Slim/Interfaces/CallableResolverInterface.php
@@ -15,7 +15,7 @@ interface CallableResolverInterface
     /**
      * Resolve $toResolve into a callable
      *
-     * @param string|callable $toResolve
+     * @param callable|array{class-string, string}|string $toResolve
      */
     public function resolve($toResolve): callable;
 }

--- a/Slim/Interfaces/RouteCollectorInterface.php
+++ b/Slim/Interfaces/RouteCollectorInterface.php
@@ -95,9 +95,9 @@ interface RouteCollectorInterface
     /**
      * Add route
      *
-     * @param string[]        $methods Array of HTTP methods
-     * @param string          $pattern The route pattern
-     * @param callable|string $handler The route callable
+     * @param string[] $methods Array of HTTP methods
+     * @param string $pattern The route pattern
+     * @param callable|array{class-string, string}|string $handler The route callable
      */
     public function map(array $methods, string $pattern, $handler): RouteInterface;
 }

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -45,65 +45,65 @@ interface RouteCollectorProxyInterface
     /**
      * Add GET route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param string $pattern The route URI pattern
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function get(string $pattern, $callable): RouteInterface;
 
     /**
      * Add POST route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param string $pattern The route URI pattern
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function post(string $pattern, $callable): RouteInterface;
 
     /**
      * Add PUT route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param string $pattern The route URI pattern
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function put(string $pattern, $callable): RouteInterface;
 
     /**
      * Add PATCH route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param string $pattern The route URI pattern
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function patch(string $pattern, $callable): RouteInterface;
 
     /**
      * Add DELETE route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param string $pattern The route URI pattern
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function delete(string $pattern, $callable): RouteInterface;
 
     /**
      * Add OPTIONS route
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param string $pattern The route URI pattern
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function options(string $pattern, $callable): RouteInterface;
 
     /**
      * Add route for any HTTP method
      *
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param string $pattern The route URI pattern
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function any(string $pattern, $callable): RouteInterface;
 
     /**
      * Add route with multiple methods
      *
-     * @param  string[]        $methods  Numeric array of HTTP method names
-     * @param  string          $pattern  The route URI pattern
-     * @param  callable|string $callable The route callback routine
+     * @param string[] $methods Numeric array of HTTP method names
+     * @param string $pattern The route URI pattern
+     * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function map(array $methods, string $pattern, $callable): RouteInterface;
 

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -47,14 +47,14 @@ interface RouteInterface
     /**
      * Get route callable
      *
-     * @return callable|string
+     * @return callable|array{class-string, string}|string
      */
     public function getCallable();
 
     /**
      * Set route callable
      *
-     * @param callable|string $callable
+     * @param callable|array{class-string, string}|string $callable
      */
     public function setCallable($callable): RouteInterface;
 

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -91,7 +91,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * Route callable
      *
-     * @var callable|string
+     * @var callable|array{class-string, string}|string
      */
     protected $callable;
 
@@ -107,15 +107,15 @@ class Route implements RouteInterface, RequestHandlerInterface
     protected bool $groupMiddlewareAppended = false;
 
     /**
-     * @param string[]                         $methods    The route HTTP methods
-     * @param string                           $pattern    The route pattern
-     * @param callable|string                  $callable   The route callable
-     * @param ResponseFactoryInterface         $responseFactory
-     * @param CallableResolverInterface        $callableResolver
-     * @param TContainerInterface              $container
+     * @param string[] $methods The route HTTP methods
+     * @param string $pattern The route pattern
+     * @param callable|array{class-string, string}|string $callable The route callable
+     * @param ResponseFactoryInterface $responseFactory
+     * @param CallableResolverInterface $callableResolver
+     * @param TContainerInterface $container
      * @param InvocationStrategyInterface|null $invocationStrategy
-     * @param RouteGroupInterface[]            $groups     The parent route groups
-     * @param int                              $identifier The route identifier
+     * @param RouteGroupInterface[] $groups The parent route groups
+     * @param int $identifier The route identifier
      */
     public function __construct(
         array $methods,
@@ -348,7 +348,6 @@ class Route implements RouteInterface, RequestHandlerInterface
         }
         $strategy = $this->invocationStrategy;
 
-        /** @var string[] $strategyImplements */
         $strategyImplements = class_implements($strategy);
 
         if (

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -25,9 +25,9 @@ use Slim\Interfaces\RouteParserInterface;
 use function array_pop;
 use function dirname;
 use function file_exists;
-use function sprintf;
 use function is_readable;
 use function is_writable;
+use function sprintf;
 
 /**
  * RouteCollector is used to collect routes and route groups
@@ -282,8 +282,8 @@ class RouteCollector implements RouteCollectorInterface
     }
 
     /**
-     * @param string[]        $methods
-     * @param callable|string $callable
+     * @param string[] $methods
+     * @param callable|array{class-string, string}|string $callable
      */
     protected function createRoute(array $methods, string $pattern, $callable): RouteInterface
     {

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     "require-dev": {
         "ext-simplexml": "*",
-        "adriansuter/php-autoload-override": "^1.4",
+        "adriansuter/php-autoload-override": "^1.4 || ^2",
         "guzzlehttp/psr7": "^2.6",
         "httpsoft/http-message": "^1.1",
         "httpsoft/http-server-request": "^1.1",
@@ -69,7 +69,7 @@
         "slim/http": "^1.3",
         "slim/psr7": "^1.6",
         "squizlabs/php_codesniffer": "^3.10",
-        "vimeo/psalm": "^5.26.1"
+        "vimeo/psalm": "^5 || ^6"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR will fix the DocBlocks for callable route handlers.
I also had to update the dependencies to test it with phpstan and PHP 8.4.

See #3384 and #3379