### PR TITLE
Add support for PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,9 @@ jobs:
         include:
           - php: 8.2
             analysis: true
+          - php: 8.5
+            experimental: true
+            composer-options: '--ignore-platform-req=php+'
           - php: nightly
             experimental: true
             composer-options: '--ignore-platform-req=php+'

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "wiki": "https://github.com/slimphp/Slim/wiki"
     },
     "require": {
-        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-json": "*",
         "nikic/fast-route": "^1.3",
         "psr/container": "^1.0 || ^2.0",

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -703,18 +703,18 @@ class AppTest extends TestCase
 
         // Check that the routing middleware really has been added to the tip of the app middleware stack.
         $middlewareDispatcherProperty = new ReflectionProperty(App::class, 'middlewareDispatcher');
-        $middlewareDispatcherProperty->setAccessible(true);
+        $this->setAccessible($middlewareDispatcherProperty);
         /** @var MiddlewareDispatcher $middlewareDispatcher */
         $middlewareDispatcher = $middlewareDispatcherProperty->getValue($app);
 
         $tipProperty = new ReflectionProperty(MiddlewareDispatcher::class, 'tip');
-        $tipProperty->setAccessible(true);
+        $this->setAccessible($tipProperty);
         /** @var RequestHandlerInterface $tip */
         $tip = $tipProperty->getValue($middlewareDispatcher);
 
         $reflection = new ReflectionClass($tip);
         $middlewareProperty = $reflection->getProperty('middleware');
-        $middlewareProperty->setAccessible(true);
+        $this->setAccessible($middlewareProperty);
 
         $this->assertSame($routingMiddleware, $middlewareProperty->getValue($tip));
         $this->assertInstanceOf(RoutingMiddleware::class, $routingMiddleware);
@@ -736,18 +736,18 @@ class AppTest extends TestCase
 
         // Check that the error middleware really has been added to the tip of the app middleware stack.
         $middlewareDispatcherProperty = new ReflectionProperty(App::class, 'middlewareDispatcher');
-        $middlewareDispatcherProperty->setAccessible(true);
+        $this->setAccessible($middlewareDispatcherProperty);
         /** @var MiddlewareDispatcher $middlewareDispatcher */
         $middlewareDispatcher = $middlewareDispatcherProperty->getValue($app);
 
         $tipProperty = new ReflectionProperty(MiddlewareDispatcher::class, 'tip');
-        $tipProperty->setAccessible(true);
+        $this->setAccessible($tipProperty);
         /** @var RequestHandlerInterface $tip */
         $tip = $tipProperty->getValue($middlewareDispatcher);
 
         $reflection = new ReflectionClass($tip);
         $middlewareProperty = $reflection->getProperty('middleware');
-        $middlewareProperty->setAccessible(true);
+        $this->setAccessible($middlewareProperty);
 
         $this->assertSame($errorMiddleware, $middlewareProperty->getValue($tip));
         $this->assertInstanceOf(ErrorMiddleware::class, $errorMiddleware);
@@ -766,18 +766,18 @@ class AppTest extends TestCase
 
         // Check that the body parsing middleware really has been added to the tip of the app middleware stack.
         $middlewareDispatcherProperty = new ReflectionProperty(App::class, 'middlewareDispatcher');
-        $middlewareDispatcherProperty->setAccessible(true);
+        $this->setAccessible($middlewareDispatcherProperty);
         /** @var MiddlewareDispatcher $middlewareDispatcher */
         $middlewareDispatcher = $middlewareDispatcherProperty->getValue($app);
 
         $tipProperty = new ReflectionProperty(MiddlewareDispatcher::class, 'tip');
-        $tipProperty->setAccessible(true);
+        $this->setAccessible($tipProperty);
         /** @var RequestHandlerInterface $tip */
         $tip = $tipProperty->getValue($middlewareDispatcher);
 
         $reflection = new ReflectionClass($tip);
         $middlewareProperty = $reflection->getProperty('middleware');
-        $middlewareProperty->setAccessible(true);
+        $this->setAccessible($middlewareProperty);
 
         $this->assertSame($bodyParsingMiddleware, $middlewareProperty->getValue($tip));
         $this->assertInstanceOf(BodyParsingMiddleware::class, $bodyParsingMiddleware);

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -60,7 +60,7 @@ class AbstractErrorRendererTest extends TestCase
         $reflectionRenderer = new ReflectionClass(HtmlErrorRenderer::class);
 
         $method = $reflectionRenderer->getMethod('renderExceptionFragment');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
         $output = $method->invoke($renderer, $exception);
 
         $this->assertMatchesRegularExpression('/.*Type:*/', $output);
@@ -101,7 +101,7 @@ class AbstractErrorRendererTest extends TestCase
         $reflectionRenderer = new ReflectionClass(JsonErrorRenderer::class);
 
         $method = $reflectionRenderer->getMethod('formatExceptionFragment');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
 
         $fragment = $method->invoke($renderer, $exception);
         $output = json_encode(json_decode($renderer->__invoke($exception, true)));
@@ -128,7 +128,7 @@ class AbstractErrorRendererTest extends TestCase
         $renderer = new JsonErrorRenderer();
         $reflectionRenderer = new ReflectionClass(JsonErrorRenderer::class);
         $method = $reflectionRenderer->getMethod('formatExceptionFragment');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
 
         $output = json_encode(json_decode($renderer->__invoke($exception, true)));
 
@@ -208,7 +208,7 @@ class AbstractErrorRendererTest extends TestCase
         $reflectionRenderer = new ReflectionClass(PlainTextErrorRenderer::class);
 
         $method = $reflectionRenderer->getMethod('formatExceptionFragment');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
         $output = $method->invoke($renderer, $exception);
         $this->assertIsString($output);
 

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -77,7 +77,7 @@ class AppFactoryTest extends TestCase
         $routeCollector = $app->getRouteCollector();
 
         $responseFactoryProperty = new ReflectionProperty(RouteCollector::class, 'responseFactory');
-        $responseFactoryProperty->setAccessible(true);
+        $this->setAccessible($responseFactoryProperty);
 
         $responseFactory = $responseFactoryProperty->getValue($routeCollector);
 
@@ -281,7 +281,7 @@ class AppFactoryTest extends TestCase
         $response = $responseFactory->createResponse();
 
         $streamFactoryProperty = new ReflectionProperty(DecoratedResponse::class, 'streamFactory');
-        $streamFactoryProperty->setAccessible(true);
+        $this->setAccessible($streamFactoryProperty);
 
         $this->assertSame($streamFactoryProphecy->reveal(), $streamFactoryProperty->getValue($response));
     }

