### PR TITLE
Add BasePathMiddleware for subdirectory deployments

### DIFF
--- a/Slim/Middleware/BasePathMiddleware.php
+++ b/Slim/Middleware/BasePathMiddleware.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use function array_pop;
+use function dirname;
+use function end;
+use function explode;
+use function implode;
+use function is_string;
+use function ltrim;
+use function rtrim;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+/**
+ * Middleware to handle applications running in a subdirectory.
+ *
+ * Strips the base path from the request URI so routes can be defined
+ * without the base path prefix.
+ *
+ * @package Slim\Middleware
+ * @api
+ */
+class BasePathMiddleware implements MiddlewareInterface
+{
+    /**
+     * @var string The base path to strip (e.g., '/myapp')
+     */
+    private string $basePath;
+
+    /**
+     * @param string $basePath The base path to strip (e.g., '/myapp')
+     */
+    public function __construct(string $basePath = '')
+    {
+        $this->basePath = rtrim($basePath, '/');
+    }
+
+    /**
+     * Create middleware with auto-detected base path from request server params.
+     *
+     * Detects the base path from SCRIPT_NAME server parameter.
+     * If SCRIPT_NAME points to /public/index.php, it strips the /public part.
+     *
+     * @param ServerRequestInterface $request The request to detect base path from
+     * @return self
+     */
+    public static function fromRequest(ServerRequestInterface $request): self
+    {
+        $serverParams = $request->getServerParams();
+        $scriptName = $serverParams['SCRIPT_NAME'] ?? '';
+
+        if (!is_string($scriptName) || $scriptName === '') {
+            return new self('');
+        }
+
+        // Get the directory of the script
+        $basePath = rtrim(dirname($scriptName), '/');
+
+        // If the script is in /public directory, strip it
+        if (str_starts_with($basePath, '/')) {
+            $parts = explode('/', $basePath);
+            if (end($parts) === 'public') {
+                array_pop($parts);
+                $basePath = implode('/', $parts);
+            }
+        }
+
+        return new self($basePath);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    #[\Override]
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        // If base path is empty, skip processing
+        if ($this->basePath === '') {
+            return $handler->handle($request);
+        }
+
+        $uri = $request->getUri();
+        $path = $uri->getPath();
+
+        // If base path doesn't match, skip
+        if (!str_starts_with($path, $this->basePath . '/')) {
+            // Special case: exact match on base path (e.g., /myapp -> /)
+            if ($path !== $this->basePath) {
+                return $handler->handle($request);
+            }
+        }
+
+        // Strip the base path
+        $newPath = (string) substr($path, strlen($this->basePath));
+
+        // Ensure path starts with /
+        if ($newPath === '' || !str_starts_with($newPath, '/')) {
+            $newPath = '/' . ltrim($newPath, '/');
+        }
+
+        // Create new request with modified URI
+        $newUri = $uri->withPath($newPath);
+        $request = $request->withUri($newUri);
+
+        // Store original base path in attribute (useful for URL generation)
+        $request = $request->withAttribute('basePath', $this->basePath);
+
+        return $handler->handle($request);
+    }
+}

