### PR TITLE
v5 - Use strict routing

### DIFF
--- a/Slim/Routing/Router.php
+++ b/Slim/Routing/Router.php
@@ -42,19 +42,17 @@ final class Router implements RouterInterface, RequestHandlerInterface
             throw new InvalidArgumentException('HTTP methods array cannot be empty');
         }
 
-        $routePattern = $this->normalizePath($path);
-        $route = new Route($methods, $routePattern, $handler, null);
+        $route = new Route($methods, $path, $handler, null);
 
-        $this->collector->addRoute($methods, $routePattern, $route);
+        $this->collector->addRoute($methods, $path, $route);
 
         return $route;
     }
 
     public function group(string $path, callable $handler): RouteGroup
     {
-        $routePattern = $this->normalizePath($path);
-        $routeGroup = new RouteGroup($routePattern, $handler, $this->getRouteCollector());
-        $this->collector->addGroup($routePattern, $routeGroup);
+        $routeGroup = new RouteGroup($path, $handler, $this->getRouteCollector());
+        $this->collector->addGroup($path, $routeGroup);
 
         return $routeGroup;
     }
@@ -79,28 +77,5 @@ final class Router implements RouterInterface, RequestHandlerInterface
         return $this->pipelineRunner
             ->withPipeline($this->getMiddleware())
             ->handle($request);
-    }
-
-    /**
-     * Normalizes a path by ensuring:
-     * - Starts with a forward slash
-     * - No trailing slash (unless root path)
-     * - No double slashes
-     */
-    private function normalizePath(string $path): string
-    {
-        // If path is empty or just a slash, return single slash
-        if ($path === '' || $path === '/') {
-            return '/';
-        }
-
-        // Ensure path starts with a slash
-        $path = '/' . ltrim($path, '/');
-
-        // Remove trailing slash unless it's the root path
-        $path = rtrim($path, '/');
-
-        // Replace multiple consecutive slashes with a single slash
-        return preg_replace('#/+#', '/', $path) ?? '';
     }
 }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -287,6 +287,10 @@ final class AppTest extends TestCase
             ['/foo//', '/foo//'],
             // Route That contains In A double Slash
             ['/foo//bar', '/foo//bar'],
+            // FastRoute optional trailing slash segment matches /foo
+            ['/foo[/]', '/foo'],
+            // FastRoute optional trailing slash segment matches /foo/
+            ['/foo[/]', '/foo/'],
         ];
     }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -277,20 +277,16 @@ final class AppTest extends TestCase
     {
         return [
             // Route pattern -> http uri
-            // Empty route
-            ['', '/'],
             // Single slash route
             ['/', '/'],
-            // Route That Does Not Start With A Slash
-            ['foo', '/foo'],
             // Route That Does Not End In A Slash
             ['/foo', '/foo'],
             // Route That Ends In A Slash
-            ['/foo/', '/foo'],
+            ['/foo/', '/foo/'],
             // Route That Ends In A double Slash
-            ['/foo//', '/foo'],
+            ['/foo//', '/foo//'],
             // Route That contains In A double Slash
-            ['/foo//bar', '/foo/bar'],
+            ['/foo//bar', '/foo//bar'],
         ];
     }
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -311,6 +311,47 @@ final class AppTest extends TestCase
         $this->assertSame('Hello World', (string)$response->getBody());
     }
 
+    public static function strictRouteMismatchProvider(): array
+    {
+        return [
+            'foo does not match foo trailing slash' => [
+                '/foo',       // route pattern
+                '/foo/',      // request URI
+            ],
+            'foo trailing slash does not match foo' => [
+                '/foo/',      // route pattern
+                '/foo',       // request URI
+            ],
+            'foo does not match FOO uppercase' => [
+                '/foo',       // route pattern
+                '/FOO',       // request URI
+            ],
+            'route without leading slash does not match' => [
+                'foo',        // route pattern
+                '/foo',       // request URI
+            ],
+        ];
+    }
+
+    #[DataProvider('strictRouteMismatchProvider')]
+    public function testStrictRouteMismatch(string $routePattern, string $requestUri): void
+    {
+        $this->expectException(HttpNotFoundException::class);
+
+        $app = AppFactory::create();
+        $app->addRoutingMiddleware();
+
+        $request = $this
+            ->getServerRequestFactory($app)
+            ->createServerRequest('GET', $requestUri);
+
+        $app->get($routePattern, function () {
+            // noop
+        });
+
+        $app->handle($request);
+    }
+
     /********************************************************************************
      * Route Groups
      *******************************************************************************/


### PR DESCRIPTION
`/foo` and `/foo/` are now treated as **different routes**.

## Removed 

- Remove route path normalization

Removed the normalizePath() method and all path normalization from the Router. Route paths are now used exactly as provided by the caller, with no leading-slash prepending, trailing-slash stripping, or double-slash collapsing.

| Route defined as | Request URI | Result|
|---|---|---|
| `'/foo'` | `/foo` | 200 |
| `'/foo'` | `/foo/` | 404 (not found) |
| `'/foo/'` | `/foo/` | 200  |
| `'/foo'` | `/FOO` | 404 (not found) |
| `'foo'` (no leading slash) | `/foo` |  404 (not found) |

## Trailing slash handling with strict routing

This section explains how to handle trailing slashes depending on your use case.

### Option 1: Accept both with a single definition (FastRoute optional segments)

Use FastRoute's optional segment syntax `[/]` to define a single route that matches both:

```php
$app->get('/foo[/]', function (ServerRequestInterface $request, ResponseInterface $response) {
    $response->getBody()->write('Matches both /foo and /foo/');
    return $response;
});
```

### Option 2: Define both routes explicitly

If you want both `/foo` and `/foo/` to work with different handlers:

```php
$app->get('/foo', function (ServerRequestInterface $request, ResponseInterface $response) {
    $response->getBody()->write('Handler for /foo');
    return $response;
});

$app->get('/foo/', function (ServerRequestInterface $request, ResponseInterface $response) {
    $response->getBody()->write('Handler for /foo/');
    return $response;
});
```

### Option 3: Redirect or rewrite trailing slashes via middleware

For **GET** requests a permanent redirect (`301`) is fine. For other request methods like **POST** or **PUT** the browser will change the second request to GET. To avoid this, remove the trailing slash silently and pass the rewritten URI to the next handler.

```php
use Psr\Http\Message\ResponseFactoryInterface;
use Psr\Http\Message\ResponseInterface;
use Psr\Http\Message\ServerRequestInterface;
use Psr\Http\Server\MiddlewareInterface;
use Psr\Http\Server\RequestHandlerInterface;

final class TrailingSlashMiddleware implements MiddlewareInterface
{
    private ResponseFactoryInterface $responseFactory;

    public function __construct(ResponseFactoryInterface $responseFactory)
    {
        $this->responseFactory = $responseFactory;
    }

    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
    {
        $uri = $request->getUri();
        $path = $uri->getPath();

        if ($path !== '/' && str_ends_with($path, '/')) {
            // Recursively remove trailing slashes
            $path = rtrim($path, '/');
            $uri = $uri->withPath($path);

            if ($request->getMethod() === 'GET') {
                return $this->responseFactory
                    ->createResponse(301)
                    ->withHeader('Location', (string) $uri);
            }

            // For non-GET requests, rewrite silently (no redirect)
            return $handler->handle($request->withUri($uri));
        }

        return $handler->handle($request);
    }
}
```

Register it early, before `RoutingMiddleware`:

```php
$app->add(TrailingSlashMiddleware::class);
$app->addRoutingMiddleware();
```