--- a/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
+++ b/tests/Factory/Psr17/SlimHttpServerRequestCreatorTest.php
@@ -36,7 +36,7 @@ class SlimHttpServerRequestCreatorTest extends TestCase
             SlimHttpServerRequestCreator::class,
             'serverRequestDecoratorClass'
         );
-        $serverRequestDecoratorClassProperty->setAccessible(true);
+        $this->setAccessible($serverRequestDecoratorClassProperty);
         $serverRequestDecoratorClassProperty->setValue($slimHttpServerRequestCreator, ServerRequest::class);
     }
 
@@ -69,7 +69,7 @@ class SlimHttpServerRequestCreatorTest extends TestCase
             SlimHttpServerRequestCreator::class,
             'serverRequestDecoratorClass'
         );
-        $serverRequestDecoratorClassProperty->setAccessible(true);
+        $this->setAccessible($serverRequestDecoratorClassProperty);
         $serverRequestDecoratorClassProperty->setValue($slimHttpServerRequestCreator, '');
 
         $slimHttpServerRequestCreator->createServerRequestFromGlobals();

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -40,15 +40,15 @@ class ErrorHandlerTest extends TestCase
         $class = new ReflectionClass(ErrorHandler::class);
 
         $callableResolverProperty = $class->getProperty('callableResolver');
-        $callableResolverProperty->setAccessible(true);
+        $this->setAccessible($callableResolverProperty);
         $callableResolverProperty->setValue($handler, $this->getCallableResolver());
 
         $reflectionProperty = $class->getProperty('contentType');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $reflectionProperty->setValue($handler, 'application/json');
 
         $method = $class->getMethod('determineRenderer');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
 
         $renderer = $method->invoke($handler);
         $this->assertIsCallable($renderer);
@@ -78,15 +78,15 @@ class ErrorHandlerTest extends TestCase
         $class = new ReflectionClass(ErrorHandler::class);
 
         $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $reflectionProperty->setValue($handler, $this->getResponseFactory());
 
         $reflectionProperty = $class->getProperty('exception');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $reflectionProperty->setValue($handler, new HttpNotFoundException($request));
 
         $method = $class->getMethod('determineStatusCode');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
 
         $statusCode = $method->invoke($handler);
         $this->assertSame($statusCode, 404);
