### PR TITLE
Clean up routing middleware

### DIFF
--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -63,14 +63,14 @@ interface RouteInterface
     /**
      * Get route arguments.
      *
-     * @return array<string, mixed>
+     * @return array<string, string>
      */
     public function getArguments(): array;
 
     /**
      * Set route arguments.
      *
-     * @param array<string,mixed> $arguments The arguments.
+     * @param array<string,string> $arguments The arguments.
      *
      * @return RouteInterface
      */

--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -63,7 +63,7 @@ interface RouteInterface
     /**
      * Get route arguments.
      *
-     * @return array<string, string>
+     * @return array<string, mixed>
      */
     public function getArguments(): array;
 

--- a/Slim/Middleware/BasePathMiddleware.php
+++ b/Slim/Middleware/BasePathMiddleware.php
@@ -45,8 +45,6 @@ final class BasePathMiddleware implements MiddlewareInterface
             $basePath = $this->getBasePathByRequestUri($request);
         }
 
-        // $request = $request->withAttribute(RouteMatch::BASE_PATH_ATTRIBUTE, $basePath);
-
         $this->router->setBasePath($basePath);
 
         return $handler->handle($request);

--- a/Slim/Middleware/RoutingMiddleware.php
+++ b/Slim/Middleware/RoutingMiddleware.php
@@ -42,14 +42,14 @@ final class RoutingMiddleware implements MiddlewareInterface
     {
         $requestPath = $request->getUri()->getPath();
         $basePath = $this->router->getBasePath();
-        $dispatchPath = $this->stripBasePath($requestPath, $this->router->getBasePath());
+        $dispatchPath = $this->stripBasePath($requestPath, $basePath);
 
         $routingResult = $this->dispatcher->dispatch(
             $request->getMethod(),
             rawurldecode($dispatchPath)
         );
 
-        $routeMatch = $this->createRouteMatch($routingResult, $basePath);
+        $routeMatch = $this->createRouteMatch($routingResult);
         $request = $request->withAttribute(RouteMatch::class, $routeMatch);
 
         return $handler->handle($request);
@@ -58,7 +58,7 @@ final class RoutingMiddleware implements MiddlewareInterface
     /**
      * @param array<int, mixed> $routingResult
      */
-    private function createRouteMatch(array $routingResult, string $basePath): RouteMatch
+    private function createRouteMatch(array $routingResult): RouteMatch
     {
         $status = $routingResult[0] ?? null;
 

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -11,6 +11,8 @@ namespace Slim\Routing;
 use Slim\Interfaces\MiddlewareCollectionInterface;
 use Slim\Interfaces\RouteInterface;
 
+use function array_key_exists;
+
 final class Route implements RouteInterface, MiddlewareCollectionInterface
 {
     use MiddlewareCollectionTrait;

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -45,7 +45,7 @@ final class Route implements RouteInterface, MiddlewareCollectionInterface
      *
      * @var array<string, string>
      */
-    private array $arguments;
+    private array $arguments = [];
 
     /**
      * @param array<string> $methods

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -13,11 +13,14 @@ namespace Slim\Tests\Middleware;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use RuntimeException;
 use Slim\Exception\HttpMethodNotAllowedException;
 use Slim\Exception\HttpNotFoundException;
 use Slim\Factory\AppFactory;
 use Slim\Interfaces\DispatcherInterface;
+use Slim\Interfaces\RouterInterface;
 use Slim\Interfaces\UrlGeneratorInterface;
 use Slim\Middleware\EndpointMiddleware;
 use Slim\Middleware\JsonBodyParserMiddleware;
@@ -193,5 +196,42 @@ final class RoutingMiddlewareTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('/api/users/123?page=2', $response->getHeaderLine('X-relativeUrlFor'));
         $this->assertSame('/api/users/123?page=2', $response->getHeaderLine('X-fullUrlFor'));
+    }
+
+    public function testMethodNotAllowedThrowsRuntimeExceptionWhenAllowedMethodsPayloadIsInvalid(): void
+    {
+        $dispatcher = $this->createMock(DispatcherInterface::class);
+        $dispatcher
+            ->method('dispatch')
+            ->willReturn([
+                DispatcherInterface::METHOD_NOT_ALLOWED,
+                'GET',
+            ]);
+
+        $router = $this->createMock(RouterInterface::class);
+        $router
+            ->method('getBasePath')
+            ->willReturn('');
+
+        $middleware = new RoutingMiddleware($dispatcher, $router);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $uri = $this->createMock(UriInterface::class);
+        $uri
+            ->method('getPath')
+            ->willReturn('/hello/foo');
+        $request
+            ->method('getUri')
+            ->willReturn($uri);
+        $request
+            ->method('getMethod')
+            ->willReturn('GET');
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Dispatcher returned invalid allowed methods.');
+
+        $middleware->process($request, $handler);
     }
 }

--- a/tests/Middleware/RoutingMiddlewareTest.php
+++ b/tests/Middleware/RoutingMiddlewareTest.php
@@ -23,7 +23,6 @@ use Slim\Middleware\EndpointMiddleware;
 use Slim\Middleware\JsonBodyParserMiddleware;
 use Slim\Middleware\RoutingMiddleware;
 use Slim\Routing\RouteMatch;
-use Slim\Routing\RoutingResults;
 use Slim\Tests\Traits\AppTestTrait;
 
 final class RoutingMiddlewareTest extends TestCase
@@ -97,7 +96,7 @@ final class RoutingMiddlewareTest extends TestCase
             } catch (HttpMethodNotAllowedException $exception) {
                 $request = $exception->getRequest();
 
-                // routingResults is available
+                // RouteMatch is available
                 /** @var RouteMatch $routeMatch */
                 $routeMatch = $request->getAttribute(RouteMatch::class);
                 $test->assertSame(DispatcherInterface::METHOD_NOT_ALLOWED, $routeMatch->getStatus());
@@ -140,7 +139,7 @@ final class RoutingMiddlewareTest extends TestCase
             } catch (HttpNotFoundException $exception) {
                 $request = $exception->getRequest();
 
-                // routingResults is available
+                // RouteMatch is available
                 $routeMatch = $request->getAttribute(RouteMatch::class);
                 $test->assertSame(DispatcherInterface::NOT_FOUND, $routeMatch->getStatus());
 

--- a/tests/Routing/RouteMatchTest.php
+++ b/tests/Routing/RouteMatchTest.php
@@ -41,9 +41,7 @@ final class RouteMatchTest extends TestCase
 
     public function testNotFoundRouteMatch(): void
     {
-        $basePath = '/api';
-
-        $routeMatch = RouteMatch::notFound($basePath);
+        $routeMatch = RouteMatch::notFound();
 
         $this->assertFalse($routeMatch->isFound());
         $this->assertTrue($routeMatch->isNotFound());
@@ -57,9 +55,7 @@ final class RouteMatchTest extends TestCase
     public function testMethodNotAllowedRouteMatch(): void
     {
         $allowedMethods = ['GET', 'POST'];
-        $basePath = '/api';
-
-        $routeMatch = RouteMatch::methodNotAllowed($allowedMethods, $basePath);
+        $routeMatch = RouteMatch::methodNotAllowed($allowedMethods);
 
         $this->assertFalse($routeMatch->isFound());
         $this->assertFalse($routeMatch->isNotFound());

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Routing;
 
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -153,22 +152,6 @@ class RouteTest extends TestCase
 
         $this->assertSame($arguments, $route->getArguments());
         $this->assertSame('123', $route->getArgument('id'));
-    }
-
-    public function testSetArgumentsRejectsNonStringValues(): void
-    {
-        $methods = ['GET'];
-        $pattern = '/users/{id}';
-        $handler = function () {
-            return 'handler';
-        };
-
-        $route = new Route($methods, $pattern, $handler);
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Route arguments must be an array<string, string>.');
-
-        $route->setArguments(['id' => 123]);
     }
 
     private function createMiddleware(): MiddlewareInterface

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Slim\Tests\Routing;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -135,6 +136,39 @@ class RouteTest extends TestCase
         $route = new Route($methods, $pattern, $handler);
 
         $this->assertSame($methods, $route->getMethods());
+    }
+
+    public function testSetArgumentsStoresStringArguments(): void
+    {
+        $methods = ['GET'];
+        $pattern = '/users/{id}';
+        $handler = function () {
+            return 'handler';
+        };
+
+        $route = new Route($methods, $pattern, $handler);
+
+        $arguments = ['id' => '123', 'slug' => 'john-doe'];
+        $route->setArguments($arguments);
+
+        $this->assertSame($arguments, $route->getArguments());
+        $this->assertSame('123', $route->getArgument('id'));
+    }
+
+    public function testSetArgumentsRejectsNonStringValues(): void
+    {
+        $methods = ['GET'];
+        $pattern = '/users/{id}';
+        $handler = function () {
+            return 'handler';
+        };
+
+        $route = new Route($methods, $pattern, $handler);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Route arguments must be an array<string, string>.');
+
+        $route->setArguments(['id' => 123]);
     }
 
     private function createMiddleware(): MiddlewareInterface


### PR DESCRIPTION
## v5

### Changed

- `RouteInterface::getArguments()` return type updated from `array<string, string>` to `array<string, mixed>` for improved flexibility.
- `RoutingMiddleware` no longer passes or depends on `basePath` when creating `RouteMatch`.
- Simplified `RoutingMiddleware::createRouteMatch()` signature by removing unused `basePath` parameter.
- Minor cleanup in `BasePathMiddleware` by removing unused/commented code.

### Fixed

- Initialize route arguments with an empty array in `Route` to prevent potential undefined property usage.
- Adjust tests to reflect updated `RouteMatch` API (removed `basePath` parameter from factory methods).
- Updated test comments to reflect usage of `RouteMatch` instead of legacy routing results.

### Removed

- Unused `basePath` handling in `RouteMatch` creation and related test usage.