### PR TITLE
Drop setAccessible() usage for PHP 8.5 support

### DIFF
--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -698,18 +698,24 @@ class AppTest extends TestCase
 
         // Check that the routing middleware really has been added to the tip of the app middleware stack.
         $middlewareDispatcherProperty = new ReflectionProperty(App::class, 'middlewareDispatcher');
-        $middlewareDispatcherProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $middlewareDispatcherProperty->setAccessible(true);
+        }
         /** @var MiddlewareDispatcher $middlewareDispatcher */
         $middlewareDispatcher = $middlewareDispatcherProperty->getValue($app);
 
         $tipProperty = new ReflectionProperty(MiddlewareDispatcher::class, 'tip');
-        $tipProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $tipProperty->setAccessible(true);
+        }
         /** @var RequestHandlerInterface $tip */
         $tip = $tipProperty->getValue($middlewareDispatcher);
 
         $reflection = new ReflectionClass($tip);
         $middlewareProperty = $reflection->getProperty('middleware');
-        $middlewareProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $middlewareProperty->setAccessible(true);
+        }
 
         $this->assertSame($routingMiddleware, $middlewareProperty->getValue($tip));
         $this->assertInstanceOf(RoutingMiddleware::class, $routingMiddleware);
@@ -731,18 +737,24 @@ class AppTest extends TestCase
 
         // Check that the error middleware really has been added to the tip of the app middleware stack.
         $middlewareDispatcherProperty = new ReflectionProperty(App::class, 'middlewareDispatcher');
-        $middlewareDispatcherProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $middlewareDispatcherProperty->setAccessible(true);
+        }
         /** @var MiddlewareDispatcher $middlewareDispatcher */
         $middlewareDispatcher = $middlewareDispatcherProperty->getValue($app);
 
         $tipProperty = new ReflectionProperty(MiddlewareDispatcher::class, 'tip');
-        $tipProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $tipProperty->setAccessible(true);
+        }
         /** @var RequestHandlerInterface $tip */
         $tip = $tipProperty->getValue($middlewareDispatcher);
 
         $reflection = new ReflectionClass($tip);
         $middlewareProperty = $reflection->getProperty('middleware');
-        $middlewareProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $middlewareProperty->setAccessible(true);
+        }
 
         $this->assertSame($errorMiddleware, $middlewareProperty->getValue($tip));
         $this->assertInstanceOf(ErrorMiddleware::class, $errorMiddleware);
@@ -761,18 +773,24 @@ class AppTest extends TestCase
 
         // Check that the body parsing middleware really has been added to the tip of the app middleware stack.
         $middlewareDispatcherProperty = new ReflectionProperty(App::class, 'middlewareDispatcher');
-        $middlewareDispatcherProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $middlewareDispatcherProperty->setAccessible(true);
+        }
         /** @var MiddlewareDispatcher $middlewareDispatcher */
         $middlewareDispatcher = $middlewareDispatcherProperty->getValue($app);
 
         $tipProperty = new ReflectionProperty(MiddlewareDispatcher::class, 'tip');
-        $tipProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $tipProperty->setAccessible(true);
+        }
         /** @var RequestHandlerInterface $tip */
         $tip = $tipProperty->getValue($middlewareDispatcher);
 
         $reflection = new ReflectionClass($tip);
         $middlewareProperty = $reflection->getProperty('middleware');
-        $middlewareProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $middlewareProperty->setAccessible(true);
+        }
 
         $this->assertSame($bodyParsingMiddleware, $middlewareProperty->getValue($tip));
         $this->assertInstanceOf(BodyParsingMiddleware::class, $bodyParsingMiddleware);

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -60,7 +60,9 @@ class AbstractErrorRendererTest extends TestCase
         $reflectionRenderer = new ReflectionClass(HtmlErrorRenderer::class);
 
         $method = $reflectionRenderer->getMethod('renderExceptionFragment');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
         $output = $method->invoke($renderer, $exception);
 
         $this->assertMatchesRegularExpression('/.*Type:*/', $output);
@@ -101,7 +103,9 @@ class AbstractErrorRendererTest extends TestCase
         $reflectionRenderer = new ReflectionClass(JsonErrorRenderer::class);
 
         $method = $reflectionRenderer->getMethod('formatExceptionFragment');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $fragment = $method->invoke($renderer, $exception);
         $output = json_encode(json_decode($renderer->__invoke($exception, true)));
@@ -128,7 +132,9 @@ class AbstractErrorRendererTest extends TestCase
         $renderer = new JsonErrorRenderer();
         $reflectionRenderer = new ReflectionClass(JsonErrorRenderer::class);
         $method = $reflectionRenderer->getMethod('formatExceptionFragment');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $output = json_encode(json_decode($renderer->__invoke($exception, true)));
 
