### PR TITLE
Refine RouteParserInterface type annotations for query-params.

### DIFF
--- a/Slim/Interfaces/RouteParserInterface.php
+++ b/Slim/Interfaces/RouteParserInterface.php
@@ -20,9 +20,9 @@ interface RouteParserInterface
     /**
      * Build the path for a named route excluding the base path
      *
-     * @param string                $routeName   Route name
-     * @param array<string, string> $data        Named argument replacement data
-     * @param array<string, string> $queryParams Optional query string parameters
+     * @param string                                           $routeName   Route name
+     * @param array<string, string>                            $data        Named argument replacement data
+     * @param array<string, string | array<array-key, string>> $queryParams Optional query string parameters
      *
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
@@ -32,9 +32,9 @@ interface RouteParserInterface
     /**
      * Build the path for a named route including the base path
      *
-     * @param string                $routeName   Route name
-     * @param array<string, string> $data        Named argument replacement data
-     * @param array<string, string> $queryParams Optional query string parameters
+     * @param string                                           $routeName   Route name
+     * @param array<string, string>                            $data        Named argument replacement data
+     * @param array<string, string | array<array-key, string>> $queryParams Optional query string parameters
      *
      * @throws RuntimeException         If named route does not exist
      * @throws InvalidArgumentException If required data not provided
@@ -44,10 +44,10 @@ interface RouteParserInterface
     /**
      * Get fully qualified URL for named route
      *
-     * @param UriInterface              $uri
-     * @param string                    $routeName   Route name
-     * @param array<string, string>     $data        Named argument replacement data
-     * @param array<string, string>     $queryParams Optional query string parameters
+     * @param UriInterface                                     $uri
+     * @param string                                           $routeName   Route name
+     * @param array<string, string>                            $data        Named argument replacement data
+     * @param array<string, string | array<array-key, string>> $queryParams Optional query string parameters
      */
     public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string;
 }

--- a/tests/Routing/RouteParserTest.php
+++ b/tests/Routing/RouteParserTest.php
@@ -34,12 +34,26 @@ class RouteParserTest extends TestCase
                 [],
                 '/hello/world',
             ],
-            'without query parameters' => [
+            'with query parameters' => [
                 false,
                 '/{first}/{second}',
                 ['first' => 'hello', 'second' => 'world'],
                 ['a' => 'b', 'c' => 'd'],
                 '/hello/world?a=b&c=d',
+            ],
+            'with query parameters containing array with string keys' => [
+                false,
+                '/{first}/{second}',
+                ['first' => 'hello', 'second' => 'world'],
+                ['a' => ['k' => '1', 'f' => 'x'], 'b', 'c' => 'd'],
+                '/hello/world?a%5Bk%5D=1&a%5Bf%5D=x&0=b&c=d',
+            ],
+            'with query parameters containing array with numeric keys' => [
+                false,
+                '/{first}/{second}',
+                ['first' => 'hello', 'second' => 'world'],
+                ['a' => ['b', 'x', 'y'], 'c' => 'd'],
+                '/hello/world?a%5B0%5D=b&a%5B1%5D=x&a%5B2%5D=y&c=d',
             ],
             'with argument without optional parameter' => [
                 false,


### PR DESCRIPTION
Expanded the $queryParams type to support arrays of strings, increasing flexibility for query parameters.

This allows you to pass arrays as query parameters and avoids the need for ugly workarounds with PHPStan stub files just to silence PHPStan.