### PR TITLE
Replace get_class() calls with ::class keyword

### DIFF
--- a/Slim/Middleware/HtmlExceptionMiddleware.php
+++ b/Slim/Middleware/HtmlExceptionMiddleware.php
@@ -55,7 +55,7 @@ final class HtmlExceptionMiddleware implements MiddlewareInterface
     {
         $html = sprintf(
             '<div><strong>Type:</strong> %s</div>',
-            $this->escapeHtml(get_class($exception)),
+            $this->escapeHtml($exception::class),
         );
 
         $code = $exception instanceof ErrorException ? $exception->getSeverity() : $exception->getCode();

--- a/Slim/Middleware/JsonExceptionMiddleware.php
+++ b/Slim/Middleware/JsonExceptionMiddleware.php
@@ -78,7 +78,7 @@ final class JsonExceptionMiddleware implements MiddlewareInterface
         $code = $exception instanceof ErrorException ? $exception->getSeverity() : $exception->getCode();
 
         return [
-            'type' => get_class($exception),
+            'type' => $exception::class,
             'code' => $code,
             'message' => $exception->getMessage(),
             'file' => $exception->getFile(),

--- a/Slim/Middleware/PlainTextExceptionMiddleware.php
+++ b/Slim/Middleware/PlainTextExceptionMiddleware.php
@@ -56,7 +56,7 @@ final class PlainTextExceptionMiddleware implements MiddlewareInterface
 
     private function formatExceptionFragment(Throwable $exception): string
     {
-        $text = sprintf("Type: %s\n", get_class($exception));
+        $text = sprintf("Type: %s\n", $exception::class);
 
         $code = $exception instanceof ErrorException ? $exception->getSeverity() : $exception->getCode();
 

--- a/Slim/Middleware/XmlExceptionMiddleware.php
+++ b/Slim/Middleware/XmlExceptionMiddleware.php
@@ -55,7 +55,7 @@ final class XmlExceptionMiddleware implements MiddlewareInterface
             do {
                 $exceptionElement = $dom->createElement('exception');
 
-                $typeElement = $dom->createElement('type', get_class($exception));
+                $typeElement = $dom->createElement('type', $exception::class);
                 $exceptionElement->appendChild($typeElement);
 
                 $code = $exception instanceof ErrorException ? $exception->getSeverity() : $exception->getCode();


### PR DESCRIPTION
Since Slim 5.x requires PHP 8.2+, we can use the `$object::class` syntax (available since PHP 8.0) instead of `get_class($object)`.

### Changes

Replaced `get_class($exception)` with `$exception::class` in 4 exception middleware files:

- `HtmlExceptionMiddleware`
- `JsonExceptionMiddleware`
- `PlainTextExceptionMiddleware`
- `XmlExceptionMiddleware`

### Why

- More concise and idiomatic for modern PHP
- Consistent with static `ClassName::class` usage
- Avoids unnecessary function call overhead
- `get_class()` without arguments is deprecated since PHP 8.3