### PR TITLE
Use consistent HTML escaping in error details fragment

### DIFF
--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -32,11 +32,7 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
             $html .= '<h2>Details</h2>';
             $html .= $this->renderExceptionFragment($exception);
         } else {
-            $description = htmlspecialchars(
-                $this->getErrorDescription($exception),
-                ENT_QUOTES | ENT_SUBSTITUTE,
-                'UTF-8'
-            );
+            $description = $this->escapeHtml($this->getErrorDescription($exception));
             $html = "<p>{$description}</p>";
         }
 
@@ -45,32 +41,25 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
 
     private function renderExceptionFragment(Throwable $exception): string
     {
-        $html = sprintf('<div><strong>Type:</strong> %s</div>', get_class($exception));
-
-        $code = $exception->getCode();
-        $html .= sprintf('<div><strong>Code:</strong> %s</div>', $code);
-
-        $html .= sprintf(
-            '<div><strong>Message:</strong> %s</div>',
-            htmlspecialchars($exception->getMessage(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
-        );
-
-        $html .= sprintf('<div><strong>File:</strong> %s</div>', $exception->getFile());
-
-        $html .= sprintf('<div><strong>Line:</strong> %s</div>', $exception->getLine());
-
+        $html = sprintf('<div><strong>Type:</strong> %s</div>', $this->escapeHtml(get_class($exception)));
+        $html .= sprintf('<div><strong>Code:</strong> %s</div>', $this->escapeHtml((string) $exception->getCode()));
+        $html .= sprintf('<div><strong>Message:</strong> %s</div>', $this->escapeHtml($exception->getMessage()));
+        $html .= sprintf('<div><strong>File:</strong> %s</div>', $this->escapeHtml($exception->getFile()));
+        $html .= sprintf('<div><strong>Line:</strong> %s</div>', $this->escapeHtml((string) $exception->getLine()));
         $html .= '<h2>Trace</h2>';
-        $html .= sprintf(
-            '<pre>%s</pre>',
-            htmlspecialchars($exception->getTraceAsString(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
-        );
+        $html .= sprintf('<pre>%s</pre>', $this->escapeHtml($exception->getTraceAsString()));
 
         return $html;
     }
 
+    private function escapeHtml(string $text): string
+    {
+        return htmlspecialchars($text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+
     public function renderHtmlBody(string $title = '', string $html = ''): string
     {
-        $title = htmlspecialchars($title, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $title = $this->escapeHtml($title);
 
         return sprintf(
             '<!doctype html>' .

--- a/Slim/Error/Renderers/HtmlErrorRenderer.php
+++ b/Slim/Error/Renderers/HtmlErrorRenderer.php
@@ -14,7 +14,6 @@ use Slim\Error\AbstractErrorRenderer;
 use Throwable;
 
 use function get_class;
-use function htmlentities;
 use function htmlspecialchars;
 use function sprintf;
 
@@ -51,14 +50,20 @@ class HtmlErrorRenderer extends AbstractErrorRenderer
         $code = $exception->getCode();
         $html .= sprintf('<div><strong>Code:</strong> %s</div>', $code);
 
-        $html .= sprintf('<div><strong>Message:</strong> %s</div>', htmlentities($exception->getMessage()));
+        $html .= sprintf(
+            '<div><strong>Message:</strong> %s</div>',
+            htmlspecialchars($exception->getMessage(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+        );
 
         $html .= sprintf('<div><strong>File:</strong> %s</div>', $exception->getFile());
 
         $html .= sprintf('<div><strong>Line:</strong> %s</div>', $exception->getLine());
 
         $html .= '<h2>Trace</h2>';
-        $html .= sprintf('<pre>%s</pre>', htmlentities($exception->getTraceAsString()));
+        $html .= sprintf(
+            '<pre>%s</pre>',
+            htmlspecialchars($exception->getTraceAsString(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+        );
 
         return $html;
     }

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -21,10 +21,18 @@ use Slim\Exception\HttpException;
 use Slim\Tests\TestCase;
 use stdClass;
 
+use function bin2hex;
+use function file_put_contents;
+use function get_class;
 use function htmlspecialchars;
 use function json_decode;
 use function json_encode;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
 use function simplexml_load_string;
+use function sys_get_temp_dir;
+use function unlink;
 
 use const ENT_QUOTES;
 use const ENT_SUBSTITUTE;
@@ -76,7 +84,19 @@ class AbstractErrorRendererTest extends TestCase
 
     public function testHTMLErrorRendererEscapesQuotesInErrorDetails()
     {
-        $exception = new Exception("O'Brien <script>");
+        $unsafe = "O'Brien <script>";
+        $escaped = htmlspecialchars($unsafe, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+        $exception = new class ($unsafe) extends Exception {
+            public function __construct(string $unsafe)
+            {
+                parent::__construct($unsafe, 0);
+                $this->file = '/tmp/' . $unsafe . '.php';
+                $this->code = "SQL'" . $unsafe;
+                $this->line = 7;
+            }
+        };
+
         $renderer = new HtmlErrorRenderer();
         $reflectionRenderer = new ReflectionClass(HtmlErrorRenderer::class);
 
@@ -84,11 +104,48 @@ class AbstractErrorRendererTest extends TestCase
         $this->setAccessible($method);
         $output = $method->invoke($renderer, $exception);
 
+        $this->assertStringNotContainsString($unsafe, $output);
+        $this->assertStringContainsString($escaped, $output);
         $this->assertStringContainsString(
-            htmlspecialchars("O'Brien <script>", ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-            $output,
-            'Message must be HTML-escaped including quotes'
+            htmlspecialchars('/tmp/' . $unsafe . '.php', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            $output
         );
+        $this->assertStringContainsString(
+            htmlspecialchars("SQL'" . $unsafe, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            $output
+        );
+        $this->assertStringContainsString('<div><strong>Line:</strong> 7</div>', $output);
+    }
+
+    public function testHTMLErrorRendererEscapesAnonymousClassType()
+    {
+        $unsafe = "O'Brien <script>";
+        $dir = sys_get_temp_dir() . '/slim-html-' . bin2hex(random_bytes(4));
+        $unsafeDir = $dir . '/' . $unsafe;
+        mkdir($unsafeDir, 0700, true);
+        $file = $unsafeDir . '/anon.php';
+        file_put_contents($file, '<?php return new class extends Exception {};');
+
+        try {
+            /** @var Exception $exception */
+            $exception = require $file;
+            $renderer = new HtmlErrorRenderer();
+            $reflectionRenderer = new ReflectionClass(HtmlErrorRenderer::class);
+
+            $method = $reflectionRenderer->getMethod('renderExceptionFragment');
+            $this->setAccessible($method);
+            $output = $method->invoke($renderer, $exception);
+
+            $this->assertStringNotContainsString($unsafe, $output);
+            $this->assertStringContainsString(
+                htmlspecialchars(get_class($exception), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+                $output
+            );
+        } finally {
+            unlink($file);
+            rmdir($unsafeDir);
+            rmdir($dir);
+        }
     }
 
     public function testHTMLErrorRendererRenderHttpException()

--- a/tests/Error/AbstractErrorRendererTest.php
+++ b/tests/Error/AbstractErrorRendererTest.php
@@ -74,6 +74,23 @@ class AbstractErrorRendererTest extends TestCase
         $this->assertMatchesRegularExpression('/.*Line*/', $output);
     }
 
+    public function testHTMLErrorRendererEscapesQuotesInErrorDetails()
+    {
+        $exception = new Exception("O'Brien <script>");
+        $renderer = new HtmlErrorRenderer();
+        $reflectionRenderer = new ReflectionClass(HtmlErrorRenderer::class);
+
+        $method = $reflectionRenderer->getMethod('renderExceptionFragment');
+        $this->setAccessible($method);
+        $output = $method->invoke($renderer, $exception);
+
+        $this->assertStringContainsString(
+            htmlspecialchars("O'Brien <script>", ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            $output,
+            'Message must be HTML-escaped including quotes'
+        );
+    }
+
     public function testHTMLErrorRendererRenderHttpException()
     {
         $exceptionTitle = 'title';


### PR DESCRIPTION
`HtmlErrorRenderer::renderExceptionFragment()` escapes the exception message and stack trace with bare `htmlentities()`, while the title and description are escaped with explicit `htmlspecialchars(..., ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')`. The two escape sites therefore behave differently across the supported PHP range: `htmlentities()` default flags gained `ENT_QUOTES` only in PHP 8.1, so on 7.4/8.0 single quotes in the message pass through unescaped, and the charset is inherited from the `default_charset` ini rather than pinned to UTF-8.

This aligns the fragment escaping with the same explicit call used everywhere else in the renderer, making behavior identical on every supported PHP version.
