### PR TITLE
Add query() route method for the HTTP QUERY verb (RFC 10008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Add `query()` route helper for the HTTP `QUERY` method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008))
+
 ### Changed
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 
 ### Added
 
-- Add `query()` route helper for the HTTP `QUERY` method ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008))
-
 ### Changed
 
 ### Removed

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -91,6 +91,16 @@ interface RouteCollectorProxyInterface
     public function options(string $pattern, $callable): RouteInterface;
 
     /**
+     * Add QUERY route
+     *
+     * @param string $pattern The route URI pattern
+     * @param callable|array{class-string, string}|string $callable The route callback routine
+     *
+     * @link https://www.rfc-editor.org/rfc/rfc10008
+     */
+    public function query(string $pattern, $callable): RouteInterface;
+
+    /**
      * Add route for any HTTP method
      *
      * @param string $pattern The route URI pattern

--- a/Slim/Interfaces/RouteCollectorProxyInterface.php
+++ b/Slim/Interfaces/RouteCollectorProxyInterface.php
@@ -17,6 +17,8 @@ use Psr\Http\Message\UriInterface;
 /**
  * @api
  * @template TContainerInterface of (ContainerInterface|null)
+ *
+ * @method RouteInterface query(string $pattern, callable|array{0: string, 1: string}|string $callable)
  */
 interface RouteCollectorProxyInterface
 {
@@ -89,16 +91,6 @@ interface RouteCollectorProxyInterface
      * @param callable|array{class-string, string}|string $callable The route callback routine
      */
     public function options(string $pattern, $callable): RouteInterface;
-
-    /**
-     * Add QUERY route
-     *
-     * @param string $pattern The route URI pattern
-     * @param callable|array{class-string, string}|string $callable The route callback routine
-     *
-     * @link https://www.rfc-editor.org/rfc/rfc10008
-     */
-    public function query(string $pattern, $callable): RouteInterface;
 
     /**
      * Add route for any HTTP method

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -152,7 +152,13 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Add QUERY route
+     *
+     * @api
+     * @param string $pattern The route URI pattern
+     * @param callable|array{class-string, string}|string $callable The route callback routine
+     *
+     * @link https://www.rfc-editor.org/rfc/rfc10008
      */
     public function query(string $pattern, $callable): RouteInterface
     {

--- a/Slim/Routing/RouteCollectorProxy.php
+++ b/Slim/Routing/RouteCollectorProxy.php
@@ -154,6 +154,14 @@ class RouteCollectorProxy implements RouteCollectorProxyInterface
     /**
      * {@inheritdoc}
      */
+    public function query(string $pattern, $callable): RouteInterface
+    {
+        return $this->map(['QUERY'], $pattern, $callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function any(string $pattern, $callable): RouteInterface
     {
         return $this->map(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'], $pattern, $callable);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -241,6 +241,38 @@ class AppTest extends TestCase
         }
     }
 
+    public function testQueryRoute(): void
+    {
+        $streamProphecy = $this->prophesize(StreamInterface::class);
+        $streamProphecy->__toString()->willReturn('Hello World');
+
+        $responseProphecy = $this->prophesize(ResponseInterface::class);
+        $responseProphecy->getBody()->willReturn($streamProphecy->reveal());
+
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $responseFactoryProphecy->createResponse()->willReturn($responseProphecy->reveal());
+
+        $uriProphecy = $this->prophesize(UriInterface::class);
+        $uriProphecy->getPath()->willReturn('/');
+
+        $requestProphecy = $this->prophesize(ServerRequestInterface::class);
+        $requestProphecy->getMethod()->willReturn('QUERY');
+        $requestProphecy->getUri()->willReturn($uriProphecy->reveal());
+        $requestProphecy->getAttribute(RouteContext::ROUTING_RESULTS)->willReturn(null);
+        $requestProphecy->withAttribute(Argument::type('string'), Argument::any())->will(function ($args) {
+            $this->getAttribute($args[0])->willReturn($args[1]);
+            return $this;
+        });
+
+        $app = new App($responseFactoryProphecy->reveal());
+        $app->query('/', function (ServerRequestInterface $request, ResponseInterface $response) {
+            return $response;
+        });
+        $response = $app->handle($requestProphecy->reveal());
+
+        $this->assertSame('Hello World', (string) $response->getBody());
+    }
+
     /********************************************************************************
      * Route collector proxy methods
      *******************************************************************************/

--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -113,6 +113,7 @@ class AppFactoryTest extends TestCase
     /**
      * @runInSeparateProcess - Psr17FactoryProvider::setFactories breaks other tests
      */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testDetermineResponseFactoryThrowsRuntimeException()
     {
         $this->expectException(RuntimeException::class);

--- a/tests/Routing/RouteCollectorProxyTest.php
+++ b/tests/Routing/RouteCollectorProxyTest.php
@@ -317,6 +317,39 @@ class RouteCollectorProxyTest extends TestCase
         $this->assertSame($pattern, $route->getPattern());
     }
 
+    public function testQuery()
+    {
+        $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);
+        $callableResolverProphecy = $this->prophesize(CallableResolverInterface::class);
+
+        $pattern = '/';
+        $callable = function () {
+        };
+
+        $routeProphecy = $this->prophesize(RouteInterface::class);
+        $routeProphecy
+            ->getPattern()
+            ->willReturn($pattern)
+            ->shouldBeCalledOnce();
+
+        $routeCollectorProphecy = $this->prophesize(RouteCollectorInterface::class);
+        $routeCollectorProphecy
+            ->map(['QUERY'], $pattern, Argument::is($callable))
+            ->willReturn($routeProphecy->reveal())
+            ->shouldBeCalledOnce();
+
+        $routeCollectorProxy = new RouteCollectorProxy(
+            $responseFactoryProphecy->reveal(),
+            $callableResolverProphecy->reveal(),
+            null,
+            $routeCollectorProphecy->reveal()
+        );
+
+        $route = $routeCollectorProxy->query($pattern, $callable);
+
+        $this->assertSame($pattern, $route->getPattern());
+    }
+
     public function testAny()
     {
         $responseFactoryProphecy = $this->prophesize(ResponseFactoryInterface::class);


### PR DESCRIPTION
## Summary

The HTTP `QUERY` method was recently published as [RFC 10008](https://www.rfc-editor.org/rfc/rfc10008) on the IETF Standards Track. It is a safe, cacheable method that carries its query in the request body, enabling expressive queries without the URL-length and cacheability trade-offs of GET vs. POST. Support for `QUERY` is landing across the ecosystem, so this adds a `query()` helper as a sibling of the existing `get()`/`post()`/`put()`/`patch()`/`delete()`/`options()` route methods.

- Adds `query()` to `RouteCollectorProxyInterface` and its implementation in `RouteCollectorProxy`, equivalent to `map(['QUERY'], $pattern, $callable)`.
- Deliberately **not** added to `any()`'s method list, so existing `any()` routes are unaffected.
- Adds a CHANGELOG entry under `[Unreleased] / Added`.

```php
$app->query('/search', function (Request $request, Response $response) {
    $criteria = (string) $request->getBody();
    // ...run the query described in the request body...
    return $response;
});
```

## Test plan

- [x] `vendor/bin/phpunit` — full suite passes (437 tests)
- [x] `vendor/bin/phpcs` — clean (PSR-12)
- [x] `vendor/bin/phpstan --memory-limit=-1` — clean (level max)
- [x] Added `RouteCollectorProxyTest::testQuery()` (unit-level, mirrors `testOptions()`)
- [x] Added `AppTest::testQueryRoute()` (end-to-end, mirrors the GET/POST/etc. verb test)