### PR TITLE
 Add StructArmed to QA 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,4 +17,5 @@
 /phpstan.neon.dist  export-ignore
 /phpunit.xml.dist   export-ignore
 /psalm.xml          export-ignore
+/structarmed.php    export-ignore
 /tests              export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,12 @@ jobs:
         if: matrix.analysis
         run: vendor/bin/phpstan
 
+      - name: Structarmed analysis
+        if: matrix.php == 8.2
+        run: |
+          composer require --dev boundwize/structarmed:^0.14.0 --prefer-dist --no-progress --no-interaction --ansi
+          vendor/bin/structarmed analyse
+
       - name: Tests
         run: vendor/bin/phpunit ${{ matrix.analysis && '--coverage-clover clover.xml' || '--no-coverage'  }}
 

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
     "require-dev": {
         "ext-simplexml": "*",
         "adriansuter/php-autoload-override": "^1.4 || ^2",
+        "boundwize/structarmed": "^0.14.8",
         "guzzlehttp/psr7": "^2.6",
         "httpsoft/http-message": "^1.1",
         "httpsoft/http-server-request": "^1.1",

--- a/structarmed.php
+++ b/structarmed.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Boundwize\StructArmed\Architecture;
+use Boundwize\StructArmed\Preset\Preset;
+
+return Architecture::define()
+    ->withPreset(Preset::PSR4());

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -28,6 +28,7 @@ use Slim\Interfaces\InvocationStrategyInterface;
 use Slim\Interfaces\RouteCollectorProxyInterface;
 use Slim\Routing\Route;
 use Slim\Routing\RouteGroup;
+use Slim\Tests\TestCase;
 use Slim\Tests\Mocks\CallableTest;
 use Slim\Tests\Mocks\InvocationStrategyTest;
 use Slim\Tests\Mocks\MockCustomRequestHandlerInvocationStrategy;

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -8,7 +8,7 @@
 
 declare(strict_types=1);
 
-namespace Slim\Tests;
+namespace Slim\Tests\Routing;
 
 use Closure;
 use Exception;


### PR DESCRIPTION
This PR adds StructArmed to github workflow static analysis for QA.

https://github.com/boundwize/structarmed

StructArmed is a configurable PHP architecture guard, that we can define layers and rules, then keep them enforced. 

For starter, this PR uses the PSR4 preset, and already found violations that fixed and included in this PR.

Since this repo support php 7.x as well, this only add on github workflow on php 8.2 👍

On more practical use case of how set the config layer -> ruleset for more complex use, you can take a look on how cakephp and codeigniter4 uses it :)

- https://github.com/cakephp/cakephp/blob/5.next/structarmed.php
- https://github.com/codeigniter4/CodeIgniter4/blob/develop/structarmed.php

that can be in separate PR if this PR approved.