@@ -133,15 +133,15 @@ class ErrorHandlerTest extends TestCase
         $class = new ReflectionClass(ErrorHandler::class);
 
         $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $reflectionProperty->setValue($handler, $this->getResponseFactory());
 
         $reflectionProperty = $class->getProperty('errorRenderers');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $reflectionProperty->setValue($handler, $newErrorRenderers);
 
         $method = $class->getMethod('determineContentType');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
 
         $contentType = $method->invoke($handler, $request);
 
@@ -165,15 +165,15 @@ class ErrorHandlerTest extends TestCase
         $class = new ReflectionClass(ErrorHandler::class);
 
         $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $reflectionProperty->setValue($handler, $this->getResponseFactory());
 
         $reflectionProperty = $class->getProperty('errorRenderers');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $reflectionProperty->setValue($handler, $errorRenderers);
 
         $method = $class->getMethod('determineContentType');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
 
         $contentType = $method->invoke($handler, $request);
 
@@ -196,15 +196,15 @@ class ErrorHandlerTest extends TestCase
         $class = new ReflectionClass(ErrorHandler::class);
 
         $reflectionProperty = $class->getProperty('responseFactory');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $reflectionProperty->setValue($handler, $this->getResponseFactory());
 
         $reflectionProperty = $class->getProperty('errorRenderers');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $reflectionProperty->setValue($handler, $errorRenderers);
 
         $method = $class->getMethod('determineContentType');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
 
         $contentType = $method->invoke($handler, $request);
 
@@ -224,7 +224,7 @@ class ErrorHandlerTest extends TestCase
         // provide access to the determineContentType() as it's a protected method
         $class = new ReflectionClass(ErrorHandler::class);
         $method = $class->getMethod('determineContentType');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
 
         // use a mock object here as ErrorHandler cannot be directly instantiated
         $handler = $this->createMock(ErrorHandler::class);
@@ -242,7 +242,7 @@ class ErrorHandlerTest extends TestCase
 
         $reflectionClass = new ReflectionClass(ErrorHandler::class);
         $reflectionProperty = $reflectionClass->getProperty('errorRenderers');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $errorRenderers = $reflectionProperty->getValue($handler);
 
         $this->assertArrayHasKey('application/slim', $errorRenderers);
@@ -255,11 +255,11 @@ class ErrorHandlerTest extends TestCase
 
         $reflectionClass = new ReflectionClass(ErrorHandler::class);
         $reflectionProperty = $reflectionClass->getProperty('defaultErrorRenderer');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $defaultErrorRenderer = $reflectionProperty->getValue($handler);
 
         $defaultErrorRendererContentTypeProperty = $reflectionClass->getProperty('defaultErrorRendererContentType');
-        $defaultErrorRendererContentTypeProperty->setAccessible(true);
+        $this->setAccessible($defaultErrorRendererContentTypeProperty);
         $defaultErrorRendererContentType = $defaultErrorRendererContentTypeProperty->getValue($handler);
 
         $this->assertSame(PlainTextErrorRenderer::class, $defaultErrorRenderer);
@@ -396,16 +396,16 @@ class ErrorHandlerTest extends TestCase
         $handler->setLogErrorRenderer('logErrorRenderer');
 
         $displayErrorDetailsProperty = new ReflectionProperty($handler, 'displayErrorDetails');
-        $displayErrorDetailsProperty->setAccessible(true);
+        $this->setAccessible($displayErrorDetailsProperty);
         $displayErrorDetailsProperty->setValue($handler, true);
 
         $exception = new RuntimeException();
         $exceptionProperty = new ReflectionProperty($handler, 'exception');
-        $exceptionProperty->setAccessible(true);
+        $this->setAccessible($exceptionProperty);
         $exceptionProperty->setValue($handler, $exception);
 
         $writeToErrorLogMethod = new ReflectionMethod($handler, 'writeToErrorLog');
-        $writeToErrorLogMethod->setAccessible(true);
+        $this->setAccessible($writeToErrorLogMethod);
         $writeToErrorLogMethod->invoke($handler);
     }
 }

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Handlers;
 
+use Prophecy\Argument;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
@@ -392,7 +393,16 @@ class ErrorHandlerTest extends TestCase
             ->willReturn($renderer)
             ->shouldBeCalledOnce();
 
