### PR TITLE
Add Conditional Middleware Support

### DIFF
--- a/Slim/Middleware/ConditionalMiddleware.php
+++ b/Slim/Middleware/ConditionalMiddleware.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/5.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Conditional Middleware
+ *
+ * This middleware allows you to conditionally execute another middleware based on
+ * a given condition (callable). If the condition returns true, the wrapped middleware
+ * is executed. If it returns false, the request is passed directly to the next handler.
+ *
+ * This is useful for applying middleware only to certain routes, methods, or based
+ * on request attributes without having to duplicate middleware logic.
+ *
+ * @api
+ */
+class ConditionalMiddleware implements MiddlewareInterface
+{
+    /**
+     * The middleware to conditionally execute
+     *
+     * @var MiddlewareInterface
+     */
+    protected MiddlewareInterface $middleware;
+
+    /**
+     * The condition callable
+     *
+     * @var callable
+     */
+    protected $condition;
+
+    /**
+     * Constructor
+     *
+     * @param MiddlewareInterface $middleware The middleware to wrap
+     * @param callable $condition A callable that receives ServerRequestInterface and returns bool.
+     *                            Return true to execute middleware, false to skip it.
+     */
+    public function __construct(MiddlewareInterface $middleware, callable $condition)
+    {
+        $this->middleware = $middleware;
+        $this->condition = $condition;
+    }
+
+    /**
+     * Process the request through conditional middleware
+     *
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        // Call the condition with the request
+        if (call_user_func($this->condition, $request)) {
+            // Condition returned true, execute the wrapped middleware
+            return $this->middleware->process($request, $handler);
+        }
+
+        // Condition returned false, skip the middleware and pass to next handler
+        return $handler->handle($request);
+    }
+
+    /**
+     * Create a conditional middleware that only executes for specific paths
+     *
+     * @param MiddlewareInterface $middleware
+     * @param string $pathPrefix Path prefix to match (e.g., '/admin')
+     * @return self
+     */
+    public static function forPath(MiddlewareInterface $middleware, string $pathPrefix): self
+    {
+        return new self(
+            $middleware,
+            fn(ServerRequestInterface $request) => str_starts_with($request->getUri()->getPath(), $pathPrefix)
+        );
+    }
+
+    /**
+     * Create a conditional middleware that only executes for specific HTTP methods
+     *
+     * @param MiddlewareInterface $middleware
+     * @param string[] $methods HTTP methods to match (e.g., ['POST', 'PUT', 'DELETE'])
+     * @return self
+     */
+    public static function forMethods(MiddlewareInterface $middleware, array $methods): self
+    {
+        $methods = array_map('strtoupper', $methods);
+        return new self(
+            $middleware,
+            fn(ServerRequestInterface $request) => in_array($request->getMethod(), $methods, true)
+        );
+    }
+
+    /**
+     * Create a conditional middleware that only executes for specific paths AND methods
+     *
+     * @param MiddlewareInterface $middleware
+     * @param string $pathPrefix Path prefix to match (e.g., '/api')
+     * @param string[] $methods HTTP methods to match (e.g., ['POST', 'PUT'])
+     * @return self
+     */
+    public static function forPathAndMethods(
+        MiddlewareInterface $middleware,
+        string $pathPrefix,
+        array $methods
+    ): self {
+        $methods = array_map('strtoupper', $methods);
+        return new self(
+            $middleware,
+            fn(ServerRequestInterface $request) =>
+            str_starts_with($request->getUri()->getPath(), $pathPrefix) &&
+                in_array($request->getMethod(), $methods, true)
+        );
+    }
+}