@@ -208,7 +214,9 @@ class AbstractErrorRendererTest extends TestCase
         $reflectionRenderer = new ReflectionClass(PlainTextErrorRenderer::class);
 
         $method = $reflectionRenderer->getMethod('formatExceptionFragment');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
         $output = $method->invoke($renderer, $exception);
         $this->assertIsString($output);
 

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -76,7 +76,9 @@ class AppFactoryTest extends TestCase
         $routeCollector = $app->getRouteCollector();
 
         $responseFactoryProperty = new ReflectionProperty(RouteCollector::class, 'responseFactory');
-        $responseFactoryProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $responseFactoryProperty->setAccessible(true);
+        }
 
         $responseFactory = $responseFactoryProperty->getValue($routeCollector);
 
@@ -276,7 +278,9 @@ class AppFactoryTest extends TestCase
         $response = $responseFactory->createResponse();
 
         $streamFactoryProperty = new ReflectionProperty(DecoratedResponse::class, 'streamFactory');
-        $streamFactoryProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $streamFactoryProperty->setAccessible(true);
+        }
 
         $this->assertSame($streamFactoryProphecy->reveal(), $streamFactoryProperty->getValue($response));
     }

--- a/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
+++ b/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
@@ -36,7 +36,9 @@ class SlimHttpServerRequestCreatorTest extends TestCase
             SlimHttpServerRequestCreator::class,
             'serverRequestDecoratorClass'
         );
-        $serverRequestDecoratorClassProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+                    $serverRequestDecoratorClassProperty->setAccessible(true);
+        }
         $serverRequestDecoratorClassProperty->setValue($slimHttpServerRequestCreator, ServerRequest::class);
     }
 
@@ -69,7 +71,9 @@ class SlimHttpServerRequestCreatorTest extends TestCase
             SlimHttpServerRequestCreator::class,
             'serverRequestDecoratorClass'
         );
-        $serverRequestDecoratorClassProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $serverRequestDecoratorClassProperty->setAccessible(true);
+        }
         $serverRequestDecoratorClassProperty->setValue($slimHttpServerRequestCreator, '');
 
         $slimHttpServerRequestCreator->createServerRequestFromGlobals();

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -43,15 +43,21 @@ class ErrorHandlerTest extends TestCase
         $class = new ReflectionClass(ErrorHandler::class);
 
         $callableResolverProperty = $class->getProperty('callableResolver');
-        $callableResolverProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $callableResolverProperty->setAccessible(true);
+        }
         $callableResolverProperty->setValue($handler, $this->getCallableResolver());
 
         $reflectionProperty = $class->getProperty('contentType');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($handler, 'application/json');
 
         $method = $class->getMethod('determineRenderer');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $renderer = $method->invoke($handler);
         $this->assertIsCallable($renderer);
@@ -84,15 +90,21 @@ class ErrorHandlerTest extends TestCase
         $class = new ReflectionClass(ErrorHandler::class);
 
         $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($handler, $this->getResponseFactory());
 
         $reflectionProperty = $class->getProperty('exception');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($handler, new HttpNotFoundException($request));
 
         $method = $class->getMethod('determineStatusCode');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $statusCode = $method->invoke($handler);
         $this->assertSame($statusCode, 404);
@@ -142,15 +154,21 @@ class ErrorHandlerTest extends TestCase
         $class = new ReflectionClass(ErrorHandler::class);
 
         $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($handler, $this->getResponseFactory());
 
         $reflectionProperty = $class->getProperty('errorRenderers');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($handler, $newErrorRenderers);
 
         $method = $class->getMethod('determineContentType');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $contentType = $method->invoke($handler, $request);
 
@@ -177,15 +195,21 @@ class ErrorHandlerTest extends TestCase
         $class = new ReflectionClass(ErrorHandler::class);
 
         $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($handler, $this->getResponseFactory());
 
         $reflectionProperty = $class->getProperty('errorRenderers');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($handler, $errorRenderers);
 
         $method = $class->getMethod('determineContentType');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $contentType = $method->invoke($handler, $request);
 
@@ -211,15 +235,21 @@ class ErrorHandlerTest extends TestCase
         $class = new ReflectionClass(ErrorHandler::class);
 
         $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($handler, $this->getResponseFactory());
 
         $reflectionProperty = $class->getProperty('errorRenderers');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue($handler, $errorRenderers);
 
         $method = $class->getMethod('determineContentType');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $contentType = $method->invoke($handler, $request);
 
@@ -239,7 +269,9 @@ class ErrorHandlerTest extends TestCase
         // provide access to the determineContentType() as it's a protected method
         $class = new ReflectionClass(ErrorHandler::class);
         $method = $class->getMethod('determineContentType');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         // use a mock object here as ErrorHandler cannot be directly instantiated
         $handler = $this
