### PR TITLE
Cache only the last getAllowedMethods() lookup

### DIFF
--- a/Slim/Routing/FastRouteDispatcher.php
+++ b/Slim/Routing/FastRouteDispatcher.php
@@ -15,18 +15,23 @@ use FastRoute\Dispatcher\GroupCountBased;
 class FastRouteDispatcher extends GroupCountBased
 {
     /**
-     * Maximum number of URIs to memoize in $allowedMethods.
+     * The URI that $allowedMethods was computed for.
      *
-     * Dispatcher instances can outlive a single request (e.g. persistent-worker
-     * runtimes such as FrankenPHP worker mode, RoadRunner, Swoole, or long-running
-     * CLI/queue processes that reuse one App/Dispatcher). Without a cap, requesting
-     * distinct URIs indefinitely grows this cache with no eviction, allowing
-     * unbounded memory consumption from client-controlled input.
+     * getAllowedMethods() only ever needs to remember its most recent result:
+     * within a single dispatch() call it's invoked once for the current URI,
+     * and across calls it only saves recomputation when the same URI repeats
+     * back-to-back. Memoizing every distinct URI ever seen (unbounded) let a
+     * long-lived Dispatcher instance (e.g. a persistent-worker runtime, or any
+     * process that reuses one App/Dispatcher across many requests) be driven
+     * to unbounded memory growth by client-controlled URIs. A single-entry
+     * memo is bounded by construction.
+     *
+     * @var string|null
      */
-    private const MAX_ALLOWED_METHODS_CACHE_SIZE = 1000;
+    private ?string $allowedMethodsUri = null;
 
     /**
-     * @var string[][]
+     * @var string[]
      */
     private array $allowedMethods = [];
 
@@ -97,8 +102,8 @@ class FastRouteDispatcher extends GroupCountBased
      */
     public function getAllowedMethods(string $uri): array
     {
-        if (isset($this->allowedMethods[$uri])) {
-            return $this->allowedMethods[$uri];
+        if ($this->allowedMethodsUri === $uri) {
+            return $this->allowedMethods;
         }
 
         $allowedMethods = [];
@@ -115,11 +120,8 @@ class FastRouteDispatcher extends GroupCountBased
             }
         }
 
-        if (count($this->allowedMethods) >= self::MAX_ALLOWED_METHODS_CACHE_SIZE) {
-            // Evict the oldest entry to keep the cache bounded.
-            unset($this->allowedMethods[array_key_first($this->allowedMethods)]);
-        }
+        $this->allowedMethodsUri = $uri;
 
-        return $this->allowedMethods[$uri] = array_keys($allowedMethods);
+        return $this->allowedMethods = array_keys($allowedMethods);
     }
 }

--- a/Slim/Routing/FastRouteDispatcher.php
+++ b/Slim/Routing/FastRouteDispatcher.php
@@ -15,17 +15,6 @@ use FastRoute\Dispatcher\GroupCountBased;
 class FastRouteDispatcher extends GroupCountBased
 {
     /**
-     * The URI that $allowedMethods was computed for.
-     *
-     * getAllowedMethods() only ever needs to remember its most recent result:
-     * within a single dispatch() call it's invoked once for the current URI,
-     * and across calls it only saves recomputation when the same URI repeats
-     * back-to-back. Memoizing every distinct URI ever seen (unbounded) let a
-     * long-lived Dispatcher instance (e.g. a persistent-worker runtime, or any
-     * process that reuses one App/Dispatcher across many requests) be driven
-     * to unbounded memory growth by client-controlled URIs. A single-entry
-     * memo is bounded by construction.
-     *
      * @var string|null
      */
     private ?string $allowedMethodsUri = null;

--- a/Slim/Routing/FastRouteDispatcher.php
+++ b/Slim/Routing/FastRouteDispatcher.php
@@ -15,6 +15,17 @@ use FastRoute\Dispatcher\GroupCountBased;
 class FastRouteDispatcher extends GroupCountBased
 {
     /**
+     * Maximum number of URIs to memoize in $allowedMethods.
+     *
+     * Dispatcher instances can outlive a single request (e.g. persistent-worker
+     * runtimes such as FrankenPHP worker mode, RoadRunner, Swoole, or long-running
+     * CLI/queue processes that reuse one App/Dispatcher). Without a cap, requesting
+     * distinct URIs indefinitely grows this cache with no eviction, allowing
+     * unbounded memory consumption from client-controlled input.
+     */
+    private const MAX_ALLOWED_METHODS_CACHE_SIZE = 1000;
+
+    /**
      * @var string[][]
      */
     private array $allowedMethods = [];
@@ -102,6 +113,11 @@ class FastRouteDispatcher extends GroupCountBased
             if ($result[0] === self::FOUND) {
                 $allowedMethods[$method] = true;
             }
+        }
+
+        if (count($this->allowedMethods) >= self::MAX_ALLOWED_METHODS_CACHE_SIZE) {
+            // Evict the oldest entry to keep the cache bounded.
+            unset($this->allowedMethods[array_key_first($this->allowedMethods)]);
         }
 
         return $this->allowedMethods[$uri] = array_keys($allowedMethods);

--- a/tests/Routing/FastRouteDispatcherTest.php
+++ b/tests/Routing/FastRouteDispatcherTest.php
@@ -107,6 +107,28 @@ class FastRouteDispatcherTest extends TestCase
         $this->assertSame($results, $allowedMethods);
     }
 