--- a/tests/Middleware/BasePathMiddlewareTest.php
+++ b/tests/Middleware/BasePathMiddlewareTest.php
@@ -1,0 +1,293 @@
+<?php
+
+/**
+ * Slim Framework (https://slimframework.com)
+ *
+ * @license https://github.com/slimphp/Slim/blob/4.x/LICENSE.md (MIT License)
+ */
+
+declare(strict_types=1);
+
+namespace Slim\Tests\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Middleware\BasePathMiddleware;
+use Slim\Tests\TestCase;
+
+class BasePathMiddlewareTest extends TestCase
+{
+    /**
+     * Create a request handler that captures the request for inspection.
+     */
+    protected function createRequestHandler(): RequestHandlerInterface
+    {
+        $response = $this->createResponse();
+        return new class ($response) implements RequestHandlerInterface {
+            private ResponseInterface $response;
+            public ?ServerRequestInterface $receivedRequest = null;
+
+            public function __construct(ResponseInterface $response)
+            {
+                $this->response = $response;
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->receivedRequest = $request;
+                return $this->response;
+            }
+        };
+    }
+
+    /**
+     * Create a request with specific server params.
+     *
+     * @param string $uri The request URI
+     * @param array<string, string> $serverParams Additional server params
+     * @return ServerRequestInterface
+     */
+    protected function createRequestWithServerParams(string $uri, array $serverParams = []): ServerRequestInterface
+    {
+        return $this->createServerRequest($uri, 'GET', $serverParams);
+    }
+
+    public function testStripsBasePath(): void
+    {
+        $middleware = new BasePathMiddleware('/myapp');
+        $request = $this->createServerRequest('/myapp/api/users');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testAddsBasePathAttribute(): void
+    {
+        $middleware = new BasePathMiddleware('/myapp');
+        $request = $this->createServerRequest('/myapp/api/users');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/myapp', $handler->receivedRequest->getAttribute('basePath'));
+    }
+
+    public function testSkipsWhenNoMatch(): void
+    {
+        $middleware = new BasePathMiddleware('/other');
+        $request = $this->createServerRequest('/myapp/api/users');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/myapp/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testSkipsWhenBasePathEmpty(): void
+    {
+        $middleware = new BasePathMiddleware('');
+        $request = $this->createServerRequest('/api/users');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+        $this->assertNull($handler->receivedRequest->getAttribute('basePath'));
+    }
+
+    public function testHandlesRootPath(): void
+    {
+        $middleware = new BasePathMiddleware('/myapp');
+        $request = $this->createServerRequest('/myapp');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testHandlesRootPathWithTrailingSlash(): void
+    {
+        $middleware = new BasePathMiddleware('/myapp');
+        $request = $this->createServerRequest('/myapp/');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testHandlesTrailingSlashInBasePath(): void
+    {
+        $middleware = new BasePathMiddleware('/myapp/');
+        $request = $this->createServerRequest('/myapp/api/users');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testPreservesQueryString(): void
+    {
+        $middleware = new BasePathMiddleware('/myapp');
+        $request = $this->createServerRequest('/myapp/api/users?page=2&limit=10');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+        $this->assertEquals('page=2&limit=10', $handler->receivedRequest->getUri()->getQuery());
+    }
+
+    public function testHandlesNestedPath(): void
+    {
+        $middleware = new BasePathMiddleware('/myapp/v2');
+        $request = $this->createServerRequest('/myapp/v2/api/users');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testHandlesPartialMatchInPathSegment(): void
+    {
+        // /myapp2 should NOT match /myapp
+        $middleware = new BasePathMiddleware('/myapp');
+        $request = $this->createServerRequest('/myapp2/api/users');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        // Path should remain unchanged since /myapp2 != /myapp
+        $this->assertEquals('/myapp2/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testFromRequestAutoDetectsBasePath(): void
+    {
+        $request = $this->createRequestWithServerParams(
+            '/myapp/api/users',
+            ['SCRIPT_NAME' => '/myapp/public/index.php']
+        );
+
+        $middleware = BasePathMiddleware::fromRequest($request);
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testFromRequestWithScriptInRoot(): void
+    {
+        $request = $this->createRequestWithServerParams(
+            '/api/users',
+            ['SCRIPT_NAME' => '/index.php']
+        );
+
+        $middleware = BasePathMiddleware::fromRequest($request);
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testFromRequestWithEmptyScriptName(): void
+    {
+        $request = $this->createRequestWithServerParams(
+            '/api/users',
+            ['SCRIPT_NAME' => '']
+        );
+
+        $middleware = BasePathMiddleware::fromRequest($request);
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testFromRequestWithNoScriptNameParam(): void
+    {
+        $request = $this->createRequestWithServerParams('/api/users');
+
+        $middleware = BasePathMiddleware::fromRequest($request);
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testFromRequestKeepsPublicDirectoryIfNotAtEnd(): void
+    {
+        // /public/app should NOT strip /public
+        $request = $this->createRequestWithServerParams(
+            '/public/app/api/users',
+            ['SCRIPT_NAME' => '/public/app/index.php']
+        );
+
+        $middleware = BasePathMiddleware::fromRequest($request);
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testFromRequestWithNestedPublicPath(): void
+    {
+        $request = $this->createRequestWithServerParams(
+            '/myapp/public/api/users',
+            ['SCRIPT_NAME' => '/myapp/public/public/index.php']
+        );
+
+        $middleware = BasePathMiddleware::fromRequest($request);
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        // Only strips the last /public
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testAttributeNotSetWhenNoMatch(): void
+    {
+        $middleware = new BasePathMiddleware('/other');
+        $request = $this->createServerRequest('/myapp/api/users');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertNull($handler->receivedRequest->getAttribute('basePath'));
+    }
+
+    public function testHandlesSingleCharacterBasePath(): void
+    {
+        $middleware = new BasePathMiddleware('/a');
+        $request = $this->createServerRequest('/a/b');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/b', $handler->receivedRequest->getUri()->getPath());
+    }
+
+    public function testPreservesFragment(): void
+    {
+        $middleware = new BasePathMiddleware('/myapp');
+        $request = $this->createServerRequest('/myapp/api/users#section');
+        $handler = $this->createRequestHandler();
+
+        $middleware->process($request, $handler);
+
+        $this->assertEquals('/api/users', $handler->receivedRequest->getUri()->getPath());
+        // Note: Fragment is typically not sent by browsers in HTTP requests,
+        // but we should ensure the URI object preserves it if present
+    }
+}


### PR DESCRIPTION
This PR adds a new `BasePathMiddleware` that automatically strips the base path from request URIs, allowing Slim applications to run in subdirectories without modifying route definitions.

---

## 🎯 Problem Statement

### Typical Scenario:
```apache
# Apache configuration with Alias
Alias /myapp /var/www/myapp/public
```

```php
// Route is defined as:
$app->get('/api/users', function ($request, $response) {
    return $response->withJson(['users' => []]);
});

// But request comes to:
// GET /myapp/api/users

// Result: ❌ 404 Not Found
// Slim looks for exact match with /myapp/api/users
// But route is defined as /api/users
```

### Current workarounds are inelegant:
- Manual path stripping before adding to Slim
- `.htaccess` hacks that don't work on all servers
- Defining routes with variable prefix: `$app->get($basePath . '/api/users', ...)`

---

## 💡 Solution

`BasePathMiddleware` strips the base path before the request reaches the router:

```
Request: GET /myapp/api/users
    ↓
BasePathMiddleware (/myapp)
    ↓
Slim Router sees: /api/users ✅
    ↓
Route match: /api/users → 200 OK
```

---

## 🚀 Usage

### Option 1: Explicit Base Path

When you know the exact base path:

```php
<?php
// index.php

use Slim\Factory\AppFactory;
use Slim\Middleware\BasePathMiddleware;

$app = AppFactory::create();

// Add the middleware first in the stack!
$app->add(new BasePathMiddleware('/myapp'));

// Now routes work without prefix
$app->get('/api/users', function ($request, $response) {
    return $response->withJson(['users' => []]);
});

$app->run();
```

**Apache configuration:**
```apache
Alias /myapp /var/www/html/myapp/public
<Directory /var/www/html/myapp/public>
    AllowOverride All
    Require all granted
    
    <IfModule mod_rewrite.c>
        RewriteEngine On
        RewriteCond %{REQUEST_FILENAME} !-f
        RewriteCond %{REQUEST_FILENAME} !-d
        RewriteRule ^ index.php [QSA,L]
    </IfModule>
</Directory>
```

---

### Option 2: Auto-Detection

When base path varies (dev vs production):

```php
<?php
// index.php

use Slim\Middleware\BasePathMiddleware;

$app = AppFactory::create();

// Auto-detect from $_SERVER['SCRIPT_NAME']
// If it's /myapp/public/index.php → /myapp
$app->add(BasePathMiddleware::fromRequest($request));

$app->get('/api/users', ...);
$app->run();
```

---

### Option 3: Environment Variable

```php
$app->add(new BasePathMiddleware($_ENV['APP_BASE_PATH'] ?? ''));
```

---

## 🎁 Additional Features

### Access Base Path in Routes

The middleware stores the original base path in request attributes:

```php
$app->get('/api/users', function ($request, $response) {
    $basePath = $request->getAttribute('basePath'); // '/myapp'
    
    // Useful for URL generation
    $url = $basePath . '/api/users/123';
    
    return $response->withJson([
        'basePath' => $basePath,
        'url' => $url
    ]);
});
```

---

## 🧪 Deployment Examples

### Shared Hosting (cPanel, etc.)

```php
// If application is in /public_html/myapp/
$app->add(new BasePathMiddleware('/myapp'));
```

### Docker with Subdirectory

```yaml
# docker-compose.yml
nginx:
  image: nginx:alpine
  volumes:
    - ./nginx.conf:/etc/nginx/conf.d/default.conf
```

```nginx
# nginx.conf
location /api/ {
    alias /var/www/public/;
    try_files $uri $uri/ /index.php?$query_string;
    
    location ~ \.php$ {
        fastcgi_pass php:9000;
        fastcgi_param SCRIPT_FILENAME $request_filename;
        include fastcgi_params;
    }
}
```

```php
// index.php
$app->add(new BasePathMiddleware('/api'));
```

### Multi-tenant Application

```php
// For /client1/ prefix
$app->add(new BasePathMiddleware('/client1'));

// All routes are accessible at /client1/api/...
```



---

## 🔄 Backwards Compatibility

- ✅ **Fully backwards compatible**
- ✅ No breaking changes
- ✅ Optional middleware
- ✅ Doesn't affect existing routes

---

## 🧪 Testing

### Unit Tests
```bash
vendor/bin/phpunit tests/Middleware/BasePathMiddlewareTest.php
```

### Integration Testing
```bash
# Apache configuration for testing
Alias /testapp /path/to/test/public

# Start application
php -S localhost:8080 -t public/

# Test
curl http://localhost:8080/testapp/api/users
```

---
## 🎯 Goal of This PR

The goal of this PR is to:

1. **Simplify deployment** in subdirectory environments
2. **Lower barrier** for using Slim on shared hosting
3. **Standardize** a solution for the most common 404 error problem
4. **Enable** clean route definitions without hardcoded prefixes
---

## 🙏 Thank You

Hope this middleware helps the Slim community simplify their deployments! 🚀
