### PR TITLE
Substitute invalid UTF-8 in JSON error renderer output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Fixed
+ - Substitute invalid UTF-8 in JSON error renderer output (#811)
 
 ### Added
 

--- a/Slim/Error/Renderers/JsonErrorRenderer.php
+++ b/Slim/Error/Renderers/JsonErrorRenderer.php
@@ -16,6 +16,7 @@ use Throwable;
 use function get_class;
 use function json_encode;
 
+use const JSON_INVALID_UTF8_SUBSTITUTE;
 use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
 
@@ -35,7 +36,10 @@ class JsonErrorRenderer extends AbstractErrorRenderer
             } while ($exception = $exception->getPrevious());
         }
 
-        return (string) json_encode($error, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        return (string) json_encode(
+            $error,
+            JSON_INVALID_UTF8_SUBSTITUTE | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+        );
     }
 
     /**

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -163,6 +163,19 @@ class AbstractErrorRendererTest extends TestCase
         $this->assertSame($output, json_encode(['message' => 'Slim Application Error']));
     }
 
+    public function testJSONErrorRendererSubstitutesInvalidUtf8()
+    {
+        $exception = new Exception("Invalid \xB1\x31 UTF-8 sequence");
+
+        $renderer = new JsonErrorRenderer();
+        $output = $renderer->__invoke($exception, false);
+
+        $this->assertNotSame('', $output);
+        $decoded = json_decode($output, true);
+        $this->assertIsArray($decoded);
+        $this->assertArrayHasKey('message', $decoded);
+    }
+
     public function testJSONErrorRendererDisplaysPreviousError()
     {
         $previousException = new Exception('Oh no!');

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -168,12 +168,16 @@ class AbstractErrorRendererTest extends TestCase
         $exception = new Exception("Invalid \xB1\x31 UTF-8 sequence");
 
         $renderer = new JsonErrorRenderer();
-        $output = $renderer->__invoke($exception, false);
+        $output = $renderer->__invoke($exception, true);
 
         $this->assertNotSame('', $output);
         $decoded = json_decode($output, true);
         $this->assertIsArray($decoded);
-        $this->assertArrayHasKey('message', $decoded);
+        $this->assertSame('Slim Application Error', $decoded['message']);
+        $this->assertSame(
+            "Invalid \u{FFFD}1 UTF-8 sequence",
+            $decoded['exception'][0]['message']
+        );
     }
 
     public function testJSONErrorRendererDisplaysPreviousError()


### PR DESCRIPTION
`json_encode()` returns `false` when any string in the payload contains an invalid UTF-8 sequence, so a JSON error response for an exception whose message or title carries raw binary data (invalid-UTF-8 user input echoed into exception messages is the common path) was emitted as a zero-length body under `Content-Type: application/json`. Strict API clients then fail to parse the empty body and the actual error information is silently discarded.

This adds `JSON_INVALID_UTF8_SUBSTITUTE` so invalid byte sequences are replaced with the UTF-8 replacement character instead of failing the whole encode. The renderer output stays valid JSON in all cases.

Reproduction on 4.x before this change:

```php
$renderer = new \Slim\Error\Renderers\JsonErrorRenderer();
$output = $renderer(new \RuntimeException("bad \xB1\x31 bytes"), true);
var_dump(strlen($output)); // int(0)
```
