### PR TITLE
v5 - Add query() route method for HTTP QUERY (RFC 10008)

### DIFF
--- a/Slim/Interfaces/RouteCollectionInterface.php
+++ b/Slim/Interfaces/RouteCollectionInterface.php
@@ -75,6 +75,16 @@ interface RouteCollectionInterface
     public function options(string $path, callable|string $handler): RouteInterface;
 
     /**
+     * Register a QUERY route.
+     *
+     * @param string $path
+     * @param callable|string $handler
+     *
+     * @return RouteInterface
+     */
+    public function query(string $path, callable|string $handler): RouteInterface;
+
+    /**
      * Register a route for any HTTP method.
      *
      * @param string $path

--- a/Slim/Interfaces/RouterInterface.php
+++ b/Slim/Interfaces/RouterInterface.php
@@ -21,6 +21,8 @@ interface RouterInterface
 
     public function options(string $path, callable|string $handler): RouteInterface;
 
+    public function query(string $path, callable|string $handler): RouteInterface;
+
     public function any(string $pattern, callable|string $handler): RouteInterface;
 
     /**

--- a/Slim/Routing/RouteCollectionTrait.php
+++ b/Slim/Routing/RouteCollectionTrait.php
@@ -48,6 +48,11 @@ trait RouteCollectionTrait
         return $this->map(['OPTIONS'], $path, $handler);
     }
 
+    public function query(string $path, callable|string $handler): RouteInterface
+    {
+        return $this->map(['QUERY'], $path, $handler);
+    }
+
     public function any(string $pattern, callable|string $handler): RouteInterface
     {
         return $this->map(['*'], $pattern, $handler);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -170,6 +170,7 @@ final class AppTest extends TestCase
             ['patch'],
             ['delete'],
             ['options'],
+            ['query'],
         ];
     }
 
@@ -222,6 +223,7 @@ final class AppTest extends TestCase
             ['PATCH'],
             ['DELETE'],
             ['OPTIONS'],
+            ['QUERY'],
         ];
     }
 

--- a/tests/Routing/RouterTest.php
+++ b/tests/Routing/RouterTest.php
@@ -107,6 +107,14 @@ class RouterTest extends TestCase
                 },
                 ['PUT'],
             ],
+            [
+                'query',
+                '/query',
+                function () {
+                    return 'query_handler';
+                },
+                ['QUERY'],
+            ],
         ];
     }
 


### PR DESCRIPTION
Add a `query()`  method on `App`, `Router`, and `RouteGroup` for the HTTP `QUERY` verb ([RFC 10008](https://www.rfc-editor.org/rfc/rfc10008.html)).

`QUERY` is a safe, idempotent method that may include a request body, so it is a better fit than `GET` for searches and other parameterized lookups.

## Usage

```php
$app->query('/search', function ($request, $response) {
    return $response;
});