### PR TITLE
Fix MissingOverrideAttribute errors by adding #[\Override]

### DIFF
--- a/Slim/App.php
+++ b/Slim/App.php
@@ -204,6 +204,7 @@ class App extends RouteCollectorProxy implements RequestHandlerInterface
      * @param ServerRequestInterface $request
      * @return ResponseInterface
      */
+    #[\Override]
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $response = $this->middlewareDispatcher->handle($request);

--- a/Slim/CallableResolver.php
+++ b/Slim/CallableResolver.php
@@ -47,6 +47,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function resolve($toResolve): callable
     {
         $toResolve = $this->prepareToResolve($toResolve);
@@ -65,6 +66,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function resolveRoute($toResolve): callable
     {
         return $this->resolveByPredicate($toResolve, [$this, 'isRoute'], 'handle');
@@ -73,6 +75,7 @@ final class CallableResolver implements AdvancedCallableResolverInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function resolveMiddleware($toResolve): callable
     {
         return $this->resolveByPredicate($toResolve, [$this, 'isMiddleware'], 'process');

--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -22,6 +22,7 @@ use function sprintf;
  */
 class HtmlErrorRenderer extends AbstractErrorRenderer
 {
+    #[\Override]
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
         if ($displayErrorDetails) {

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -24,6 +24,7 @@ use const JSON_UNESCAPED_SLASHES;
  */
 class JsonErrorRenderer extends AbstractErrorRenderer
 {
+    #[\Override]
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
         $error = ['message' => $this->getErrorTitle($exception)];

--- a/Slim/Error/Renderers/PlainTextErrorRenderer.php
+++ b/Slim/Error/Renderers/PlainTextErrorRenderer.php
@@ -22,6 +22,7 @@ use function sprintf;
  */
 class PlainTextErrorRenderer extends AbstractErrorRenderer
 {
+    #[\Override]
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
         $text = "{$this->getErrorTitle($exception)}\n";

--- a/Slim/Error/Renderers/XmlErrorRenderer.php
+++ b/Slim/Error/Renderers/XmlErrorRenderer.php
@@ -22,6 +22,7 @@ use function str_replace;
  */
 class XmlErrorRenderer extends AbstractErrorRenderer
 {
+    #[\Override]
     public function __invoke(Throwable $exception, bool $displayErrorDetails): string
     {
         $xml = '<' . '?xml version="1.0" encoding="UTF-8" standalone="yes"?' . ">\n";

--- a/Slim/Factory/Psr17/NyholmPsr17Factory.php
+++ b/Slim/Factory/Psr17/NyholmPsr17Factory.php
@@ -16,6 +16,7 @@ class NyholmPsr17Factory extends Psr17Factory
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public static function getServerRequestCreator(): ServerRequestCreatorInterface
     {
         /*

--- a/Slim/Factory/Psr17/Psr17Factory.php
+++ b/Slim/Factory/Psr17/Psr17Factory.php
@@ -32,6 +32,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public static function getResponseFactory(): ResponseFactoryInterface
     {
         if (
@@ -47,6 +48,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public static function getStreamFactory(): StreamFactoryInterface
     {
         if (
@@ -62,6 +64,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public static function getServerRequestCreator(): ServerRequestCreatorInterface
     {
         if (!static::isServerRequestCreatorAvailable()) {
@@ -74,6 +77,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public static function isResponseFactoryAvailable(): bool
     {
         return static::$responseFactoryClass && class_exists(static::$responseFactoryClass);
@@ -82,6 +86,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public static function isStreamFactoryAvailable(): bool
     {
         return static::$streamFactoryClass && class_exists(static::$streamFactoryClass);
@@ -90,6 +95,7 @@ abstract class Psr17Factory implements Psr17FactoryInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public static function isServerRequestCreatorAvailable(): bool
     {
         return (

--- a/Slim/Factory/Psr17/Psr17FactoryProvider.php
+++ b/Slim/Factory/Psr17/Psr17FactoryProvider.php
@@ -30,6 +30,7 @@ class Psr17FactoryProvider implements Psr17FactoryProviderInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public static function getFactories(): array
     {
         return static::$factories;
@@ -38,6 +39,7 @@ class Psr17FactoryProvider implements Psr17FactoryProviderInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public static function setFactories(array $factories): void
     {
         static::$factories = $factories;
@@ -46,6 +48,7 @@ class Psr17FactoryProvider implements Psr17FactoryProviderInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public static function addFactory(string $factory): void
     {
         array_unshift(static::$factories, $factory);

--- a/Slim/Factory/Psr17/ServerRequestCreator.php
+++ b/Slim/Factory/Psr17/ServerRequestCreator.php
@@ -35,6 +35,7 @@ class ServerRequestCreator implements ServerRequestCreatorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function createServerRequestFromGlobals(): ServerRequestInterface
     {
         /** @var callable $callable */

--- a/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
+++ b/Slim/Factory/Psr17/SlimHttpServerRequestCreator.php
@@ -30,6 +30,7 @@ class SlimHttpServerRequestCreator implements ServerRequestCreatorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function createServerRequestFromGlobals(): ServerRequestInterface
     {
         if (!static::isServerRequestDecoratorAvailable()) {

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -111,6 +111,7 @@ class ErrorHandler implements ErrorHandlerInterface
      * @param bool                   $logErrors           Whether or not to log errors
      * @param bool                   $logErrorDetails     Whether or not to log error details
      */
+    #[\Override]
     public function __invoke(
         ServerRequestInterface $request,
         Throwable $exception,

--- a/Slim/Handlers/Strategies/RequestHandler.php
+++ b/Slim/Handlers/Strategies/RequestHandler.php
@@ -31,6 +31,7 @@ class RequestHandler implements RequestHandlerInvocationStrategyInterface
      *
      * @param array<string, string>  $routeArguments
      */
+    #[\Override]
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,

--- a/Slim/Handlers/Strategies/RequestResponse.php
+++ b/Slim/Handlers/Strategies/RequestResponse.php
@@ -25,6 +25,7 @@ class RequestResponse implements InvocationStrategyInterface
      *
      * @param array<string, string>  $routeArguments
      */
+    #[\Override]
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,

--- a/Slim/Handlers/Strategies/RequestResponseArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseArgs.php
@@ -28,6 +28,7 @@ class RequestResponseArgs implements InvocationStrategyInterface
      *
      * @param array<string, string>  $routeArguments
      */
+    #[\Override]
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,

--- a/Slim/Handlers/Strategies/RequestResponseNamedArgs.php
+++ b/Slim/Handlers/Strategies/RequestResponseNamedArgs.php
@@ -27,6 +27,7 @@ class RequestResponseNamedArgs implements InvocationStrategyInterface
      *
      * @param array<string, string>  $routeArguments
      */
+    #[\Override]
     public function __invoke(
         callable $callable,
         ServerRequestInterface $request,

--- a/Slim/Logger.php
+++ b/Slim/Logger.php
@@ -25,6 +25,7 @@ class Logger extends AbstractLogger
      *
      * @throws InvalidArgumentException
      */
+    #[\Override]
     public function log($level, $message, array $context = []): void
     {
         error_log((string) $message);

--- a/Slim/Middleware/BodyParsingMiddleware.php
+++ b/Slim/Middleware/BodyParsingMiddleware.php
@@ -52,6 +52,7 @@ class BodyParsingMiddleware implements MiddlewareInterface
         }
     }
 
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $parsedBody = $request->getParsedBody();

--- a/Slim/Middleware/ContentLengthMiddleware.php
+++ b/Slim/Middleware/ContentLengthMiddleware.php
@@ -18,6 +18,7 @@ use Psr\Http\Server\RequestHandlerInterface;
 /** @api */
 class ContentLengthMiddleware implements MiddlewareInterface
 {
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);

--- a/Slim/Middleware/ErrorMiddleware.php
+++ b/Slim/Middleware/ErrorMiddleware.php
@@ -71,6 +71,7 @@ class ErrorMiddleware implements MiddlewareInterface
         $this->logger = $logger;
     }
 
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         try {

--- a/Slim/Middleware/MethodOverrideMiddleware.php
+++ b/Slim/Middleware/MethodOverrideMiddleware.php
@@ -21,6 +21,7 @@ use function strtoupper;
 /** @api */
 class MethodOverrideMiddleware implements MiddlewareInterface
 {
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $methodHeader = $request->getHeaderLine('X-Http-Method-Override');

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -49,6 +49,7 @@ class OutputBufferingMiddleware implements MiddlewareInterface
     /**
      * @throws Throwable
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         try {
@@ -63,7 +64,7 @@ class OutputBufferingMiddleware implements MiddlewareInterface
         if (!empty($output)) {
             if ($this->style === static::PREPEND) {
                 $body = $this->streamFactory->createStream();
-                $body->write($output . $response->getBody());
+                $body->write($output . (string) $response->getBody());
                 $response = $response->withBody($body);
             } elseif ($this->style === static::APPEND && $response->getBody()->isWritable()) {
                 $response->getBody()->write($output);

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -64,7 +64,7 @@ class OutputBufferingMiddleware implements MiddlewareInterface
         if (!empty($output)) {
             if ($this->style === static::PREPEND) {
                 $body = $this->streamFactory->createStream();
-                $body->write($output . (string) $response->getBody());
+                $body->write($output . $response->getBody());
                 $response = $response->withBody($body);
             } elseif ($this->style === static::APPEND && $response->getBody()->isWritable()) {
                 $response->getBody()->write($output);

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -39,6 +39,7 @@ class RoutingMiddleware implements MiddlewareInterface
      * @throws HttpMethodNotAllowedException
      * @throws RuntimeException
      */
+    #[\Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $request = $this->performRouting($request);

--- a/Slim/MiddlewareDispatcher.php
+++ b/Slim/MiddlewareDispatcher.php
@@ -60,6 +60,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function seedMiddlewareStack(RequestHandlerInterface $kernel): void
     {
         $this->tip = $kernel;
@@ -68,6 +69,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
     /**
      * Invoke the middleware stack
      */
+    #[\Override]
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         return $this->tip->handle($request);
@@ -82,6 +84,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
      *
      * @param MiddlewareInterface|string|callable $middleware
      */
+    #[\Override]
     public function add($middleware): MiddlewareDispatcherInterface
     {
         if ($middleware instanceof MiddlewareInterface) {
@@ -110,6 +113,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
      * that have been added before will be executed after the newly
      * added one (last in, first out).
      */
+    #[\Override]
     public function addMiddleware(MiddlewareInterface $middleware): MiddlewareDispatcherInterface
     {
         $next = $this->tip;
@@ -124,6 +128,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
                 $this->next = $next;
             }
 
+            #[\Override]
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
                 return $this->middleware->process($request, $this->next);
@@ -170,6 +175,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
                 $this->callableResolver = $callableResolver;
             }
 
+            #[\Override]
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
                 if ($this->callableResolver instanceof AdvancedCallableResolverInterface) {
@@ -277,6 +283,7 @@ class MiddlewareDispatcher implements MiddlewareDispatcherInterface
                 $this->next = $next;
             }
 
+            #[\Override]
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
                 /** @var ResponseInterface */

--- a/Slim/Routing/Dispatcher.php
+++ b/Slim/Routing/Dispatcher.php
@@ -60,6 +60,7 @@ class Dispatcher implements DispatcherInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function dispatch(string $method, string $uri): RoutingResults
     {
         $dispatcher = $this->createDispatcher();
@@ -70,6 +71,7 @@ class Dispatcher implements DispatcherInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getAllowedMethods(string $uri): array
     {
         $dispatcher = $this->createDispatcher();

--- a/Slim/Routing/FastRouteDispatcher.php
+++ b/Slim/Routing/FastRouteDispatcher.php
@@ -25,6 +25,7 @@ class FastRouteDispatcher extends GroupCountBased
      *
      * @return array{int, string|null, array<string, string>}
      */
+    #[\Override]
     public function dispatch($httpMethod, $uri): array
     {
         $routingResults = $this->routingResults($httpMethod, $uri);

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -148,6 +148,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getInvocationStrategy(): InvocationStrategyInterface
     {
         return $this->invocationStrategy;
@@ -156,6 +157,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function setInvocationStrategy(InvocationStrategyInterface $invocationStrategy): RouteInterface
     {
         $this->invocationStrategy = $invocationStrategy;
@@ -165,6 +167,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getMethods(): array
     {
         return $this->methods;
@@ -173,6 +176,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getPattern(): string
     {
         return $this->pattern;
@@ -181,6 +185,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function setPattern(string $pattern): RouteInterface
     {
         $this->pattern = $pattern;
@@ -190,6 +195,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getCallable()
     {
         return $this->callable;
@@ -198,6 +204,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function setCallable($callable): RouteInterface
     {
         $this->callable = $callable;
@@ -207,6 +214,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getName(): ?string
     {
         return $this->name;
@@ -215,6 +223,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function setName(string $name): RouteInterface
     {
         $this->name = $name;
@@ -224,6 +233,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getIdentifier(): string
     {
         return $this->identifier;
@@ -232,6 +242,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getArgument(string $name, ?string $default = null): ?string
     {
         if (array_key_exists($name, $this->arguments)) {
@@ -243,6 +254,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getArguments(): array
     {
         return $this->arguments;
@@ -251,6 +263,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function setArguments(array $arguments, bool $includeInSavedArguments = true): RouteInterface
     {
         if ($includeInSavedArguments) {
@@ -272,6 +285,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function add($middleware): RouteInterface
     {
         $this->middlewareDispatcher->add($middleware);
@@ -281,6 +295,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function addMiddleware(MiddlewareInterface $middleware): RouteInterface
     {
         $this->middlewareDispatcher->addMiddleware($middleware);
@@ -290,6 +305,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function prepare(array $arguments): RouteInterface
     {
         $this->arguments = array_replace($this->savedArguments, $arguments);
@@ -299,6 +315,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function setArgument(string $name, string $value, bool $includeInSavedArguments = true): RouteInterface
     {
         if ($includeInSavedArguments) {
@@ -312,6 +329,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function run(ServerRequestInterface $request): ResponseInterface
     {
         if (!$this->groupMiddlewareAppended) {
@@ -339,6 +357,7 @@ class Route implements RouteInterface, RequestHandlerInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         if ($this->callableResolver instanceof AdvancedCallableResolverInterface) {
@@ -348,7 +367,7 @@ class Route implements RouteInterface, RequestHandlerInterface
         }
         $strategy = $this->invocationStrategy;
 
-        $strategyImplements = class_implements($strategy);
+        $strategyImplements = class_implements($strategy) ?: [];
 
         if (
             is_array($callable)

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -367,7 +367,7 @@ class Route implements RouteInterface, RequestHandlerInterface
         }
         $strategy = $this->invocationStrategy;
 
-        $strategyImplements = class_implements($strategy) ?: [];
+        $strategyImplements = class_implements($strategy);
 
         if (
             is_array($callable)

--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -104,6 +104,7 @@ class RouteCollector implements RouteCollectorInterface
         }
     }
 
+    #[\Override]
     public function getRouteParser(): RouteParserInterface
     {
         return $this->routeParser;
@@ -112,11 +113,13 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * Get default route invocation strategy
      */
+    #[\Override]
     public function getDefaultInvocationStrategy(): InvocationStrategyInterface
     {
         return $this->defaultInvocationStrategy;
     }
 
+    #[\Override]
     public function setDefaultInvocationStrategy(InvocationStrategyInterface $strategy): RouteCollectorInterface
     {
         $this->defaultInvocationStrategy = $strategy;
@@ -126,6 +129,7 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getCacheFile(): ?string
     {
         return $this->cacheFile;
@@ -134,6 +138,7 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function setCacheFile(string $cacheFile): RouteCollectorInterface
     {
         if (file_exists($cacheFile) && !is_readable($cacheFile)) {
@@ -155,6 +160,7 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getBasePath(): string
     {
         return $this->basePath;
@@ -163,6 +169,7 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * Set the base path used in urlFor()
      */
+    #[\Override]
     public function setBasePath(string $basePath): RouteCollectorInterface
     {
         $this->basePath = $basePath;
@@ -173,6 +180,7 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getRoutes(): array
     {
         return $this->routes;
@@ -181,6 +189,7 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function removeNamedRoute(string $name): RouteCollectorInterface
     {
         $route = $this->getNamedRoute($name);
@@ -193,6 +202,7 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getNamedRoute(string $name): RouteInterface
     {
         if (isset($this->routesByName[$name])) {
@@ -217,6 +227,7 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function lookupRoute(string $identifier): RouteInterface
     {
         if (!isset($this->routes[$identifier])) {
@@ -228,6 +239,7 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function group(string $pattern, $callable): RouteGroupInterface
     {
         $routeGroup = $this->createGroup($pattern, $callable);
@@ -266,6 +278,7 @@ class RouteCollector implements RouteCollectorInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function map(array $methods, string $pattern, $handler): RouteInterface
     {
         $route = $this->createRoute($methods, $pattern, $handler);

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -55,6 +55,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getResponseFactory(): ResponseFactoryInterface
     {
         return $this->responseFactory;
@@ -63,6 +64,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getCallableResolver(): CallableResolverInterface
     {
         return $this->callableResolver;
@@ -72,6 +74,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
      * {@inheritdoc}
      * @return TContainerInterface
      */
+    #[\Override]
     public function getContainer(): ?ContainerInterface
     {
         return $this->container;
@@ -80,6 +83,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getRouteCollector(): RouteCollectorInterface
     {
         return $this->routeCollector;
@@ -88,6 +92,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getBasePath(): string
     {
         return $this->routeCollector->getBasePath();
@@ -96,6 +101,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function setBasePath(string $basePath): RouteCollectorProxyInterface
     {
         $this->routeCollector->setBasePath($basePath);
@@ -106,6 +112,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function get(string $pattern, $callable): RouteInterface
     {
         return $this->map(['GET'], $pattern, $callable);
@@ -114,6 +121,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function post(string $pattern, $callable): RouteInterface
     {
         return $this->map(['POST'], $pattern, $callable);
@@ -122,6 +130,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function put(string $pattern, $callable): RouteInterface
     {
         return $this->map(['PUT'], $pattern, $callable);
@@ -130,6 +139,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function patch(string $pattern, $callable): RouteInterface
     {
         return $this->map(['PATCH'], $pattern, $callable);
@@ -138,6 +148,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function delete(string $pattern, $callable): RouteInterface
     {
         return $this->map(['DELETE'], $pattern, $callable);
@@ -146,6 +157,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function options(string $pattern, $callable): RouteInterface
     {
         return $this->map(['OPTIONS'], $pattern, $callable);
@@ -154,6 +166,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function any(string $pattern, $callable): RouteInterface
     {
         return $this->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], $pattern, $callable);
@@ -162,6 +175,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function map(array $methods, string $pattern, $callable): RouteInterface
     {
         $pattern = $this->groupPattern . $pattern;
@@ -172,6 +186,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function group(string $pattern, $callable): RouteGroupInterface
     {
         $pattern = $this->groupPattern . $pattern;
@@ -182,6 +197,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function redirect(string $from, $to, int $status = 302): RouteInterface
     {
         $responseFactory = $this->responseFactory;

--- a/Slim/Routing/RouteGroup.php
+++ b/Slim/Routing/RouteGroup.php
@@ -57,6 +57,7 @@ class RouteGroup implements RouteGroupInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function collectRoutes(): RouteGroupInterface
     {
         if ($this->callableResolver instanceof AdvancedCallableResolverInterface) {
@@ -71,6 +72,7 @@ class RouteGroup implements RouteGroupInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function add($middleware): RouteGroupInterface
     {
         $this->middleware[] = $middleware;
@@ -80,6 +82,7 @@ class RouteGroup implements RouteGroupInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function addMiddleware(MiddlewareInterface $middleware): RouteGroupInterface
     {
         $this->middleware[] = $middleware;
@@ -90,6 +93,7 @@ class RouteGroup implements RouteGroupInterface
      * {@inheritdoc}
      * @param MiddlewareDispatcher<\Psr\Container\ContainerInterface|null> $dispatcher
      */
+    #[\Override]
     public function appendMiddlewareToDispatcher(MiddlewareDispatcher $dispatcher): RouteGroupInterface
     {
         foreach ($this->middleware as $middleware) {
@@ -102,6 +106,7 @@ class RouteGroup implements RouteGroupInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function getPattern(): string
     {
         return $this->pattern;

--- a/Slim/Routing/RouteParser.php
+++ b/Slim/Routing/RouteParser.php
@@ -37,6 +37,7 @@ class RouteParser implements RouteParserInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function relativeUrlFor(string $routeName, array $data = [], array $queryParams = []): string
     {
         $route = $this->routeCollector->getNamedRoute($routeName);
@@ -101,6 +102,7 @@ class RouteParser implements RouteParserInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function urlFor(string $routeName, array $data = [], array $queryParams = []): string
     {
         $basePath = $this->routeCollector->getBasePath();
@@ -116,6 +118,7 @@ class RouteParser implements RouteParserInterface
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function fullUrlFor(UriInterface $uri, string $routeName, array $data = [], array $queryParams = []): string
     {
         $path = $this->urlFor($routeName, $data, $queryParams);

--- a/Slim/Routing/RouteResolver.php
+++ b/Slim/Routing/RouteResolver.php
@@ -37,6 +37,7 @@ class RouteResolver implements RouteResolverInterface
     /**
      * @param string $uri Should be $request->getUri()->getPath()
      */
+    #[\Override]
     public function computeRoutingResults(string $uri, string $method): RoutingResults
     {
         $uri = rawurldecode($uri);
@@ -49,6 +50,7 @@ class RouteResolver implements RouteResolverInterface
     /**
      * @throws RuntimeException
      */
+    #[\Override]
     public function resolveRoute(string $identifier): RouteInterface
     {
         return $this->routeCollector->lookupRoute($identifier);

--- a/Slim/Routing/RouteRunner.php
+++ b/Slim/Routing/RouteRunner.php
@@ -54,6 +54,7 @@ class RouteRunner implements RequestHandlerInterface
      * @throws HttpNotFoundException
      * @throws HttpMethodNotAllowedException
      */
+    #[\Override]
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         // If routing hasn't been done, then do it now so we can dispatch

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,3 +2,4 @@ parameters:
     level: max
     paths:
         - Slim
+    checkMissingOverrideMethodAttribute: true


### PR DESCRIPTION
This PR addresses [`MissingOverrideAttribute`](https://psalm.dev/docs/running_psalm/issues/MissingOverrideAttribute/) errors reported by Psalm by adding `#[\Override]` where appropriate.

- No functional changes were made; this should have no impact on existing behavior.
- This is my first contribution to the project, so please let me know if there are any issues with the approach or conventions.

Thank you for your time and consideration!
