### PR TITLE
Negotiate error handler content type on every request

### DIFF
--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -78,6 +78,8 @@ class ErrorHandler implements ErrorHandlerInterface
 
     protected ?string $contentType = null;
 
+    protected bool $isContentTypeForced = false;
+
     protected ?string $method = null;
 
     protected ServerRequestInterface $request;
@@ -125,7 +127,7 @@ class ErrorHandler implements ErrorHandlerInterface
         $this->exception = $exception;
         $this->method = $request->getMethod();
         $this->statusCode = $this->determineStatusCode();
-        if ($this->contentType === null) {
+        if (!$this->isContentTypeForced) {
             $this->contentType = $this->determineContentType($request);
         }
 
@@ -143,6 +145,7 @@ class ErrorHandler implements ErrorHandlerInterface
      */
     public function forceContentType(?string $contentType): void
     {
+        $this->isContentTypeForced = true;
         $this->contentType = $contentType;
     }
 

--- a/Slim/Handlers/ErrorHandler.php
+++ b/Slim/Handlers/ErrorHandler.php
@@ -141,11 +141,11 @@ class ErrorHandler implements ErrorHandlerInterface
     /**
      * Force the content type for all error handler responses.
      *
-     * @param string|null $contentType The content type
+     * @param string|null $contentType The content type. Null restores Accept-header negotiation.
      */
     public function forceContentType(?string $contentType): void
     {
-        $this->isContentTypeForced = true;
+        $this->isContentTypeForced = $contentType !== null;
         $this->contentType = $contentType;
     }
 

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -176,6 +176,43 @@ class ErrorHandlerTest extends TestCase
         $this->assertSame(['application/json'], $response->getHeader('Content-Type'));
     }
 
+    /**
+     * Test that forceContentType(null) restores Accept-header negotiation.
+     */
+    public function testForceContentTypeNullRestoresNegotiation()
+    {
+        $handler = new ErrorHandler($this->getCallableResolver(), $this->getResponseFactory());
+        $handler->forceContentType('application/json');
+
+        $xmlRequest = $this
+            ->createServerRequest('/not-defined', 'GET')
+            ->withHeader('Accept', 'application/xml');
+
+        $htmlRequest = $this
+            ->createServerRequest('/not-defined', 'GET')
+            ->withHeader('Accept', 'text/html');
+
+        $exception = new HttpNotFoundException($xmlRequest);
+
+        /** @var ResponseInterface $response */
+        $response = $handler->__invoke($xmlRequest, $exception, false, false, false);
+        $this->assertSame(['application/json'], $response->getHeader('Content-Type'));
+
+        $handler->forceContentType(null);
+
+        $exception = new HttpNotFoundException($xmlRequest);
+
+        /** @var ResponseInterface $response */
+        $response = $handler->__invoke($xmlRequest, $exception, false, false, false);
+        $this->assertSame(['application/xml'], $response->getHeader('Content-Type'));
+
+        $exception = new HttpNotFoundException($htmlRequest);
+
+        /** @var ResponseInterface $response */
+        $response = $handler->__invoke($htmlRequest, $exception, false, false, false);
+        $this->assertSame(['text/html'], $response->getHeader('Content-Type'));
+    }
+
     public function testHalfValidContentType()
     {
         $request = $this

--- a/tests/Handlers/ErrorHandlerTest.php
+++ b/tests/Handlers/ErrorHandlerTest.php
@@ -118,6 +118,64 @@ class ErrorHandlerTest extends TestCase
         $this->assertSame(['application/json'], $response->getHeader('Content-Type'));
     }
 
+    /**
+     * Test that the content type is negotiated from the Accept header on each
+     * request instead of being cached from the first invocation.
+     */
+    public function testContentTypeIsNegotiatedOnEachRequest()
+    {
+        $handler = new ErrorHandler($this->getCallableResolver(), $this->getResponseFactory());
+
+        $jsonRequest = $this
+            ->createServerRequest('/not-defined', 'GET')
+            ->withHeader('Accept', 'application/json');
+
+        $htmlRequest = $this
+            ->createServerRequest('/not-defined', 'GET')
+            ->withHeader('Accept', 'text/html');
+
+        $exception = new HttpNotFoundException($jsonRequest);
+
+        /** @var ResponseInterface $response */
+        $response = $handler->__invoke($jsonRequest, $exception, false, false, false);
+        $this->assertSame(['application/json'], $response->getHeader('Content-Type'));
+
+        $exception = new HttpNotFoundException($htmlRequest);
+
+        /** @var ResponseInterface $response */
+        $response = $handler->__invoke($htmlRequest, $exception, false, false, false);
+        $this->assertSame(['text/html'], $response->getHeader('Content-Type'));
+    }
+
+    /**
+     * Test that a forced content type still wins over per-request negotiation.
+     */
+    public function testForcedContentTypeWinsOverSubsequentNegotiation()
+    {
+        $handler = new ErrorHandler($this->getCallableResolver(), $this->getResponseFactory());
+        $handler->forceContentType('application/json');
+
+        $jsonRequest = $this
+            ->createServerRequest('/not-defined', 'GET')
+            ->withHeader('Accept', 'application/json');
+
+        $xmlRequest = $this
+            ->createServerRequest('/not-defined', 'GET')
+            ->withHeader('Accept', 'application/xml');
+
+        $exception = new HttpNotFoundException($jsonRequest);
+
+        /** @var ResponseInterface $response */
+        $response = $handler->__invoke($jsonRequest, $exception, false, false, false);
+        $this->assertSame(['application/json'], $response->getHeader('Content-Type'));
+
+        $exception = new HttpNotFoundException($xmlRequest);
+
+        /** @var ResponseInterface $response */
+        $response = $handler->__invoke($xmlRequest, $exception, false, false, false);
+        $this->assertSame(['application/json'], $response->getHeader('Content-Type'));
+    }
+
     public function testHalfValidContentType()
     {
         $request = $this


### PR DESCRIPTION
The ErrorHandler caches the content type negotiated from the first request's Accept header (`$this->contentType` is set only when currently null) and reuses it for the lifetime of the handler instance. Applications that share one `ErrorHandler` across requests, such as long-running worker runtimes (Swoole, RoadRunner, Laravel Octane) where the container-built handler persists, keep serving error responses in the first request's negotiated format regardless of later clients' Accept headers. A single JSON client pins every subsequent browser or XML client to JSON error pages until process restart.

This change recomputes the content type from each incoming request. The existing override semantics are preserved: once `forceContentType()` is called, the forced value wins for all subsequent requests.
