### PR TITLE
Fix text and eol attributes for * selector

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Enforce Unix newlines
-* text=lf
+* text=auto eol=lf
 
 # Exclude unused files
 # see: https://redd.it/2jzp6k


### PR DESCRIPTION
In `.gitattributes`: `* text=lf` is not valid syntax.
Use `* text=auto eol=lf` instead to enforce Unix newlines.
Docs: https://git-scm.com/docs/gitattributes