### PR TITLE
Extend RouteCollectorProxy::redirect() to serve non-GET requests too

### DIFF
--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -120,7 +120,10 @@ interface RouteCollectorProxyInterface
     /**
      * Add a route that sends an HTTP redirect
      *
-     * @param string|UriInterface $to
+     * @param string $from The route URI pattern
+     * @param string|UriInterface $to The redirect URI
+     * @param int $status The HTTP status code
+     * @param string[] $methods Numeric array of HTTP methods
      */
-    public function redirect(string $from, $to, int $status = 302): RouteInterface;
+    public function redirect(string $from, $to, int $status = 302, array $methods = ['GET']): RouteInterface;
 }

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -182,7 +182,7 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
-    public function redirect(string $from, $to, int $status = 302): RouteInterface
+    public function redirect(string $from, $to, int $status = 302, array $methods = ['GET']): RouteInterface
     {
         $responseFactory = $this->responseFactory;
 
@@ -191,6 +191,6 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
             return $response->withHeader('Location', (string) $to);
         };
 
-        return $this->get($from, $handler);
+        return $this->map($methods, $from, $handler);
     }
 }


### PR DESCRIPTION
While `RouteCollectorProxy::redirect()` is quite handy and useful, it only works for GET requests.  Therefore I propose to extend it by another argument to set the accepted HTTP methods.  Its default value should be `['GET']` so that legacy code can run unchanged.  Then it would be possible to also use it like that:
```php
$app->redirect('/books', '/library', 307, ['POST']);
```