-        $handler = new ErrorHandler($callableResolverProphecy->reveal(), $this->getResponseFactory());
+        $loggerProphecy = $this->prophesize(LoggerInterface::class);
+        $loggerProphecy
+            ->error(Argument::type('string'))
+            ->shouldBeCalled();
+
+        $handler = new ErrorHandler(
+            $callableResolverProphecy->reveal(),
+            $this->getResponseFactory(),
+            $loggerProphecy->reveal()
+        );
         $handler->setLogErrorRenderer('logErrorRenderer');
 
         $displayErrorDetailsProperty = new ReflectionProperty($handler, 'displayErrorDetails');

--- a/tests/Middleware/OutputBufferingMiddlewareTest.php
+++ b/tests/Middleware/OutputBufferingMiddlewareTest.php
@@ -26,7 +26,7 @@ class OutputBufferingMiddlewareTest extends TestCase
         $middleware = new OutputBufferingMiddleware($this->getStreamFactory());
 
         $reflectionProperty = new ReflectionProperty($middleware, 'style');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $value = $reflectionProperty->getValue($middleware);
 
         $this->assertSame('append', $value);
@@ -37,7 +37,7 @@ class OutputBufferingMiddlewareTest extends TestCase
         $middleware = new OutputBufferingMiddleware($this->getStreamFactory(), 'prepend');
 
         $reflectionProperty = new ReflectionProperty($middleware, 'style');
-        $reflectionProperty->setAccessible(true);
+        $this->setAccessible($reflectionProperty);
         $value = $reflectionProperty->getValue($middleware);
 
         $this->assertSame('prepend', $value);

--- a/tests/ResponseEmitterTest.php
+++ b/tests/ResponseEmitterTest.php
@@ -280,7 +280,7 @@ class ResponseEmitterTest extends TestCase
 
         $mirror = new ReflectionClass(ResponseEmitter::class);
         $emitBodyMethod = $mirror->getMethod('emitBody');
-        $emitBodyMethod->setAccessible(true);
+        $this->setAccessible($emitBodyMethod);
         $emitBodyMethod->invoke($responseEmitter, $response);
 
         $this->expectOutputString("");

--- a/tests/Routing/DispatcherTest.php
+++ b/tests/Routing/DispatcherTest.php
@@ -34,7 +34,7 @@ class DispatcherTest extends TestCase
         $dispatcher = new Dispatcher($routeCollector);
 
         $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
 
         $this->assertInstanceOf(FastRouteDispatcher::class, $method->invoke($dispatcher));
     }
@@ -57,7 +57,7 @@ class DispatcherTest extends TestCase
         $routeCollector->setCacheFile($cacheFile);
 
         $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
         $method->invoke($dispatcher);
         $this->assertFileExists($cacheFile, 'cache file was not created');
 
@@ -66,7 +66,7 @@ class DispatcherTest extends TestCase
         $dispatcher2 = new Dispatcher($routeCollector2);
 
         $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
         $method->invoke($dispatcher2);
 
         /** @var RoutingResults $result */
@@ -88,7 +88,7 @@ class DispatcherTest extends TestCase
         $dispatcher = new Dispatcher($routeCollector);
 
         $method = new ReflectionMethod(Dispatcher::class, 'createDispatcher');
-        $method->setAccessible(true);
+        $this->setAccessible($method);
 
         $fastRouteDispatcher = $method->invoke($dispatcher);
         $fastRouteDispatcher2 = $method->invoke($dispatcher);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,6 +20,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use ReflectionMethod;
+use ReflectionProperty;
 use Slim\CallableResolver;
 use Slim\Interfaces\CallableResolverInterface;
 use Slim\MiddlewareDispatcher;
@@ -119,5 +121,16 @@ abstract class TestCase extends PhpUnitTestCase
     {
         $psr7ObjectProvider = new PSR7ObjectProvider();
         return $psr7ObjectProvider->createStream($contents);
+    }
+
+    /**
+     * @param  ReflectionProperty|ReflectionMethod  $ref
+     * @return void
+     */
+    protected function setAccessible($ref, bool $accessible = true): void
+    {
+        if (PHP_VERSION_ID < 80100) {
+            $ref->setAccessible($accessible);
+        }
     }
 }


### PR DESCRIPTION
Add PHP 8.5 to composer.json's list of allowed PHP version and to the CI matrix. As PHP 8.5 isn't out yet, we need to ignore the platform requirement for 8.5.

Fix the deprecation warnings about setAccessible and also fix a risky test.