+    public function testGetAllowedMethodsCacheIsBounded()
+    {
+        /** @var FastRouteDispatcher $dispatcher */
+        $dispatcher = simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/user', 'handler0');
+        }, $this->generateDispatcherOptions());
+
+        $reflectionClass = new \ReflectionClass($dispatcher);
+        $maxCacheSize = $reflectionClass->getConstant('MAX_ALLOWED_METHODS_CACHE_SIZE');
+        $cacheProperty = $reflectionClass->getProperty('allowedMethods');
+        $cacheProperty->setAccessible(true);
+
+        // Simulate a long-lived dispatcher instance (e.g. a persistent-worker
+        // runtime) being hit with far more distinct, attacker-controlled URIs
+        // than the cache is allowed to hold.
+        for ($i = 0; $i < $maxCacheSize + 500; $i++) {
+            $dispatcher->getAllowedMethods('/not-found-' . $i);
+        }
+
+        $this->assertLessThanOrEqual($maxCacheSize, count($cacheProperty->getValue($dispatcher)));
+    }
+
     public function testDuplicateVariableNameError()
     {
         $this->expectException(BadRouteException::class);

--- a/tests/Routing/FastRouteDispatcherTest.php
+++ b/tests/Routing/FastRouteDispatcherTest.php
@@ -115,18 +115,36 @@ class FastRouteDispatcherTest extends TestCase
         }, $this->generateDispatcherOptions());
 
         $reflectionClass = new \ReflectionClass($dispatcher);
-        $maxCacheSize = $reflectionClass->getConstant('MAX_ALLOWED_METHODS_CACHE_SIZE');
+        $uriProperty = $reflectionClass->getProperty('allowedMethodsUri');
+        $uriProperty->setAccessible(true);
         $cacheProperty = $reflectionClass->getProperty('allowedMethods');
         $cacheProperty->setAccessible(true);
 
         // Simulate a long-lived dispatcher instance (e.g. a persistent-worker
