### PR TITLE
v5 - Fix process state in long-lived runtimes

### DIFF
--- a/Slim/Interfaces/RouteInterface.php
+++ b/Slim/Interfaces/RouteInterface.php
@@ -56,27 +56,6 @@ interface RouteInterface
     public function getRouteGroup(): ?RouteGroup;
 
     /**
-     * Retrieve a specific route argument.
-     */
-    public function getArgument(string $name, ?string $default = null): ?string;
-
-    /**
-     * Get route arguments.
-     *
-     * @return array<string, string>
-     */
-    public function getArguments(): array;
-
-    /**
-     * Set route arguments.
-     *
-     * @param array<string,string> $arguments The arguments.
-     *
-     * @return RouteInterface
-     */
-    public function setArguments(array $arguments): RouteInterface;
-
-    /**
      * @return array<MiddlewareInterface|callable|string>
      */
     public function getMiddleware(): array;

--- a/Slim/Middleware/ErrorExceptionMiddleware.php
+++ b/Slim/Middleware/ErrorExceptionMiddleware.php
@@ -24,7 +24,7 @@ final class ErrorExceptionMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $errorHandler = set_error_handler(function ($code, $message, $file, $line) {
+        set_error_handler(function ($code, $message, $file, $line) {
             $level = error_reporting();
             if (($level & $code) === 0) {
                 // silent error
@@ -35,13 +35,9 @@ final class ErrorExceptionMiddleware implements MiddlewareInterface
         });
 
         try {
-            $response = $handler->handle($request);
+            return $handler->handle($request);
         } finally {
-            if ($errorHandler) {
-                restore_error_handler();
-            }
+            restore_error_handler();
         }
-
-        return $response;
     }
 }

--- a/Slim/Middleware/JsonExceptionMiddleware.php
+++ b/Slim/Middleware/JsonExceptionMiddleware.php
@@ -23,7 +23,10 @@ final class JsonExceptionMiddleware implements MiddlewareInterface
 
     private const DEFAULT_TYPE = 'application/json';
 
-    private int $jsonOptions = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR;
+    private int $jsonOptions = JSON_PRETTY_PRINT
+        | JSON_UNESCAPED_SLASHES
+        | JSON_PARTIAL_OUTPUT_ON_ERROR
+        | JSON_INVALID_UTF8_SUBSTITUTE;
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/Slim/Middleware/OutputBufferingMiddleware.php
+++ b/Slim/Middleware/OutputBufferingMiddleware.php
@@ -21,6 +21,7 @@ use Throwable;
 use function in_array;
 use function ob_end_clean;
 use function ob_get_clean;
+use function ob_get_level;
 use function ob_start;
 
 final class OutputBufferingMiddleware implements MiddlewareInterface
@@ -54,12 +55,19 @@ final class OutputBufferingMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+        $level = ob_get_level();
+        ob_start();
+
         try {
-            ob_start();
             $response = $handler->handle($request);
-            $output = ob_get_clean();
+            $output = '';
+            while (ob_get_level() > $level) {
+                $output = (string)ob_get_clean() . $output;
+            }
         } catch (Throwable $e) {
-            ob_end_clean();
+            while (ob_get_level() > $level) {
+                ob_end_clean();
+            }
             throw $e;
         }
 

--- a/Slim/Routing/Route.php
+++ b/Slim/Routing/Route.php
@@ -11,8 +11,6 @@ namespace Slim\Routing;
 use Slim\Interfaces\MiddlewareCollectionInterface;
 use Slim\Interfaces\RouteInterface;
 
-use function array_key_exists;
-
 final class Route implements RouteInterface, MiddlewareCollectionInterface
 {
     use MiddlewareCollectionTrait;
@@ -41,13 +39,6 @@ final class Route implements RouteInterface, MiddlewareCollectionInterface
      * Parent route group
      */
     private ?RouteGroup $group;
-
-    /**
-     * Route parameters
-     *
-     * @var array<string, string>
-     */
-    private array $arguments = [];
 
     /**
      * @param array<string> $methods
@@ -111,34 +102,5 @@ final class Route implements RouteInterface, MiddlewareCollectionInterface
     public function getRouteGroup(): ?RouteGroup
     {
         return $this->group;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getArgument(string $name, ?string $default = null): ?string
-    {
-        if (array_key_exists($name, $this->arguments)) {
-            return $this->arguments[$name];
-        }
-        return $default;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getArguments(): array
-    {
-        return $this->arguments;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setArguments(array $arguments): RouteInterface
-    {
-        $this->arguments = $arguments;
-
-        return $this;
     }
 }

--- a/tests/Middleware/ErrorExceptionMiddlewareTest.php
+++ b/tests/Middleware/ErrorExceptionMiddlewareTest.php
@@ -118,4 +118,56 @@ final class ErrorExceptionMiddlewareTest extends TestCase
 
         $this->assertSame($response, $result);
     }
+
+    public function testErrorHandlerIsRestoredWhenNoPreviousHandlerExists(): void
+    {
+        $previous = set_error_handler(static fn() => false);
+        restore_error_handler();
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $response = $this->createMock(ResponseInterface::class);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())
+            ->method('handle')
+            ->willReturn($response);
+
+        $app = AppFactory::create();
+        $middleware = $app->getContainer()->get(ErrorExceptionMiddleware::class);
+
+        $middleware->process($request, $handler);
+
+        $current = set_error_handler(static fn() => false);
+        restore_error_handler();
+
+        $this->assertSame($previous, $current);
+    }
+
+    public function testErrorHandlerIsRestoredWhenAPreviousHandlerExists(): void
+    {
+        $custom = static fn() => false;
+        set_error_handler($custom);
+
+        try {
+            $request = $this->createMock(ServerRequestInterface::class);
+            $response = $this->createMock(ResponseInterface::class);
+
+            $handler = $this->createMock(RequestHandlerInterface::class);
+            $handler->expects($this->once())
+                ->method('handle')
+                ->willReturn($response);
+
+            $app = AppFactory::create();
+            $middleware = $app->getContainer()->get(ErrorExceptionMiddleware::class);
+
+            $middleware->process($request, $handler);
+
+            $current = set_error_handler(static fn() => false);
+            restore_error_handler();
+
+            $this->assertSame($custom, $current);
+        } finally {
+            restore_error_handler();
+        }
+    }
 }

--- a/tests/Middleware/JsonExceptionMiddlewareTest.php
+++ b/tests/Middleware/JsonExceptionMiddlewareTest.php
@@ -198,6 +198,34 @@ final class JsonExceptionMiddlewareTest extends TestCase
         $this->assertStringContainsString('Test message', (string)$response->getBody());
     }
 
+    public function testSubstitutesInvalidUtf8(): void
+    {
+        $middleware = (new JsonExceptionMiddleware(new ResponseFactory()))
+            ->withMimeType('application/json')
+            ->withErrorDetails(true);
+
+        $request = (new ServerRequestFactory())->createServerRequest('GET', '/')
+            ->withHeader('Accept', 'application/json');
+
+        $handler = new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                throw new RuntimeException("Invalid \xB1\x31 UTF-8 sequence");
+            }
+        };
+
+        $response = $middleware->process($request, $handler);
+        $decoded = json_decode((string)$response->getBody(), true);
+
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertIsArray($decoded);
+        $this->assertSame('Application Error', $decoded['message']);
+        $this->assertSame(
+            "Invalid \u{FFFD}1 UTF-8 sequence",
+            $decoded['exception'][0]['message'],
+        );
+    }
+
     public function testWithJsonOptionsChangesEncoding(): void
     {
         $middleware = (new JsonExceptionMiddleware(new ResponseFactory()))

--- a/tests/Middleware/OutputBufferingMiddlewareTest.php
+++ b/tests/Middleware/OutputBufferingMiddlewareTest.php
@@ -23,6 +23,8 @@ use Slim\Middleware\OutputBufferingMiddleware;
 use Slim\Tests\Traits\AppTestTrait;
 
 use function ob_get_contents;
+use function ob_get_level;
+use function ob_start;
 
 final class OutputBufferingMiddlewareTest extends TestCase
 {
@@ -144,6 +146,76 @@ final class OutputBufferingMiddlewareTest extends TestCase
             $app->handle($request);
         } catch (Exception $e) {
             $this->assertSame('', ob_get_contents());
+        }
+    }
+
+    public function testNestedOutputBuffersAreCapturedAndLevelRestored(): void
+    {
+        $level = ob_get_level();
+        $app = AppFactory::create();
+
+        $responseFactory = $app->getContainer()->get(ResponseFactoryInterface::class);
+        $streamFactory = $app->getContainer()->get(StreamFactoryInterface::class);
+
+        $outputBufferingMiddleware = new OutputBufferingMiddleware($streamFactory, OutputBufferingMiddleware::APPEND);
+        $app->add($outputBufferingMiddleware);
+
+        $middleware = function () use ($responseFactory) {
+            $response = $responseFactory->createResponse();
+            $response->getBody()->write('Body');
+            echo 'Outer';
+            ob_start();
+            echo 'Inner';
+
+            return $response;
+        };
+        $app->add($middleware);
+        $app->addRoutingMiddleware();
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('GET', '/');
+
+        $response = $app->handle($request);
+
+        $this->assertSame('BodyOuterInner', (string)$response->getBody());
+        $this->assertSame($level, ob_get_level());
+    }
+
+    public function testNestedOutputBuffersAreRestoredWhenThrowableIsCaught(): void
+    {
+        $level = ob_get_level();
+        $app = AppFactory::create();
+        $streamFactory = $app->getContainer()->get(StreamFactoryInterface::class);
+
+        $middleware = function () {
+            echo 'Outer';
+            ob_start();
+            echo 'Inner';
+            throw new Exception('Oops...');
+        };
+
+        $outputBufferingMiddleware = new OutputBufferingMiddleware($streamFactory, OutputBufferingMiddleware::PREPEND);
+
+        $app->add($outputBufferingMiddleware);
+        $app->add($middleware);
+        $app->addRoutingMiddleware();
+
+        $app->get('/', function (ServerRequestInterface $request, ResponseInterface $response) {
+            return $response;
+        });
+
+        $request = $app->getContainer()
+            ->get(ServerRequestFactoryInterface::class)
+            ->createServerRequest('GET', '/');
+
+        try {
+            $app->handle($request);
+            $this->fail('Expected exception was not thrown.');
+        } catch (Exception $e) {
+            $this->assertSame('Oops...', $e->getMessage());
+            $this->assertSame($level, ob_get_level());
+            $this->assertSame('', (string)ob_get_contents());
         }
     }
 }

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -137,23 +137,6 @@ class RouteTest extends TestCase
         $this->assertSame($methods, $route->getMethods());
     }
 
-    public function testSetArgumentsStoresStringArguments(): void
-    {
-        $methods = ['GET'];
-        $pattern = '/users/{id}';
-        $handler = function () {
-            return 'handler';
-        };
-
-        $route = new Route($methods, $pattern, $handler);
-
-        $arguments = ['id' => '123', 'slug' => 'john-doe'];
-        $route->setArguments($arguments);
-
-        $this->assertSame($arguments, $route->getArguments());
-        $this->assertSame('123', $route->getArgument('id'));
-    }
-
     private function createMiddleware(): MiddlewareInterface
     {
         return new class implements MiddlewareInterface {


### PR DESCRIPTION
## Summary

Small correctness fixes for leftover process state and empty JSON error bodies. These show up hardest under persistent workers (FrankenPHP, RoadRunner, Swoole) because the PHP process is reused.

Slim 5 already avoids storing the last request on `App`. This PR only fixes real leftover-state bugs and one encoding hole. It does not lock routes, close response streams, or change logging.

## Fixed

### Output buffering leaks across requests

`OutputBufferingMiddleware` used `ob_get_clean()` / `ob_end_clean()`, which pop only the innermost buffer.

If a view, PDF lib, or `echo` path started a nested buffer and did not close it (or threw), Slim popped the nested one and left its own buffer installed. In a worker that buffer — and any string still in it — lived until the process was killed.

It now records `ob_get_level()` and pops back to that level on both success and exception.

### Error handler left installed after the first request

`ErrorExceptionMiddleware` only called `restore_error_handler()` when `set_error_handler()` returned a previous handler.

On the first request that value is `null`, so restore was skipped. Slim’s “turn PHP errors into `ErrorException`” handler stayed installed for the rest of the process, including between requests.

It now always restores.

### Empty JSON error body on invalid UTF-8

`json_encode()` returns `false` when any string contains invalid UTF-8. An exception message with raw bytes (common when user input is echoed into the exception) produced a zero-length body with `Content-Type: application/json`. Clients then failed to parse the error.

`JSON_PARTIAL_OUTPUT_ON_ERROR` does not cover `JSON_ERROR_UTF8`. Added `JSON_INVALID_UTF8_SUBSTITUTE` so invalid sequences become U+FFFD and the payload stays valid JSON.

Same fix as #3465 on 4.x (`JsonErrorRenderer`); v5’s equivalent is `JsonExceptionMiddleware`.

## Changed (breaking)

### Route arguments no longer live on `Route`

Removed `RouteInterface::getArgument()`, `getArguments()`, and `setArguments()`.

Slim 5 already puts match args on a per-request `RouteMatch`. The `Route` instance is the FastRoute handler and lives for the process lifetime. `setArguments()` wrote request-shaped data onto that shared object, so one request’s args could be read on the next. The framework never called these methods.

Get args from:

- the handler `$args` array
- `$request->getAttribute(RouteMatch::class)`
- request attributes via `RoutingArgumentsMiddleware`