--- a/tests/Middleware/ConditionalMiddlewareTest.php
+++ b/tests/Middleware/ConditionalMiddlewareTest.php
@@ -1,0 +1,508 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/5.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Slim\Factory\AppFactory;
+use Slim\Middleware\ConditionalMiddleware;
+
+final class ConditionalMiddlewareTest extends TestCase
+{
+    /**
+     * Test that middleware executes when condition returns true
+     */
+    public function testMiddlewareExecutesWhenConditionTrue(): void
+    {
+        $app = AppFactory::create();
+
+        $middlewareCalled = false;
+
+        // Add conditional middleware that always executes (condition = true)
+        $app->add(new ConditionalMiddleware(
+            new class($middlewareCalled) implements \Psr\Http\Server\MiddlewareInterface {
+                public function __construct(private bool &$called) {}
+
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $this->called = true;
+                    $response = $handler->handle($request);
+                    $response->getBody()->write('|middleware');
+                    return $response;
+                }
+            },
+            fn(ServerRequestInterface $request): bool => true
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->get('/test', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('Route');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('GET', '/test');
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($middlewareCalled);
+        $this->assertSame('Route|middleware', (string)$response->getBody());
+    }
+
+    /**
+     * Test that middleware is skipped when condition returns false
+     */
+    public function testMiddlewareSkippedWhenConditionFalse(): void
+    {
+        $app = AppFactory::create();
+
+        $middlewareCalled = false;
+
+        // Add conditional middleware that never executes (condition = false)
+        $app->add(new ConditionalMiddleware(
+            new class($middlewareCalled) implements \Psr\Http\Server\MiddlewareInterface {
+                public function __construct(private bool &$called) {}
+
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $this->called = true;
+                    $response = $handler->handle($request);
+                    $response->getBody()->write('|middleware');
+                    return $response;
+                }
+            },
+            fn(ServerRequestInterface $request): bool => false
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->get('/test', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('Route');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('GET', '/test');
+
+        $response = $app->handle($request);
+
+        $this->assertFalse($middlewareCalled);
+        $this->assertSame('Route', (string)$response->getBody());
+    }
+
+    /**
+     * Test path-based conditional middleware with matching path
+     */
+    public function testForPathConditionMatches(): void
+    {
+        $app = AppFactory::create();
+
+        $middlewareCalled = false;
+
+        // Add conditional middleware that executes only for /admin paths
+        $app->add(ConditionalMiddleware::forPath(
+            new class($middlewareCalled) implements \Psr\Http\Server\MiddlewareInterface {
+                public function __construct(private bool &$called) {}
+
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $this->called = true;
+                    $response = $handler->handle($request);
+                    $response->getBody()->write('|admin-middleware');
+                    return $response;
+                }
+            },
+            '/admin'
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->get('/admin/dashboard', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('Admin Dashboard');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('GET', '/admin/dashboard');
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($middlewareCalled);
+        $this->assertSame('Admin Dashboard|admin-middleware', (string)$response->getBody());
+    }
+
+    /**
+     * Test path-based conditional middleware with non-matching path
+     */
+    public function testForPathConditionDoesNotMatch(): void
+    {
+        $app = AppFactory::create();
+
+        $middlewareCalled = false;
+
+        // Add conditional middleware that executes only for /admin paths
+        $app->add(ConditionalMiddleware::forPath(
+            new class($middlewareCalled) implements \Psr\Http\Server\MiddlewareInterface {
+                public function __construct(private bool &$called) {}
+
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $this->called = true;
+                    $response = $handler->handle($request);
+                    $response->getBody()->write('|admin-middleware');
+                    return $response;
+                }
+            },
+            '/admin'
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->get('/public/page', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('Public Page');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('GET', '/public/page');
+
+        $response = $app->handle($request);
+
+        $this->assertFalse($middlewareCalled);
+        $this->assertSame('Public Page', (string)$response->getBody());
+    }
+
+    /**
+     * Test HTTP method-based conditional middleware with matching method
+     */
+    public function testForMethodsConditionMatches(): void
+    {
+        $app = AppFactory::create();
+
+        $middlewareCalled = false;
+
+        // Add conditional middleware that executes only for POST/PUT/DELETE
+        $app->add(ConditionalMiddleware::forMethods(
+            new class($middlewareCalled) implements \Psr\Http\Server\MiddlewareInterface {
+                public function __construct(private bool &$called) {}
+
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $this->called = true;
+                    $response = $handler->handle($request);
+                    $response->getBody()->write('|csrf-middleware');
+                    return $response;
+                }
+            },
+            ['POST', 'PUT', 'DELETE']
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->post('/api/users', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('User Created');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('POST', '/api/users');
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($middlewareCalled);
+        $this->assertSame('User Created|csrf-middleware', (string)$response->getBody());
+    }
+
+    /**
+     * Test HTTP method-based conditional middleware with non-matching method
+     */
+    public function testForMethodsConditionDoesNotMatch(): void
+    {
+        $app = AppFactory::create();
+
+        $middlewareCalled = false;
+
+        // Add conditional middleware that executes only for POST/PUT/DELETE
+        $app->add(ConditionalMiddleware::forMethods(
+            new class($middlewareCalled) implements \Psr\Http\Server\MiddlewareInterface {
+                public function __construct(private bool &$called) {}
+
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $this->called = true;
+                    $response = $handler->handle($request);
+                    $response->getBody()->write('|csrf-middleware');
+                    return $response;
+                }
+            },
+            ['POST', 'PUT', 'DELETE']
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->get('/api/users', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('Users List');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('GET', '/api/users');
+
+        $response = $app->handle($request);
+
+        $this->assertFalse($middlewareCalled);
+        $this->assertSame('Users List', (string)$response->getBody());
+    }
+
+    /**
+     * Test path and method-based conditional middleware with matching conditions
+     */
+    public function testForPathAndMethodsConditionMatches(): void
+    {
+        $app = AppFactory::create();
+
+        $middlewareCalled = false;
+
+        // Add conditional middleware that executes only for POST/PUT to /api paths
+        $app->add(ConditionalMiddleware::forPathAndMethods(
+            new class($middlewareCalled) implements \Psr\Http\Server\MiddlewareInterface {
+                public function __construct(private bool &$called) {}
+
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $this->called = true;
+                    $response = $handler->handle($request);
+                    $response->getBody()->write('|validation-middleware');
+                    return $response;
+                }
+            },
+            '/api',
+            ['POST', 'PUT']
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->post('/api/users', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('User Created');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('POST', '/api/users');
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($middlewareCalled);
+        $this->assertSame('User Created|validation-middleware', (string)$response->getBody());
+    }
+
+    /**
+     * Test path and method-based conditional middleware with non-matching method
+     */
+    public function testForPathAndMethodsConditionFailsWithNonMatchingMethod(): void
+    {
+        $app = AppFactory::create();
+
+        $middlewareCalled = false;
+
+        // Add conditional middleware that executes only for POST/PUT to /api paths
+        $app->add(ConditionalMiddleware::forPathAndMethods(
+            new class($middlewareCalled) implements \Psr\Http\Server\MiddlewareInterface {
+                public function __construct(private bool &$called) {}
+
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $this->called = true;
+                    $response = $handler->handle($request);
+                    $response->getBody()->write('|validation-middleware');
+                    return $response;
+                }
+            },
+            '/api',
+            ['POST', 'PUT']
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->get('/api/users', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('Users List');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('GET', '/api/users');
+
+        $response = $app->handle($request);
+
+        $this->assertFalse($middlewareCalled);
+        $this->assertSame('Users List', (string)$response->getBody());
+    }
+
+    /**
+     * Test path and method-based conditional middleware with non-matching path
+     */
+    public function testForPathAndMethodsConditionFailsWithNonMatchingPath(): void
+    {
+        $app = AppFactory::create();
+
+        $middlewareCalled = false;
+
+        // Add conditional middleware that executes only for POST/PUT to /api paths
+        $app->add(ConditionalMiddleware::forPathAndMethods(
+            new class($middlewareCalled) implements \Psr\Http\Server\MiddlewareInterface {
+                public function __construct(private bool &$called) {}
+
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $this->called = true;
+                    $response = $handler->handle($request);
+                    $response->getBody()->write('|validation-middleware');
+                    return $response;
+                }
+            },
+            '/api',
+            ['POST', 'PUT']
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->post('/public/users', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('Public Creation');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('POST', '/public/users');
+
+        $response = $app->handle($request);
+
+        $this->assertFalse($middlewareCalled);
+        $this->assertSame('Public Creation', (string)$response->getBody());
+    }
+
+    /**
+     * Test custom condition with complex logic
+     */
+    public function testCustomConditionWithComplexLogic(): void
+    {
+        $app = AppFactory::create();
+
+        $middlewareCalled = false;
+
+        // Add conditional middleware with complex condition logic
+        $app->add(new ConditionalMiddleware(
+            new class($middlewareCalled) implements \Psr\Http\Server\MiddlewareInterface {
+                public function __construct(private bool &$called) {}
+
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $this->called = true;
+                    $response = $handler->handle($request);
+                    $response->getBody()->write('|auth-middleware');
+                    return $response;
+                }
+            },
+            function (ServerRequestInterface $request): bool {
+                // Only execute for POST/PUT requests to /api with JSON content-type
+                return in_array($request->getMethod(), ['POST', 'PUT'], true)
+                    && str_starts_with($request->getUri()->getPath(), '/api')
+                    && $request->getHeaderLine('Content-Type') === 'application/json';
+            }
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->post('/api/users', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('User Created');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('POST', '/api/users')
+            ->withHeader('Content-Type', 'application/json');
+
+        $response = $app->handle($request);
+
+        $this->assertTrue($middlewareCalled);
+        $this->assertSame('User Created|auth-middleware', (string)$response->getBody());
+    }
+
+    /**
+     * Test that middleware response headers are preserved
+     */
+    public function testMiddlewareCanAddHeaders(): void
+    {
+        $app = AppFactory::create();
+
+        // Add conditional middleware that adds headers
+        $app->add(new ConditionalMiddleware(
+            new class implements \Psr\Http\Server\MiddlewareInterface {
+                public function process(
+                    ServerRequestInterface $request,
+                    \Psr\Http\Server\RequestHandlerInterface $handler
+                ): ResponseInterface {
+                    $response = $handler->handle($request);
+                    return $response->withHeader('X-Middleware', 'Conditional');
+                }
+            },
+            fn(ServerRequestInterface $request): bool => true
+        ));
+
+        $app->addRoutingMiddleware();
+
+        $app->get('/test', function (ServerRequestInterface $request, ResponseInterface $response) {
+            $response->getBody()->write('Test');
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('GET', '/test');
+
+        $response = $app->handle($request);
+
+        $this->assertSame('Conditional', $response->getHeaderLine('X-Middleware'));
+        $this->assertSame('Test', (string)$response->getBody());
+    }
+}


### PR DESCRIPTION
Added Conditional Middleware, a new PSR-15 compliant middleware that enables conditional execution of middleware based on request properties. 

**Use Cases**
1. Path-based Middleware Application
```php
// Authentication only for admin routes
$app->add(
    ConditionalMiddleware::forPath($authMiddleware, '/admin')
);
```
2. Method-based Middleware Application
```php
// CSRF protection only for state-changing methods
$app->add(
    ConditionalMiddleware::forMethods($csrfMiddleware, ['POST', 'PUT', 'PATCH', 'DELETE'])
);
```
3. Combined Conditions
```php
// Rate limiting only for API POST/PUT requests
$app->add(
    ConditionalMiddleware::forPathAndMethods(
        $rateLimitMiddleware,
        '/api',
        ['POST', 'PUT']
    )
);
```
4. Attribute-based Conditions
```php
// Audit logging only for authenticated users
$app->add(
    new ConditionalMiddleware(
        $auditMiddleware,
        fn($request) => $request->getAttribute('user') !== null
    )
);
```
5. Complex Business Logic
```php
// Apply middleware based on multiple criteria
$app->add(
    new ConditionalMiddleware(
        $specialMiddleware,
        fn($request) => 
            $request->getAttribute('subscription') === 'premium' &&
            !str_starts_with($request->getUri()->getPath(), '/public')
    )
);
```