### PR TITLE
Fix static analysis suppression in RouteCollector::removeNamedRoute()

### DIFF
--- a/Slim/Routing/RouteCollector.php
+++ b/Slim/Routing/RouteCollector.php
@@ -185,8 +185,7 @@ class RouteCollector implements RouteCollectorInterface
     {
         $route = $this->getNamedRoute($name);
 
-        /** @psalm-suppress PossiblyNullArrayOffset */
-        unset($this->routesByName[$route->getName()], $this->routes[$route->getIdentifier()]);
+        unset($this->routesByName[$name], $this->routes[$route->getIdentifier()]);
         return $this;
     }
 


### PR DESCRIPTION
Remove static analysis suppression about using null as an array key (PHP 8.5 deprecation warning), by passing `$name` directly as it's a string, whereas `$route->getName()` is string|null.

Note that we can use `$route->getIdentifier()` as that returns `string`.
