### PR TITLE
Isolate testDetermineResponseFactoryThrowsRuntimeException on PHPUnit 10+

### DIFF
--- a/tests/Factory/AppFactoryTest.php
+++ b/tests/Factory/AppFactoryTest.php
@@ -113,6 +113,7 @@ class AppFactoryTest extends TestCase
     /**
      * @runInSeparateProcess - Psr17FactoryProvider::setFactories breaks other tests
      */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testDetermineResponseFactoryThrowsRuntimeException()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
For PHPUnit 10+ we need the annotation rather than the docblock. This solves the intermittent test failure problem.
