### PR TITLE
Ensure that Nyholm PSR17 factory is fully available

### DIFF
--- a/Slim/Factory/Psr17/NyholmPsr17Factory.php
+++ b/Slim/Factory/Psr17/NyholmPsr17Factory.php
@@ -33,4 +33,15 @@ class NyholmPsr17Factory extends Psr17Factory
 
         return new ServerRequestCreator($serverRequestCreator, static::$serverRequestCreatorMethod);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function isServerRequestCreatorAvailable(): bool
+    {
+        return (
+            parent::isServerRequestCreatorAvailable()
+            && class_exists(static::$responseFactoryClass)
+        );
+    }
 }


### PR DESCRIPTION
We currently use Guzzle for PSR17/PSR7.

We're also now adding in open-telemetry (`open-telemetry/exporter-otlp`), which makes use of `nyholm/psr7-server`, but it does not depend on `nyholm/psr7`.

As a result we now have the Nyholm server request creator, but not the response Factory class.

`\Slim\Factory\Psr17\Psr17Factory::isServerRequestCreatorAvailable()` returns a truthy value for Nyholm, but when `getServerRequestCreator()` is called, it errors out.

The Nyholm PSR7 packages are split into a server package, and a client package. Both are required for the NyholmPsr17Factory to be able to return an instance of the `ServerRequestCreator` class.

This change amends the `NyholmPsr17Factory:: isServerRequestCreatorAvailable()` method to also check if the response factory class provided by the client package is available.

I can't think of a way of testing this with automated testing. For manual testing you can install `nyholm/psr7-server` without `nyholm/psr7` -- before this change we were hitting an exception.