@@ -260,7 +292,9 @@ class ErrorHandlerTest extends TestCase
 
         $reflectionClass = new ReflectionClass(ErrorHandler::class);
         $reflectionProperty = $reflectionClass->getProperty('errorRenderers');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $errorRenderers = $reflectionProperty->getValue($handler);
 
         $this->assertArrayHasKey('application/slim', $errorRenderers);
@@ -273,11 +307,15 @@ class ErrorHandlerTest extends TestCase
 
         $reflectionClass = new ReflectionClass(ErrorHandler::class);
         $reflectionProperty = $reflectionClass->getProperty('defaultErrorRenderer');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $defaultErrorRenderer = $reflectionProperty->getValue($handler);
 
         $defaultErrorRendererContentTypeProperty = $reflectionClass->getProperty('defaultErrorRendererContentType');
-        $defaultErrorRendererContentTypeProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $defaultErrorRendererContentTypeProperty->setAccessible(true);
+        }
         $defaultErrorRendererContentType = $defaultErrorRendererContentTypeProperty->getValue($handler);
 
         $this->assertSame(PlainTextErrorRenderer::class, $defaultErrorRenderer);
@@ -414,16 +452,22 @@ class ErrorHandlerTest extends TestCase
         $handler->setLogErrorRenderer('logErrorRenderer');
 
         $displayErrorDetailsProperty = new ReflectionProperty($handler, 'displayErrorDetails');
-        $displayErrorDetailsProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $displayErrorDetailsProperty->setAccessible(true);
+        }
         $displayErrorDetailsProperty->setValue($handler, true);
 
         $exception = new RuntimeException();
         $exceptionProperty = new ReflectionProperty($handler, 'exception');
-        $exceptionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $exceptionProperty->setAccessible(true);
+        }
         $exceptionProperty->setValue($handler, $exception);
 
         $writeToErrorLogMethod = new ReflectionMethod($handler, 'writeToErrorLog');
-        $writeToErrorLogMethod->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $writeToErrorLogMethod->setAccessible(true);
+        }
         $writeToErrorLogMethod->invoke($handler);
     }
 }

--- a/tests/Middleware/OutputBufferingMiddlewareTest.php
+++ b/tests/Middleware/OutputBufferingMiddlewareTest.php
@@ -26,7 +26,9 @@ class OutputBufferingMiddlewareTest extends TestCase
         $middleware = new OutputBufferingMiddleware($this->getStreamFactory());
 
         $reflectionProperty = new ReflectionProperty($middleware, 'style');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $value = $reflectionProperty->getValue($middleware);
 
         $this->assertSame('append', $value);
@@ -37,7 +39,9 @@ class OutputBufferingMiddlewareTest extends TestCase
         $middleware = new OutputBufferingMiddleware($this->getStreamFactory(), 'prepend');
 
         $reflectionProperty = new ReflectionProperty($middleware, 'style');
-        $reflectionProperty->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $value = $reflectionProperty->getValue($middleware);
 
         $this->assertSame('prepend', $value);

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -280,7 +280,9 @@ class ResponseEmitterTest extends TestCase
 
         $mirror = new ReflectionClass(ResponseEmitter::class);
         $emitBodyMethod = $mirror->getMethod('emitBody');
-        $emitBodyMethod->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $emitBodyMethod->setAccessible(true);
+        }
         $emitBodyMethod->invoke($responseEmitter, $response);
 
         $this->expectOutputString("");

--- a/tests/Routing/DispatcherTest.php
+++ b/tests/Routing/DispatcherTest.php
@@ -34,7 +34,9 @@ class DispatcherTest extends TestCase
         $dispatcher = new Dispatcher($routeCollector);
 
         $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $this->assertInstanceOf(FastRouteDispatcher::class, $method->invoke($dispatcher));
     }
@@ -57,7 +59,9 @@ class DispatcherTest extends TestCase
         $routeCollector->setCacheFile($cacheFile);
 
         $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
         $method->invoke($dispatcher);
         $this->assertFileExists($cacheFile, 'cache file was not created');
 
@@ -66,7 +70,9 @@ class DispatcherTest extends TestCase
         $dispatcher2 = new Dispatcher($routeCollector2);
 
         $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
         $method->invoke($dispatcher2);
 
         /** @var RoutingResults $result */
@@ -88,7 +94,9 @@ class DispatcherTest extends TestCase
         $dispatcher = new Dispatcher($routeCollector);
 
         $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
-        $method->setAccessible(true);
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
 
         $fastRouteDispatcher = $method->invoke($dispatcher);
         $fastRouteDispatcher2 = $method->invoke($dispatcher);


### PR DESCRIPTION
Remove `setAccessible()` calls to support PHP 8.5 and avoid deprecation