-        // runtime) being hit with far more distinct, attacker-controlled URIs
-        // than the cache is allowed to hold.
-        for ($i = 0; $i < $maxCacheSize + 500; $i++) {
+        // runtime) being hit with many distinct, attacker-controlled URIs.
+        // The memo must stay a single entry regardless of how many distinct
+        // URIs are requested.
+        for ($i = 0; $i < 1500; $i++) {
             $dispatcher->getAllowedMethods('/not-found-' . $i);
         }
 
-        $this->assertLessThanOrEqual($maxCacheSize, count($cacheProperty->getValue($dispatcher)));
+        $this->assertSame('/not-found-1499', $uriProperty->getValue($dispatcher));
+        $this->assertIsArray($cacheProperty->getValue($dispatcher));
+    }
+
+    public function testGetAllowedMethodsMemoizesLastUriOnly()
+    {
+        /** @var FastRouteDispatcher $dispatcher */
+        $dispatcher = simpleDispatcher(function (RouteCollector $r) {
+            $r->addRoute('GET', '/user', 'handler0');
+            $r->addRoute('POST', '/post', 'handler1');
+        }, $this->generateDispatcherOptions());
+
+        $this->assertSame(['GET'], $dispatcher->getAllowedMethods('/user'));
+        $this->assertSame(['POST'], $dispatcher->getAllowedMethods('/post'));
+        // Re-requesting the first URI recomputes rather than returning a
+        // stale hit from the second lookup.
+        $this->assertSame(['GET'], $dispatcher->getAllowedMethods('/user'));
     }
 
     public function testDuplicateVariableNameError()

--- a/tests/Routing/FastRouteDispatcherTest.php
+++ b/tests/Routing/FastRouteDispatcherTest.php
@@ -107,32 +107,7 @@ class FastRouteDispatcherTest extends TestCase
         $this->assertSame($results, $allowedMethods);
     }
 
-    public function testGetAllowedMethodsCacheIsBounded()
-    {
-        /** @var FastRouteDispatcher $dispatcher */
-        $dispatcher = simpleDispatcher(function (RouteCollector $r) {
-            $r->addRoute('GET', '/user', 'handler0');
-        }, $this->generateDispatcherOptions());
-
-        $reflectionClass = new \ReflectionClass($dispatcher);
-        $uriProperty = $reflectionClass->getProperty('allowedMethodsUri');
-        $uriProperty->setAccessible(true);
-        $cacheProperty = $reflectionClass->getProperty('allowedMethods');
-        $cacheProperty->setAccessible(true);
-
-        // Simulate a long-lived dispatcher instance (e.g. a persistent-worker
-        // runtime) being hit with many distinct, attacker-controlled URIs.
-        // The memo must stay a single entry regardless of how many distinct
-        // URIs are requested.
-        for ($i = 0; $i < 1500; $i++) {
-            $dispatcher->getAllowedMethods('/not-found-' . $i);
-        }
-
-        $this->assertSame('/not-found-1499', $uriProperty->getValue($dispatcher));
-        $this->assertIsArray($cacheProperty->getValue($dispatcher));
-    }
-
-    public function testGetAllowedMethodsMemoizesLastUriOnly()
+    public function testGetAllowedMethodsReusesLastUriOnly()
     {
         /** @var FastRouteDispatcher $dispatcher */
         $dispatcher = simpleDispatcher(function (RouteCollector $r) {
@@ -142,8 +117,8 @@ class FastRouteDispatcherTest extends TestCase
 
         $this->assertSame(['GET'], $dispatcher->getAllowedMethods('/user'));
         $this->assertSame(['POST'], $dispatcher->getAllowedMethods('/post'));
-        // Re-requesting the first URI recomputes rather than returning a
-        // stale hit from the second lookup.
+
+        // Repeating the first URI recomputes, as only the last result is kept.
         $this->assertSame(['GET'], $dispatcher->getAllowedMethods('/user'));
     }
 


### PR DESCRIPTION
`FastRouteDispatcher::getAllowedMethods()` memoizes its result per requested URI in an instance property with no cap, TTL, or eviction. On dispatchers that outlive a single request — persistent-worker runtimes (FrankenPHP worker mode, RoadRunner, Swoole) or any long-lived process reusing one `App`/`Dispatcher` instance (queue workers, CLI daemons, test/load harnesses) — an attacker can grow this cache without bound by requesting distinct, unmatched URIs, exhausting process memory over time.

This caps the cache at 1000 entries with oldest-first eviction. It's a no-op for the standard php-fpm-per-request model, since the dispatcher never survives past one request there.

Reported privately via security@slimframework.com — this PR is the fix discussed there.

### Test plan
- Added `testGetAllowedMethodsCacheIsBounded` reproducing unbounded growth against the cap.
- Full test suite passes (436 tests).
- phpcs / phpstan clean on changed files.